### PR TITLE
fix: resolve Vercel build TypeScript errors

### DIFF
--- a/api/_lib/auth.ts
+++ b/api/_lib/auth.ts
@@ -1,4 +1,4 @@
-import { createClerkClient } from '@clerk/backend'
+import { createClerkClient, verifyToken } from '@clerk/backend'
 import crypto from 'crypto'
 import type { VercelRequest } from '@vercel/node'
 import { createAdminClient } from './supabase'
@@ -59,14 +59,12 @@ export async function authenticateRequest(req: VercelRequest): Promise<AuthConte
         null
       db.from('service_api_key_logs')
         .insert({ key_id: keyId, endpoint: req.url ?? '', ip })
-        .then(() => {})
-        .catch(() => {})
+        .then(null, () => {})
 
       db.from('service_api_keys')
         .update({ last_used_at: new Date().toISOString() })
         .eq('key_id', keyId)
-        .then(() => {})
-        .catch(() => {})
+        .then(null, () => {})
     }
 
     return { mode: 'service' }
@@ -76,7 +74,7 @@ export async function authenticateRequest(req: VercelRequest): Promise<AuthConte
   if (authHeader?.startsWith('Bearer ')) {
     const token = authHeader.slice(7)
     try {
-      const payload = await clerk.verifyToken(token)
+      const payload = await verifyToken(token, { secretKey: process.env.CLERK_SECRET_KEY })
       return {
         mode: 'user',
         userId: payload.sub,
@@ -122,7 +120,7 @@ export async function verifyAuth(req: any): Promise<AuthResult> {
 
   const token = authHeader.slice(7)
   try {
-    const payload = await clerk.verifyToken(token)
+    const payload = await verifyToken(token, { secretKey: process.env.CLERK_SECRET_KEY })
     return { ok: true, userId: payload.sub, type: 'clerk' }
   } catch {
     return { ok: false, error: 'Invalid token' }

--- a/src/components/map/MapView.tsx
+++ b/src/components/map/MapView.tsx
@@ -5,7 +5,7 @@ import type { Property, ServiceLocation, MapFilter } from '../../types'
 import { CATEGORY_COLORS } from '../../lib/constants'
 import 'mapbox-gl/dist/mapbox-gl.css'
 
-mapboxgl.accessToken = import.meta.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN ?? ''
+mapboxgl.accessToken = import.meta.env.VITE_MAPBOX_ACCESS_TOKEN ?? ''
 
 interface MapPin {
   property: Property
@@ -81,7 +81,7 @@ export default function MapView({
       radius: 60,
       maxZoom: 16,
     })
-    clusterRef.current.load(geojsonFeatures)
+    clusterRef.current.load(geojsonFeatures as any)
 
     const m = map.current
     const sourceId = 'properties'

--- a/src/components/portfolio/ShareLinkModal.tsx
+++ b/src/components/portfolio/ShareLinkModal.tsx
@@ -22,7 +22,7 @@ export default function ShareLinkModal({
   const [copied, setCopied] = useState(false)
 
   const shareUrl = token
-    ? `${import.meta.env.NEXT_PUBLIC_APP_URL}/portfolio/${token}`
+    ? `${import.meta.env.VITE_APP_URL}/portfolio/${token}`
     : null
 
   const generate = async () => {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,10 +4,10 @@ import { ClerkProvider } from '@clerk/clerk-react'
 import App from './App'
 import './index.css'
 
-const publishableKey = import.meta.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
+const publishableKey = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY
 
 if (!publishableKey) {
-  throw new Error('NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY is not set')
+  throw new Error('VITE_CLERK_PUBLISHABLE_KEY is not set')
 }
 
 ReactDOM.createRoot(document.getElementById('root')!).render(

--- a/src/pages/ServiceLocation.tsx
+++ b/src/pages/ServiceLocation.tsx
@@ -36,7 +36,7 @@ export default function ServiceLocationPage() {
   const [overrideCategory, setOverrideCategory] = useState('')
   const [winteamJobNumber, setWinteamJobNumber] = useState('')
 
-  const crmBaseUrl = import.meta.env.NEXT_PUBLIC_CRM_BASE_URL
+  const crmBaseUrl = import.meta.env.VITE_RBM_CRM_BASE_URL
 
   useEffect(() => {
     async function load() {
@@ -173,7 +173,7 @@ export default function ServiceLocationPage() {
 
               {/* Editable fields */}
               {EDITABLE_PROPERTY_FIELDS.map(({ label, field }) => {
-                const val = (property as Record<string, unknown>)[field as string]
+                const val = (property as unknown as Record<string, unknown>)[field as string]
                 return (
                   <InlineEdit
                     key={field as string}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
Fixes all TypeScript build errors blocking Vercel deployment from PR #5.

- Add `src/vite-env.d.ts` so `import.meta.env` is typed
- Switch `NEXT_PUBLIC_*` env vars to `VITE_*` equivalents
- Use standalone `verifyToken()` from `@clerk/backend` v1.x
- Fix `PromiseLike` .catch usage in auth.ts
- Fix supercluster PointFeature type mismatch
- Fix Property to Record cast in ServiceLocation

Generated with [Claude Code](https://claude.ai/code)