### PR TITLE
fix: ensure upload_batch_id column exists before staged_addresses FK creation

### DIFF
--- a/supabase/migrations/20260428020000_staged_addresses.sql
+++ b/supabase/migrations/20260428020000_staged_addresses.sql
@@ -11,6 +11,25 @@ CREATE TABLE IF NOT EXISTS upload_batches (
   created_at      TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
+-- Ensure upload_batch_id exists and is referenceable on pre-existing production tables.
+-- On fresh preview DBs the CREATE TABLE above already defines it as PK; this block is a no-op.
+-- On production tables predating this migration the column may be absent (e.g. PK is named "id"),
+-- so we add it and give it a UNIQUE constraint so staged_addresses can FK-reference it.
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name   = 'upload_batches'
+      AND column_name  = 'upload_batch_id'
+  ) THEN
+    ALTER TABLE upload_batches
+      ADD COLUMN upload_batch_id UUID NOT NULL DEFAULT gen_random_uuid();
+    ALTER TABLE upload_batches
+      ADD CONSTRAINT upload_batches_upload_batch_id_unique UNIQUE (upload_batch_id);
+  END IF;
+EXCEPTION WHEN undefined_table THEN NULL;
+END $$;
+
 -- Stage 0 scrub results: one row per uploaded row, persisted before any geocoding
 CREATE TABLE IF NOT EXISTS staged_addresses (
   staged_id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),


### PR DESCRIPTION
Fixes #14

On production databases where `upload_batches` was created manually before migrations ran, the `upload_batch_id` column may not exist. A new `DO $$` block detects this and adds the column with a UNIQUE constraint so the FK reference in `staged_addresses` can be created successfully.

Generated with [Claude Code](https://claude.ai/code)