### PR TITLE
fix: convert SQL functions to plpgsql to fix Supabase preview branch migrations

### DIFF
--- a/supabase/migrations/20260418000000_rbm_geo_v1.sql
+++ b/supabase/migrations/20260418000000_rbm_geo_v1.sql
@@ -87,6 +87,8 @@ CREATE TABLE IF NOT EXISTS service_locations (
 );
 
 -- Proximity function using PostGIS (falls back to Haversine math if no PostGIS)
+-- Uses plpgsql so column references are resolved at execution time, not creation time.
+-- This allows the function to be created on fresh preview DBs before the real tables exist.
 CREATE OR REPLACE FUNCTION nearby_properties(
   query_lat   FLOAT8,
   query_lng   FLOAT8,
@@ -96,7 +98,9 @@ RETURNS TABLE (
   property_id       UUID,
   distance_miles    FLOAT8,
   service_locations JSONB
-) LANGUAGE sql STABLE AS $$
+) LANGUAGE plpgsql STABLE AS $$
+BEGIN
+  RETURN QUERY
   WITH dists AS (
     SELECT
       p.property_id,
@@ -131,4 +135,5 @@ RETURNS TABLE (
    AND sl.status != 'terminated'
   GROUP BY n.property_id, n.distance_miles
   ORDER BY n.distance_miles;
+END;
 $$;

--- a/supabase/migrations/20260428000000_parcel_layer.sql
+++ b/supabase/migrations/20260428000000_parcel_layer.sql
@@ -47,6 +47,7 @@ CREATE TABLE IF NOT EXISTS parcels (
 
 -- Nearest-parcel lookup via Haversine (PostGIS-free).
 -- Returns the single nearest parcel within p_max_distance_m metres, or empty set.
+-- Uses plpgsql so column references are resolved at execution time, not creation time.
 CREATE OR REPLACE FUNCTION find_nearest_parcel(
   p_county_fips    TEXT,
   p_lat            DOUBLE PRECISION,
@@ -75,7 +76,9 @@ RETURNS TABLE (
   imported_at           TIMESTAMPTZ,
   distance_m            DOUBLE PRECISION
 )
-LANGUAGE sql STABLE AS $$
+LANGUAGE plpgsql STABLE AS $$
+BEGIN
+  RETURN QUERY
   SELECT
     p.id,
     p.regrid_ll_uuid,
@@ -116,5 +119,6 @@ LANGUAGE sql STABLE AS $$
                            AND p_lng + (p_max_distance_m / (111320.0 * cos(radians(p_lat))))
   ) p
   ORDER BY distance_m ASC
-  LIMIT 1
+  LIMIT 1;
+END;
 $$;


### PR DESCRIPTION
Converts `nearby_properties` and `find_nearest_parcel` from `LANGUAGE sql STABLE` to `LANGUAGE plpgsql` to fix creation-time column validation errors on Supabase preview branches.

Related to PR #12.

Generated with [Claude Code](https://claude.ai/code)