### PR TITLE
Add Clients as first-class entity; scope service locations, portfolios, custom fields, uploads

### DIFF
--- a/api/scrub/[batchId]/approve.ts
+++ b/api/scrub/[batchId]/approve.ts
@@ -53,10 +53,11 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   // Fetch column mapping once
   const { data: batchData } = await db
     .from('upload_batches')
-    .select('column_mapping')
+    .select('column_mapping, client_id')
     .eq('upload_batch_id', batchId)
     .single()
   const columnMapping = (batchData?.column_mapping ?? {}) as Record<string, string>
+  const batchClientId = (batchData?.client_id as string | null) ?? null
 
   const propertyIds: string[] = []
 
@@ -123,6 +124,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
       await db.from('service_locations').insert({
         property_id: propertyId,
+        client_id: batchClientId,
         location_code: mapping.location_code ? String(originalRow[mapping.location_code] ?? '').trim() || null : null,
         display_name: mapping.display_name ? String(originalRow[mapping.display_name] ?? '').trim() || null : null,
         suite_or_floor: mapping.suite_or_floor ? String(originalRow[mapping.suite_or_floor] ?? '').trim() || null : null,

--- a/api/upload.ts
+++ b/api/upload.ts
@@ -9,7 +9,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   const auth = await verifyAuth(req)
   if (!auth.ok) return unauthorized(res, auth.error)
 
-  const { filename, rows, mapping } = req.body ?? {}
+  const { filename, rows, mapping, client_id } = req.body ?? {}
   if (!rows?.length || !mapping) return res.status(400).json({ error: 'rows and mapping required' })
 
   const db = createAdminClient()
@@ -22,6 +22,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       raw_data: rows,
       column_mapping: mapping,
       uploaded_by: auth.userId,
+      client_id: client_id ?? null,
       status: 'queued',
     })
     .select('upload_batch_id')

--- a/api/v1/admin/dangerous.ts
+++ b/api/v1/admin/dangerous.ts
@@ -1,0 +1,58 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { createAdminClient } from '../../_lib/supabase'
+import { authenticateRequest } from '../../_lib/auth'
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method === 'OPTIONS') return res.status(200).end()
+  if (req.method !== 'POST') return res.status(405).json({ error: 'Method not allowed' })
+
+  let ctx: Awaited<ReturnType<typeof authenticateRequest>>
+  try {
+    ctx = await authenticateRequest(req)
+  } catch (err: any) {
+    return res.status(err.statusCode ?? 401).json({ error: err.message ?? 'Unauthorized' })
+  }
+
+  // Only user-context auth can perform this action
+  if (ctx.mode !== 'user') {
+    return res.status(403).json({ error: 'This action requires user authentication' })
+  }
+
+  const { action, confirmation } = req.body ?? {}
+
+  if (action === 'reset_service_location_data') {
+    if (confirmation !== 'delete all service locations') {
+      return res.status(400).json({ error: 'Invalid confirmation phrase' })
+    }
+
+    const db = createAdminClient()
+
+    // Truncate in dependency order; clients table is NOT touched
+    try {
+      await db.from('staged_addresses').delete().neq('staged_id', '00000000-0000-0000-0000-000000000000')
+      await db.from('upload_batches').delete().neq('upload_batch_id', '00000000-0000-0000-0000-000000000000')
+      await db.from('service_locations').delete().neq('service_location_id', '00000000-0000-0000-0000-000000000000')
+      await db.from('properties').delete().neq('property_id', '00000000-0000-0000-0000-000000000000')
+    } catch (err: any) {
+      return res.status(500).json({ error: err.message ?? 'Reset failed' })
+    }
+
+    // Log the action (best-effort)
+    db.from('admin_audit_log')
+      .insert({
+        action: 'reset_service_location_data',
+        performed_by: ctx.userId,
+        performed_at: new Date().toISOString(),
+      })
+      .then(null, () => {})
+
+    return res.status(200).json({
+      ok: true,
+      message: 'All service location data has been wiped. Clients table was not affected.',
+      performed_by: ctx.email ?? ctx.userId,
+      performed_at: new Date().toISOString(),
+    })
+  }
+
+  return res.status(400).json({ error: `Unknown action: ${action}` })
+}

--- a/api/v1/clients/[id].ts
+++ b/api/v1/clients/[id].ts
@@ -1,0 +1,95 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { createAdminClient } from '../../_lib/supabase'
+import { authenticateRequest } from '../../_lib/auth'
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method === 'OPTIONS') return res.status(200).end()
+
+  try {
+    await authenticateRequest(req)
+  } catch (err: any) {
+    return res.status(err.statusCode ?? 401).json({ error: err.message ?? 'Unauthorized' })
+  }
+
+  const db = createAdminClient()
+  const id = req.query.id as string
+
+  // ── GET /api/v1/clients/:id ───────────────────────────────────────────────
+  if (req.method === 'GET') {
+    const { data: client, error } = await db
+      .from('clients')
+      .select('*')
+      .eq('id', id)
+      .single()
+
+    if (error || !client) return res.status(404).json({ error: 'Client not found' })
+
+    // Stats: service location count, portfolio count, total sqft
+    const [slRes, portRes, sqftRes, uploadRes] = await Promise.all([
+      db.from('service_locations').select('service_location_id', { count: 'exact', head: true }).eq('client_id', id),
+      db.from('portfolios').select('portfolio_id', { count: 'exact', head: true }).eq('client_id', id),
+      db.from('service_locations').select('serviceable_sqft').eq('client_id', id).not('serviceable_sqft', 'is', null),
+      db.from('upload_batches').select('upload_batch_id, filename, created_at, status, row_count').eq('client_id', id).order('created_at', { ascending: false }).limit(20),
+    ])
+
+    const totalSqft = (sqftRes.data ?? []).reduce((sum: number, r: any) => sum + (r.serviceable_sqft ?? 0), 0)
+
+    return res.status(200).json({
+      ...client,
+      stats: {
+        service_location_count: slRes.count ?? 0,
+        portfolio_count: portRes.count ?? 0,
+        total_serviceable_sqft: totalSqft,
+      },
+      recent_uploads: uploadRes.data ?? [],
+    })
+  }
+
+  // ── PATCH /api/v1/clients/:id ─────────────────────────────────────────────
+  if (req.method === 'PATCH') {
+    const {
+      name,
+      display_name,
+      status,
+      notes,
+      primary_contact_name,
+      primary_contact_email,
+      primary_contact_phone,
+      brand_color,
+      logo_url,
+      metadata,
+    } = req.body ?? {}
+
+    const updates: Record<string, unknown> = {}
+    if (name !== undefined) updates.name = name.trim()
+    if (display_name !== undefined) updates.display_name = display_name?.trim() ?? null
+    if (status !== undefined) {
+      const valid = ['active', 'prospect', 'churned']
+      if (!valid.includes(status)) return res.status(400).json({ error: `status must be one of: ${valid.join(', ')}` })
+      updates.status = status
+    }
+    if (notes !== undefined) updates.notes = notes ?? null
+    if (primary_contact_name !== undefined) updates.primary_contact_name = primary_contact_name ?? null
+    if (primary_contact_email !== undefined) updates.primary_contact_email = primary_contact_email ?? null
+    if (primary_contact_phone !== undefined) updates.primary_contact_phone = primary_contact_phone ?? null
+    if (brand_color !== undefined) updates.brand_color = brand_color ?? null
+    if (logo_url !== undefined) updates.logo_url = logo_url ?? null
+    if (metadata !== undefined) updates.metadata = metadata ?? {}
+
+    if (!Object.keys(updates).length) return res.status(400).json({ error: 'No fields to update' })
+
+    const { data, error } = await db
+      .from('clients')
+      .update(updates)
+      .eq('id', id)
+      .select('*')
+      .single()
+
+    if (error) return res.status(500).json({ error: error.message })
+    if (!data) return res.status(404).json({ error: 'Client not found' })
+
+    return res.status(200).json(data)
+  }
+
+  return res.status(405).json({ error: 'Method not allowed' })
+}

--- a/api/v1/clients/[id]/archive.ts
+++ b/api/v1/clients/[id]/archive.ts
@@ -1,0 +1,29 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { createAdminClient } from '../../../_lib/supabase'
+import { authenticateRequest } from '../../../_lib/auth'
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method === 'OPTIONS') return res.status(200).end()
+  if (req.method !== 'POST') return res.status(405).json({ error: 'Method not allowed' })
+
+  try {
+    await authenticateRequest(req)
+  } catch (err: any) {
+    return res.status(err.statusCode ?? 401).json({ error: err.message ?? 'Unauthorized' })
+  }
+
+  const db = createAdminClient()
+  const id = req.query.id as string
+
+  const { data, error } = await db
+    .from('clients')
+    .update({ status: 'churned' })
+    .eq('id', id)
+    .select('id, name, status')
+    .single()
+
+  if (error) return res.status(500).json({ error: error.message })
+  if (!data) return res.status(404).json({ error: 'Client not found' })
+
+  return res.status(200).json(data)
+}

--- a/api/v1/clients/index.ts
+++ b/api/v1/clients/index.ts
@@ -4,30 +4,83 @@ import { authenticateRequest } from '../../_lib/auth'
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method === 'OPTIONS') return res.status(200).end()
-  if (req.method !== 'GET') return res.status(405).json({ error: 'Method not allowed' })
 
+  let ctx: Awaited<ReturnType<typeof authenticateRequest>>
   try {
-    await authenticateRequest(req)
+    ctx = await authenticateRequest(req)
   } catch (err: any) {
     return res.status(err.statusCode ?? 401).json({ error: err.message ?? 'Unauthorized' })
   }
 
   const db = createAdminClient()
 
-  // Try clients table first; fall back to distinct client_ids from service_locations
-  const { data: clients, error } = await db
-    .from('clients')
-    .select('client_id, name')
-    .order('name')
+  // ── GET /api/v1/clients ───────────────────────────────────────────────────
+  if (req.method === 'GET') {
+    const { status, search } = req.query
 
-  if (!error && clients) return res.status(200).json(clients)
+    let query = db
+      .from('clients')
+      .select('*')
+      .order('name', { ascending: true })
 
-  // Fallback: distinct client_ids from service_locations
-  const { data: locs } = await db
-    .from('service_locations')
-    .select('client_id')
-    .not('client_id', 'is', null)
+    if (status) query = query.eq('status', String(status))
+    if (search) query = query.ilike('name', `%${String(search)}%`)
 
-  const unique = Array.from(new Set(locs?.map((l: any) => l.client_id) ?? []))
-  return res.status(200).json(unique.map((id) => ({ client_id: id, name: id })))
+    const { data, error } = await query
+    if (error) return res.status(500).json({ error: error.message })
+
+    return res.status(200).json(data ?? [])
+  }
+
+  // ── POST /api/v1/clients ──────────────────────────────────────────────────
+  if (req.method === 'POST') {
+    const {
+      name,
+      display_name,
+      status = 'active',
+      notes,
+      primary_contact_name,
+      primary_contact_email,
+      primary_contact_phone,
+      brand_color,
+      logo_url,
+      metadata,
+    } = req.body ?? {}
+
+    if (!name?.trim()) return res.status(400).json({ error: 'name is required' })
+
+    const validStatuses = ['active', 'prospect', 'churned']
+    if (!validStatuses.includes(status)) {
+      return res.status(400).json({ error: `status must be one of: ${validStatuses.join(', ')}` })
+    }
+
+    const { data, error } = await db
+      .from('clients')
+      .insert({
+        name: name.trim(),
+        display_name: display_name?.trim() ?? null,
+        status,
+        notes: notes ?? null,
+        primary_contact_name: primary_contact_name ?? null,
+        primary_contact_email: primary_contact_email ?? null,
+        primary_contact_phone: primary_contact_phone ?? null,
+        brand_color: brand_color ?? null,
+        logo_url: logo_url ?? null,
+        metadata: metadata ?? {},
+        created_by: ctx.userId ?? null,
+      })
+      .select('*')
+      .single()
+
+    if (error) {
+      if (error.code === '23505') {
+        return res.status(409).json({ error: 'A client with this name already exists' })
+      }
+      return res.status(500).json({ error: error.message })
+    }
+
+    return res.status(201).json(data)
+  }
+
+  return res.status(405).json({ error: 'Method not allowed' })
 }

--- a/api/v1/portfolios/index.ts
+++ b/api/v1/portfolios/index.ts
@@ -15,11 +15,21 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   const db = createAdminClient()
 
   if (req.method === 'GET') {
-    const { data, error } = await db
+    const { client_id } = req.query
+
+    // Service-key callers must scope to a client
+    if (ctx.mode === 'service' && !client_id) {
+      return res.status(400).json({ error: 'client_id is required for service-key auth' })
+    }
+
+    let query = db
       .from('portfolios')
       .select('*')
       .order('created_at', { ascending: false })
 
+    if (client_id) query = query.eq('client_id', String(client_id))
+
+    const { data, error } = await query
     if (error) return res.status(500).json({ error: error.message })
     return res.status(200).json(data ?? [])
   }

--- a/api/v1/properties/index.ts
+++ b/api/v1/properties/index.ts
@@ -38,6 +38,11 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       offset: offsetParam = '0',
     } = req.query
 
+    // Service-key callers must scope to a client
+    if (ctx.mode === 'service' && !client_id) {
+      return res.status(400).json({ error: 'client_id is required for service-key auth' })
+    }
+
     const limit = Math.min(Math.max(1, Number(limitParam)), 500)
     const offset = Math.max(0, Number(offsetParam))
 

--- a/api/v1/service-locations/index.ts
+++ b/api/v1/service-locations/index.ts
@@ -19,6 +19,11 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method === 'GET') {
     const { client_id, status, property_id, portfolio_id } = req.query
 
+    // Service-key callers must scope to a client
+    if (ctx.mode === 'service' && !client_id) {
+      return res.status(400).json({ error: 'client_id is required for service-key auth' })
+    }
+
     let query = db
       .from('service_locations')
       .select('*, property:properties(state, city)')

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
+import { ClientProvider } from './context/ClientContext'
 import AuthGuard from './components/auth/AuthGuard'
 import LoginPage from './pages/Login'
 import SignupPage from './pages/Signup'
@@ -14,97 +15,137 @@ import SharedPortfolioPage from './pages/SharedPortfolio'
 import ParcelImportPage from './pages/admin/parcels/Import'
 import CountiesPage from './pages/admin/parcels/Counties'
 import FallbacksPage from './pages/admin/parcels/Fallbacks'
+import DangerousAdminPage from './pages/admin/Dangerous'
+import ClientsListPage from './pages/clients/ClientsList'
+import NewClientPage from './pages/clients/NewClient'
+import ClientDetailPage from './pages/clients/ClientDetail'
 
 export default function App() {
   return (
     <BrowserRouter>
-      <Routes>
-        {/* Public auth routes */}
-        <Route path="/login" element={<LoginPage />} />
-        <Route path="/login/forgot-password" element={<ForgotPasswordPage />} />
-        <Route path="/login/update-password" element={<UpdatePasswordPage />} />
-        <Route path="/signup" element={<SignupPage />} />
-        <Route path="/logout" element={<LogoutPage />} />
+      <ClientProvider>
+        <Routes>
+          {/* Public auth routes */}
+          <Route path="/login" element={<LoginPage />} />
+          <Route path="/login/forgot-password" element={<ForgotPasswordPage />} />
+          <Route path="/login/update-password" element={<UpdatePasswordPage />} />
+          <Route path="/signup" element={<SignupPage />} />
+          <Route path="/logout" element={<LogoutPage />} />
 
-        {/* Public share / embed routes — no auth required */}
-        <Route path="/portfolio/:shareToken" element={<SharedPortfolioPage />} />
+          {/* Public share / embed routes — no auth required */}
+          <Route path="/portfolio/:shareToken" element={<SharedPortfolioPage />} />
 
-        {/* Protected app routes */}
-        <Route
-          path="/"
-          element={
-            <AuthGuard>
-              <Navigate to="/map" replace />
-            </AuthGuard>
-          }
-        />
-        <Route
-          path="/map"
-          element={
-            <AuthGuard>
-              <MapPage />
-            </AuthGuard>
-          }
-        />
-        <Route
-          path="/upload"
-          element={
-            <AuthGuard>
-              <UploadPage />
-            </AuthGuard>
-          }
-        />
-        <Route
-          path="/upload/:batchId/review"
-          element={
-            <AuthGuard>
-              <UploadReviewPage />
-            </AuthGuard>
-          }
-        />
-        <Route
-          path="/locations/:serviceLocationId"
-          element={
-            <AuthGuard>
-              <ServiceLocationPage />
-            </AuthGuard>
-          }
-        />
-        <Route
-          path="/portfolios/:portfolioId"
-          element={
-            <AuthGuard>
-              <PortfolioPage />
-            </AuthGuard>
-          }
-        />
+          {/* Protected app routes */}
+          <Route
+            path="/"
+            element={
+              <AuthGuard>
+                <Navigate to="/map" replace />
+              </AuthGuard>
+            }
+          />
+          <Route
+            path="/map"
+            element={
+              <AuthGuard>
+                <MapPage />
+              </AuthGuard>
+            }
+          />
+          <Route
+            path="/upload"
+            element={
+              <AuthGuard>
+                <UploadPage />
+              </AuthGuard>
+            }
+          />
+          <Route
+            path="/upload/:batchId/review"
+            element={
+              <AuthGuard>
+                <UploadReviewPage />
+              </AuthGuard>
+            }
+          />
+          <Route
+            path="/locations/:serviceLocationId"
+            element={
+              <AuthGuard>
+                <ServiceLocationPage />
+              </AuthGuard>
+            }
+          />
+          <Route
+            path="/portfolios/:portfolioId"
+            element={
+              <AuthGuard>
+                <PortfolioPage />
+              </AuthGuard>
+            }
+          />
 
-        {/* Admin — Parcel data layer */}
-        <Route
-          path="/admin/parcels/import"
-          element={
-            <AuthGuard>
-              <ParcelImportPage />
-            </AuthGuard>
-          }
-        />
-        <Route
-          path="/admin/parcels/counties"
-          element={
-            <AuthGuard>
-              <CountiesPage />
-            </AuthGuard>
-          }
-        />
-        <Route
-          path="/admin/parcels/fallbacks"
-          element={
-            <AuthGuard>
-              <FallbacksPage />
-            </AuthGuard>
-          }
-        />
-      </Routes>
+          {/* Clients */}
+          <Route
+            path="/clients"
+            element={
+              <AuthGuard>
+                <ClientsListPage />
+              </AuthGuard>
+            }
+          />
+          <Route
+            path="/clients/new"
+            element={
+              <AuthGuard>
+                <NewClientPage />
+              </AuthGuard>
+            }
+          />
+          <Route
+            path="/clients/:id"
+            element={
+              <AuthGuard>
+                <ClientDetailPage />
+              </AuthGuard>
+            }
+          />
+
+          {/* Admin */}
+          <Route
+            path="/admin/dangerous"
+            element={
+              <AuthGuard>
+                <DangerousAdminPage />
+              </AuthGuard>
+            }
+          />
+          <Route
+            path="/admin/parcels/import"
+            element={
+              <AuthGuard>
+                <ParcelImportPage />
+              </AuthGuard>
+            }
+          />
+          <Route
+            path="/admin/parcels/counties"
+            element={
+              <AuthGuard>
+                <CountiesPage />
+              </AuthGuard>
+            }
+          />
+          <Route
+            path="/admin/parcels/fallbacks"
+            element={
+              <AuthGuard>
+                <FallbacksPage />
+              </AuthGuard>
+            }
+          />
+        </Routes>
+      </ClientProvider>
     </BrowserRouter>
   )
 }

--- a/src/components/map/FilterSidebar.tsx
+++ b/src/components/map/FilterSidebar.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react'
 import { useAuth } from '../../hooks/useAuth'
-import type { MapFilter, RbmCategory, ServiceLocationStatus } from '../../types'
+import { useClient } from '../../context/ClientContext'
+import type { MapFilter, RbmCategory, ServiceLocationStatus, Client } from '../../types'
 import { STATUS_LABELS } from '../../lib/constants'
 
 interface FilterSidebarProps {
@@ -12,21 +13,22 @@ const STATUSES: ServiceLocationStatus[] = ['active', 'paused', 'terminated', 'pr
 
 export default function FilterSidebar({ filter, onChange }: FilterSidebarProps) {
   const { getToken } = useAuth()
+  const { clients: allClients } = useClient()
   const [categories, setCategories] = useState<RbmCategory[]>([])
-  const [clients, setClients] = useState<{ client_id: string; name: string }[]>([])
   const [portfolios, setPortfolios] = useState<{ portfolio_id: string; name: string }[]>([])
+
+  // Only show active+prospect clients in filter
+  const clients = allClients.filter((c) => c.status !== 'churned')
 
   useEffect(() => {
     async function load() {
       const token = await getToken()
       const headers = { Authorization: `Bearer ${token}` }
-      const [catsRes, clientsRes, portsRes] = await Promise.all([
+      const [catsRes, portsRes] = await Promise.all([
         fetch('/api/v1/categories', { headers }),
-        fetch('/api/v1/clients', { headers }),
         fetch('/api/v1/portfolios', { headers }),
       ])
       if (catsRes.ok) setCategories(await catsRes.json())
-      if (clientsRes.ok) setClients(await clientsRes.json())
       if (portsRes.ok) setPortfolios(await portsRes.json())
     }
     load()
@@ -129,15 +131,19 @@ export default function FilterSidebar({ filter, onChange }: FilterSidebarProps) 
               Client
             </label>
             <div className="space-y-1.5 max-h-36 overflow-y-auto">
-              {clients.map((c) => (
-                <label key={c.client_id} className="flex items-center gap-2 cursor-pointer">
+              {clients.map((c: Client) => (
+                <label key={c.id} className="flex items-center gap-2 cursor-pointer">
                   <input
                     type="checkbox"
-                    checked={filter.clients.includes(c.client_id)}
-                    onChange={() => toggleMulti('clients', c.client_id)}
+                    checked={filter.clients.includes(c.id)}
+                    onChange={() => toggleMulti('clients', c.id)}
                     className="rounded border-gray-300 text-blue-600 focus:ring-blue-500"
                   />
-                  <span className="text-sm text-gray-700 truncate">{c.name}</span>
+                  <span
+                    className="w-2.5 h-2.5 rounded-full shrink-0"
+                    style={{ backgroundColor: c.brand_color ?? hashColor(c.id) }}
+                  />
+                  <span className="text-sm text-gray-700 truncate">{c.display_name ?? c.name}</span>
                 </label>
               ))}
             </div>
@@ -168,4 +174,14 @@ export default function FilterSidebar({ filter, onChange }: FilterSidebarProps) 
       </div>
     </div>
   )
+}
+
+function hashColor(str: string): string {
+  let hash = 0
+  for (let i = 0; i < str.length; i++) {
+    hash = str.charCodeAt(i) + ((hash << 5) - hash)
+    hash |= 0
+  }
+  const h = Math.abs(hash) % 360
+  return `hsl(${h}, 65%, 50%)`
 }

--- a/src/components/map/MapView.tsx
+++ b/src/components/map/MapView.tsx
@@ -10,6 +10,7 @@ mapboxgl.accessToken = import.meta.env.VITE_MAPBOX_ACCESS_TOKEN ?? ''
 interface MapPin {
   property: Property
   locations: ServiceLocation[]
+  clientColor?: string | null
 }
 
 interface MapViewProps {
@@ -19,6 +20,7 @@ interface MapViewProps {
   bulkSelectMode: boolean
   selectedIds: Set<string>
   filter: MapFilter
+  showClientColors?: boolean
 }
 
 export default function MapView({
@@ -28,6 +30,7 @@ export default function MapView({
   bulkSelectMode,
   selectedIds,
   filter,
+  showClientColors = false,
 }: MapViewProps) {
   const mapContainer = useRef<HTMLDivElement>(null)
   const map = useRef<mapboxgl.Map | null>(null)
@@ -74,6 +77,7 @@ export default function MapView({
           rbm_category: p.property.rbm_category ?? 'default',
           selected: selectedIds.has(p.property.property_id),
           location_count: p.locations.length,
+          client_color: (showClientColors && p.clientColor) ? p.clientColor : null,
         },
       }))
 
@@ -142,10 +146,15 @@ export default function MapView({
         filter: ['!', ['has', 'point_count']],
         paint: {
           'circle-color': [
-            'match',
-            ['get', 'rbm_category'],
-            ...Object.entries(CATEGORY_COLORS).flatMap(([k, v]) => [k, v]),
-            CATEGORY_COLORS.default,
+            'case',
+            ['!=', ['get', 'client_color'], null],
+            ['get', 'client_color'],
+            [
+              'match',
+              ['get', 'rbm_category'],
+              ...Object.entries(CATEGORY_COLORS).flatMap(([k, v]) => [k, v]),
+              CATEGORY_COLORS.default,
+            ],
           ],
           'circle-radius': [
             'case',

--- a/src/components/ui/Navbar.tsx
+++ b/src/components/ui/Navbar.tsx
@@ -1,46 +1,163 @@
 import { Link, useLocation } from 'react-router-dom'
+import { useState, useRef, useEffect } from 'react'
 import { clsx } from 'clsx'
+import { useClient } from '../../context/ClientContext'
 
 const links = [
   { to: '/map', label: 'Map' },
   { to: '/upload', label: 'Upload' },
+  { to: '/clients', label: 'Clients' },
 ]
 
 export default function Navbar() {
   const { pathname } = useLocation()
+  const { clients, selectedClientId, selectedClient, setSelectedClientId } = useClient()
+  const [open, setOpen] = useState(false)
+  const dropdownRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
+        setOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [])
+
+  const activeClients = clients.filter((c) => c.status !== 'churned')
+  const displayLabel = selectedClient
+    ? `Client: ${selectedClient.display_name ?? selectedClient.name}`
+    : 'Client: All Clients'
+
+  const clientColor = selectedClient?.brand_color ?? null
 
   return (
-    <nav className="h-14 bg-white border-b flex items-center px-4 gap-6 shrink-0">
-      <Link to="/map" className="flex items-center gap-2 font-bold text-blue-700 text-lg">
-        <svg className="w-6 h-6" fill="currentColor" viewBox="0 0 24 24">
-          <path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z" />
-        </svg>
-        RBM Geo
-      </Link>
-      <div className="flex gap-1">
-        {links.map((l) => (
-          <Link
-            key={l.to}
-            to={l.to}
-            className={clsx(
-              'px-3 py-1.5 rounded-md text-sm font-medium transition-colors',
-              pathname.startsWith(l.to)
-                ? 'bg-blue-50 text-blue-700'
-                : 'text-gray-600 hover:bg-gray-100'
-            )}
-          >
-            {l.label}
-          </Link>
-        ))}
-      </div>
-      <div className="ml-auto">
-        <Link
-          to="/logout"
-          className="px-3 py-1.5 rounded-md text-sm font-medium text-gray-600 hover:bg-gray-100 transition-colors"
-        >
-          Sign out
+    <>
+      <nav className="h-14 bg-white border-b flex items-center px-4 gap-6 shrink-0 z-30 relative">
+        <Link to="/map" className="flex items-center gap-2 font-bold text-blue-700 text-lg shrink-0">
+          <svg className="w-6 h-6" fill="currentColor" viewBox="0 0 24 24">
+            <path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z" />
+          </svg>
+          RBM Geo
         </Link>
-      </div>
-    </nav>
+        <div className="flex gap-1">
+          {links.map((l) => (
+            <Link
+              key={l.to}
+              to={l.to}
+              className={clsx(
+                'px-3 py-1.5 rounded-md text-sm font-medium transition-colors',
+                pathname.startsWith(l.to)
+                  ? 'bg-blue-50 text-blue-700'
+                  : 'text-gray-600 hover:bg-gray-100'
+              )}
+            >
+              {l.label}
+            </Link>
+          ))}
+        </div>
+
+        {/* Client switcher */}
+        <div className="relative ml-2" ref={dropdownRef}>
+          <button
+            onClick={() => setOpen((v) => !v)}
+            className={clsx(
+              'flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm font-medium border transition-colors',
+              selectedClient
+                ? 'border-transparent text-white'
+                : 'border-gray-300 text-gray-700 bg-white hover:bg-gray-50'
+            )}
+            style={selectedClient && clientColor ? { backgroundColor: clientColor } : undefined}
+          >
+            <svg className="w-4 h-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-2 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4" />
+            </svg>
+            <span className="max-w-[160px] truncate">{displayLabel}</span>
+            <svg className="w-3 h-3 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+            </svg>
+          </button>
+
+          {open && (
+            <div className="absolute top-full left-0 mt-1 w-56 bg-white border border-gray-200 rounded-lg shadow-lg py-1 z-50">
+              <button
+                onClick={() => { setSelectedClientId(null); setOpen(false) }}
+                className={clsx(
+                  'w-full text-left px-3 py-2 text-sm hover:bg-gray-50 flex items-center gap-2',
+                  !selectedClientId && 'font-semibold text-blue-700 bg-blue-50'
+                )}
+              >
+                <span className="w-3 h-3 rounded-full bg-gray-300 shrink-0" />
+                All Clients
+              </button>
+              {activeClients.length > 0 && (
+                <div className="border-t my-1" />
+              )}
+              {activeClients.map((c) => (
+                <button
+                  key={c.id}
+                  onClick={() => { setSelectedClientId(c.id); setOpen(false) }}
+                  className={clsx(
+                    'w-full text-left px-3 py-2 text-sm hover:bg-gray-50 flex items-center gap-2',
+                    selectedClientId === c.id && 'font-semibold text-blue-700 bg-blue-50'
+                  )}
+                >
+                  <span
+                    className="w-3 h-3 rounded-full shrink-0"
+                    style={{ backgroundColor: c.brand_color ?? hashColor(c.id) }}
+                  />
+                  <span className="truncate">{c.display_name ?? c.name}</span>
+                </button>
+              ))}
+              <div className="border-t my-1" />
+              <Link
+                to="/clients/new"
+                onClick={() => setOpen(false)}
+                className="w-full text-left px-3 py-2 text-sm text-blue-600 hover:bg-gray-50 flex items-center gap-2"
+              >
+                <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+                </svg>
+                New Client
+              </Link>
+            </div>
+          )}
+        </div>
+
+        <div className="ml-auto flex items-center gap-2">
+          <Link
+            to="/admin/dangerous"
+            className="px-3 py-1.5 rounded-md text-sm font-medium text-gray-400 hover:bg-gray-100 transition-colors"
+          >
+            Admin
+          </Link>
+          <Link
+            to="/logout"
+            className="px-3 py-1.5 rounded-md text-sm font-medium text-gray-600 hover:bg-gray-100 transition-colors"
+          >
+            Sign out
+          </Link>
+        </div>
+      </nav>
+
+      {/* Active client context bar */}
+      {selectedClient && (
+        <div
+          className="h-1 shrink-0"
+          style={{ backgroundColor: clientColor ?? hashColor(selectedClient.id) }}
+        />
+      )}
+    </>
   )
+}
+
+function hashColor(str: string): string {
+  let hash = 0
+  for (let i = 0; i < str.length; i++) {
+    hash = str.charCodeAt(i) + ((hash << 5) - hash)
+    hash |= 0
+  }
+  const h = Math.abs(hash) % 360
+  return `hsl(${h}, 65%, 50%)`
 }

--- a/src/context/ClientContext.tsx
+++ b/src/context/ClientContext.tsx
@@ -1,0 +1,74 @@
+import { createContext, useContext, useState, useEffect, useCallback, ReactNode } from 'react'
+import { useAuth } from '../hooks/useAuth'
+import type { Client } from '../types'
+
+const STORAGE_KEY = 'selectedClientId'
+
+interface ClientContextValue {
+  clients: Client[]
+  selectedClientId: string | null // null = "all"
+  selectedClient: Client | null
+  setSelectedClientId: (id: string | null) => void
+  reloadClients: () => Promise<void>
+}
+
+const ClientContext = createContext<ClientContextValue>({
+  clients: [],
+  selectedClientId: null,
+  selectedClient: null,
+  setSelectedClientId: () => {},
+  reloadClients: async () => {},
+})
+
+export function ClientProvider({ children }: { children: ReactNode }) {
+  const { getToken } = useAuth()
+  const [clients, setClients] = useState<Client[]>([])
+  const [selectedClientId, setSelectedClientIdState] = useState<string | null>(() => {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    return stored && stored !== 'all' ? stored : null
+  })
+
+  const reloadClients = useCallback(async () => {
+    try {
+      const token = await getToken()
+      const res = await fetch('/api/v1/clients', {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      if (res.ok) {
+        const data: Client[] = await res.json()
+        setClients(data)
+        // If selected client no longer exists or is churned, clear selection
+        if (selectedClientId) {
+          const found = data.find((c) => c.id === selectedClientId)
+          if (!found || found.status === 'churned') {
+            setSelectedClientIdState(null)
+            localStorage.setItem(STORAGE_KEY, 'all')
+          }
+        }
+      }
+    } catch {
+      // ignore
+    }
+  }, [getToken, selectedClientId])
+
+  useEffect(() => {
+    reloadClients()
+  }, []) // only on mount; callers can trigger reloadClients
+
+  const setSelectedClientId = useCallback((id: string | null) => {
+    setSelectedClientIdState(id)
+    localStorage.setItem(STORAGE_KEY, id ?? 'all')
+  }, [])
+
+  const selectedClient = clients.find((c) => c.id === selectedClientId) ?? null
+
+  return (
+    <ClientContext.Provider value={{ clients, selectedClientId, selectedClient, setSelectedClientId, reloadClients }}>
+      {children}
+    </ClientContext.Provider>
+  )
+}
+
+export function useClient() {
+  return useContext(ClientContext)
+}

--- a/src/pages/Map.tsx
+++ b/src/pages/Map.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useMemo, useCallback } from 'react'
 import { useAuth } from '../hooks/useAuth'
+import { useClient } from '../context/ClientContext'
 import Navbar from '../components/ui/Navbar'
 import MapView from '../components/map/MapView'
 import FilterSidebar from '../components/map/FilterSidebar'
@@ -19,6 +20,7 @@ const DEFAULT_FILTER: MapFilter = {
 
 export default function MapPage() {
   const { getToken } = useAuth()
+  const { clients, selectedClientId } = useClient()
   const [propertiesWithLocations, setPropertiesWithLocations] = useState<PropertyWithLocations[]>([])
   const [loading, setLoading] = useState(true)
   const [filter, setFilter] = useState<MapFilter>(DEFAULT_FILTER)
@@ -30,13 +32,30 @@ export default function MapPage() {
   const [portfolioName, setPortfolioName] = useState('')
   const [savingPortfolio, setSavingPortfolio] = useState(false)
 
+  // Build a client color map for pin coloring
+  const clientColorMap = useMemo(() => {
+    const map: Record<string, string> = {}
+    for (const c of clients) {
+      map[c.id] = c.brand_color ?? hashColor(c.id)
+    }
+    return map
+  }, [clients])
+
   useEffect(() => {
     async function load() {
       setLoading(true)
       try {
         const token = await getToken()
         const params = new URLSearchParams()
-        if (filter.clients.length) params.set('client_id', filter.clients.join(','))
+
+        // Apply nav-level client switcher as a filter baseline
+        const effectiveClients = filter.clients.length
+          ? filter.clients
+          : selectedClientId
+          ? [selectedClientId]
+          : []
+
+        if (effectiveClients.length) params.set('client_id', effectiveClients.join(','))
         if (filter.categories.length) params.set('category', filter.categories.join(','))
         if (filter.statuses.length) params.set('status', filter.statuses.join(','))
         if (filter.portfolios.length) params.set('portfolio_id', filter.portfolios.join(','))
@@ -55,15 +74,18 @@ export default function MapPage() {
       }
     }
     load()
-  }, [filter, getToken])
+  }, [filter, getToken, selectedClientId])
 
   const pins = useMemo(
     () =>
       propertiesWithLocations.map((p) => ({
         property: p as Property,
         locations: p.service_locations,
+        clientColor: p.service_locations[0]?.client_id
+          ? (clientColorMap[p.service_locations[0].client_id] ?? null)
+          : null,
       })),
-    [propertiesWithLocations]
+    [propertiesWithLocations, clientColorMap]
   )
 
   const selectedProperty = useMemo(
@@ -168,6 +190,7 @@ export default function MapPage() {
             bulkSelectMode={bulkSelectMode}
             selectedIds={selectedIds}
             filter={filter}
+            showClientColors={!selectedClientId && clients.length > 1}
           />
 
           {/* Bulk select toggle */}
@@ -236,4 +259,14 @@ export default function MapPage() {
       </Modal>
     </div>
   )
+}
+
+function hashColor(str: string): string {
+  let hash = 0
+  for (let i = 0; i < str.length; i++) {
+    hash = str.charCodeAt(i) + ((hash << 5) - hash)
+    hash |= 0
+  }
+  const h = Math.abs(hash) % 360
+  return `hsl(${h}, 65%, 50%)`
 }

--- a/src/pages/Upload.tsx
+++ b/src/pages/Upload.tsx
@@ -10,9 +10,10 @@ import ColumnMapper from '../components/upload/ColumnMapper'
 import Button from '../components/ui/Button'
 import { REQUIRED_COLUMNS } from '../lib/constants'
 import { normalizeCountry, validateState, validatePostalCode } from '../lib/constants/addressValidation'
-import type { ColumnMapping, BatchStatusResponse } from '../types'
+import { useClient } from '../context/ClientContext'
+import type { ColumnMapping, BatchStatusResponse, Client } from '../types'
 
-type Step = 'upload' | 'map' | 'validate' | 'processing'
+type Step = 'client' | 'upload' | 'map' | 'validate' | 'processing'
 
 interface ParsedData {
   columns: string[]
@@ -94,7 +95,13 @@ function validateRows(
 export default function UploadPage() {
   const { getToken } = useAuth()
   const navigate = useNavigate()
-  const [step, setStep] = useState<Step>('upload')
+  const { clients, selectedClientId, reloadClients } = useClient()
+
+  const [step, setStep] = useState<Step>('client')
+  const [selectedUploadClientId, setSelectedUploadClientId] = useState<string>(selectedClientId ?? '')
+  const [showNewClientModal, setShowNewClientModal] = useState(false)
+  const [newClientName, setNewClientName] = useState('')
+  const [creatingClient, setCreatingClient] = useState(false)
   const [parsed, setParsed] = useState<ParsedData | null>(null)
   const [mapping, setMapping] = useState<Partial<ColumnMapping>>({})
   const [validationErrors, setValidationErrors] = useState<ValidationError[]>([])
@@ -103,6 +110,13 @@ export default function UploadPage() {
   const [batchId, setBatchId] = useState<string | null>(null)
   const [batchStatus, setBatchStatus] = useState<BatchStatusResponse | null>(null)
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null)
+
+  // Sync selected client when nav switcher changes
+  useEffect(() => {
+    if (selectedClientId && !selectedUploadClientId) {
+      setSelectedUploadClientId(selectedClientId)
+    }
+  }, [selectedClientId])
 
   const stopPolling = useCallback(() => {
     if (pollRef.current) {
@@ -133,15 +147,12 @@ export default function UploadPage() {
     try {
       const token = await getToken()
       if (!token) throw new Error('Not authenticated')
-      // Kick off processing in the background
       fetch(`/api/uploads/${id}/process`, {
         method: 'POST',
         headers: { Authorization: `Bearer ${token}` },
       }).catch(() => {})
 
-      // Begin polling
       pollRef.current = setInterval(() => pollStatus(id, token), 2000)
-      // Poll immediately too
       pollStatus(id, token)
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to start processing')
@@ -209,6 +220,7 @@ export default function UploadPage() {
           filename: parsed.filename,
           rows: parsed.rows,
           mapping,
+          client_id: selectedUploadClientId || null,
         }),
       })
       if (!res.ok) throw new Error(await res.text())
@@ -224,9 +236,31 @@ export default function UploadPage() {
     }
   }
 
+  const handleCreateClient = async () => {
+    if (!newClientName.trim()) return
+    setCreatingClient(true)
+    try {
+      const token = await getToken()
+      const res = await fetch('/api/v1/clients', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        body: JSON.stringify({ name: newClientName.trim() }),
+      })
+      if (!res.ok) throw new Error((await res.json()).error ?? 'Failed')
+      const client: Client = await res.json()
+      await reloadClients()
+      setSelectedUploadClientId(client.id)
+      setShowNewClientModal(false)
+      setNewClientName('')
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create client')
+    } finally {
+      setCreatingClient(false)
+    }
+  }
+
   const handleDownloadInvalid = () => {
     if (!batchStatus?.summary || !parsed) return
-    // Build CSV of rows that have validation errors from client-side pass
     const invalidRows = validationErrors
       .map((e) => e.row - 2)
       .filter((v, i, a) => a.indexOf(v) === i)
@@ -250,7 +284,17 @@ export default function UploadPage() {
   }
 
   const isMappingComplete = REQUIRED_COLUMNS.every((col) => mapping[col])
-  const STEP_LABELS: Step[] = ['upload', 'map', 'validate', 'processing']
+  const STEP_LABELS: Step[] = ['client', 'upload', 'map', 'validate', 'processing']
+  const STEP_DISPLAY: Record<Step, string> = {
+    client: 'Select Client',
+    upload: 'Upload',
+    map: 'Map',
+    validate: 'Validate',
+    processing: 'Processing',
+  }
+
+  const activeClients = clients.filter((c) => c.status !== 'churned')
+  const selectedClient = clients.find((c) => c.id === selectedUploadClientId)
 
   return (
     <div className="flex flex-col h-full bg-gray-50">
@@ -270,7 +314,7 @@ export default function UploadPage() {
                   {i + 1}
                 </div>
                 <span className={`text-sm ${step === s ? 'text-gray-900 font-medium' : 'text-gray-400'}`}>
-                  {s === 'processing' ? 'Processing' : s.charAt(0).toUpperCase() + s.slice(1)}
+                  {STEP_DISPLAY[s]}
                 </span>
                 {i < STEP_LABELS.length - 1 && <div className="w-8 h-px bg-gray-300" />}
               </div>
@@ -283,9 +327,81 @@ export default function UploadPage() {
             </div>
           )}
 
+          {/* Step 0: Select Client */}
+          {step === 'client' && (
+            <div className="bg-white rounded-xl p-6 shadow-sm border space-y-4">
+              <h2 className="font-semibold text-gray-800">Select Client</h2>
+              <p className="text-sm text-gray-500">
+                All uploaded service locations will be tagged to this client.
+              </p>
+
+              {activeClients.length === 0 ? (
+                <div className="p-4 bg-yellow-50 border border-yellow-200 rounded-lg text-yellow-800 text-sm">
+                  No active clients exist yet.{' '}
+                  <button onClick={() => setShowNewClientModal(true)} className="underline font-medium">
+                    Create one now
+                  </button>
+                </div>
+              ) : (
+                <div className="space-y-2 max-h-64 overflow-y-auto">
+                  {activeClients.map((c) => (
+                    <label key={c.id} className="flex items-center gap-3 p-3 border rounded-lg cursor-pointer hover:bg-gray-50 transition-colors">
+                      <input
+                        type="radio"
+                        name="client"
+                        value={c.id}
+                        checked={selectedUploadClientId === c.id}
+                        onChange={() => setSelectedUploadClientId(c.id)}
+                        className="text-blue-600 focus:ring-blue-500"
+                      />
+                      <span
+                        className="w-4 h-4 rounded-full shrink-0"
+                        style={{ backgroundColor: c.brand_color ?? hashColor(c.id) }}
+                      />
+                      <span className="font-medium text-gray-800">{c.display_name ?? c.name}</span>
+                    </label>
+                  ))}
+                </div>
+              )}
+
+              <button
+                onClick={() => setShowNewClientModal(true)}
+                className="text-sm text-blue-600 hover:underline flex items-center gap-1"
+              >
+                <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+                </svg>
+                Create new client
+              </button>
+
+              <div className="flex justify-end pt-2">
+                <Button onClick={() => setStep('upload')} disabled={!selectedUploadClientId}>
+                  Next: Upload File
+                </Button>
+              </div>
+
+              {selectedClient && (
+                <p className="text-xs text-gray-400 text-right">
+                  Selected: <strong>{selectedClient.display_name ?? selectedClient.name}</strong>
+                </p>
+              )}
+            </div>
+          )}
+
           {step === 'upload' && (
-            <div className="bg-white rounded-xl p-6 shadow-sm border">
+            <div className="bg-white rounded-xl p-6 shadow-sm border space-y-4">
+              <div className="flex items-center justify-between">
+                <h2 className="font-semibold text-gray-800">Upload File</h2>
+                {selectedClient && (
+                  <span className="text-sm text-gray-500">
+                    Client: <strong>{selectedClient.display_name ?? selectedClient.name}</strong>
+                  </span>
+                )}
+              </div>
               <UploadDropzone onFile={handleFile} />
+              <div className="flex justify-between">
+                <Button variant="secondary" onClick={() => setStep('client')}>Back</Button>
+              </div>
             </div>
           )}
 
@@ -371,6 +487,37 @@ export default function UploadPage() {
           )}
         </div>
       </div>
+
+      {/* New client modal */}
+      {showNewClientModal && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
+          <div className="bg-white rounded-xl shadow-xl w-full max-w-sm p-6 space-y-4">
+            <h2 className="font-semibold text-gray-900">Create New Client</h2>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Client Name <span className="text-red-500">*</span>
+              </label>
+              <input
+                type="text"
+                value={newClientName}
+                onChange={(e) => setNewClientName(e.target.value)}
+                placeholder="e.g. JLL"
+                autoFocus
+                onKeyDown={(e) => e.key === 'Enter' && handleCreateClient()}
+                className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              />
+            </div>
+            <div className="flex justify-end gap-3">
+              <Button variant="secondary" size="sm" onClick={() => { setShowNewClientModal(false); setNewClientName('') }}>
+                Cancel
+              </Button>
+              <Button size="sm" loading={creatingClient} disabled={!newClientName.trim()} onClick={handleCreateClient}>
+                Create & Select
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   )
 }
@@ -463,4 +610,14 @@ function SummaryStat({ label, value, color }: { label: string; value: number; co
       <span className="text-xs text-gray-500">{label}</span>
     </div>
   )
+}
+
+function hashColor(str: string): string {
+  let hash = 0
+  for (let i = 0; i < str.length; i++) {
+    hash = str.charCodeAt(i) + ((hash << 5) - hash)
+    hash |= 0
+  }
+  const h = Math.abs(hash) % 360
+  return `hsl(${h}, 65%, 50%)`
 }

--- a/src/pages/admin/Dangerous.tsx
+++ b/src/pages/admin/Dangerous.tsx
@@ -1,0 +1,108 @@
+import { useState } from 'react'
+import { Link } from 'react-router-dom'
+import { useAuth } from '../../hooks/useAuth'
+import Navbar from '../../components/ui/Navbar'
+import Button from '../../components/ui/Button'
+
+const RESET_PHRASE = 'delete all service locations'
+
+export default function DangerousAdminPage() {
+  const { getToken } = useAuth()
+  const [phrase, setPhrase] = useState('')
+  const [resetting, setResetting] = useState(false)
+  const [result, setResult] = useState<{ ok: boolean; message: string; performed_at?: string } | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  async function handleReset() {
+    if (phrase !== RESET_PHRASE) return
+    setResetting(true)
+    setError(null)
+    setResult(null)
+    try {
+      const token = await getToken()
+      const res = await fetch('/api/v1/admin/dangerous', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        body: JSON.stringify({
+          action: 'reset_service_location_data',
+          confirmation: phrase,
+        }),
+      })
+      const body = await res.json()
+      if (!res.ok) throw new Error(body.error ?? 'Reset failed')
+      setResult({ ok: true, message: body.message, performed_at: body.performed_at })
+      setPhrase('')
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Reset failed')
+    } finally {
+      setResetting(false)
+    }
+  }
+
+  return (
+    <div className="flex flex-col h-full bg-gray-50">
+      <Navbar />
+      <div className="flex-1 overflow-y-auto">
+        <div className="max-w-2xl mx-auto px-6 py-8 space-y-6">
+          <div className="flex items-center gap-3 mb-2">
+            <Link to="/map" className="text-gray-400 hover:text-gray-600 text-sm">← Map</Link>
+            <h1 className="text-2xl font-bold text-gray-900">Admin — Dangerous Actions</h1>
+          </div>
+
+          <div className="bg-red-50 border border-red-200 rounded-xl p-5">
+            <div className="flex items-center gap-2 mb-3">
+              <svg className="w-5 h-5 text-red-600 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+              </svg>
+              <h2 className="font-semibold text-red-800">Reset All Service Location Data</h2>
+            </div>
+            <p className="text-sm text-red-700 mb-4">
+              This permanently deletes all service locations, properties, upload batches, and staged addresses.
+              <strong> The clients table will NOT be touched.</strong> Use this before re-uploading with proper client tagging.
+            </p>
+
+            {result ? (
+              <div className="p-3 bg-green-50 border border-green-200 rounded-lg text-green-700 text-sm">
+                <p className="font-medium">{result.message}</p>
+                {result.performed_at && (
+                  <p className="text-xs mt-1">{new Date(result.performed_at).toLocaleString()}</p>
+                )}
+              </div>
+            ) : (
+              <div className="space-y-3">
+                <p className="text-sm font-medium text-red-700">
+                  Type <span className="font-mono bg-red-100 px-1 rounded">{RESET_PHRASE}</span> to confirm:
+                </p>
+                <input
+                  type="text"
+                  value={phrase}
+                  onChange={(e) => setPhrase(e.target.value)}
+                  placeholder={RESET_PHRASE}
+                  className="w-full border border-red-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-red-400 bg-white"
+                />
+                {error && <p className="text-sm text-red-700">{error}</p>}
+                <Button
+                  variant="danger"
+                  loading={resetting}
+                  disabled={phrase !== RESET_PHRASE}
+                  onClick={handleReset}
+                >
+                  Reset All Service Location Data
+                </Button>
+              </div>
+            )}
+          </div>
+
+          <div className="bg-white rounded-xl shadow-sm border p-5">
+            <h2 className="font-semibold text-gray-800 mb-2">Other Admin Pages</h2>
+            <ul className="space-y-1 text-sm">
+              <li><Link to="/admin/parcels/import" className="text-blue-600 hover:underline">Parcel Import</Link></li>
+              <li><Link to="/admin/parcels/counties" className="text-blue-600 hover:underline">County Library</Link></li>
+              <li><Link to="/admin/parcels/fallbacks" className="text-blue-600 hover:underline">Parcel Fallbacks</Link></li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/clients/ClientDetail.tsx
+++ b/src/pages/clients/ClientDetail.tsx
@@ -1,0 +1,368 @@
+import { useState, useEffect } from 'react'
+import { useParams, Link, useNavigate } from 'react-router-dom'
+import { useAuth } from '../../hooks/useAuth'
+import Navbar from '../../components/ui/Navbar'
+import Button from '../../components/ui/Button'
+import { useClient } from '../../context/ClientContext'
+import type { Client } from '../../types'
+
+const STATUS_BADGE: Record<string, string> = {
+  active: 'bg-green-100 text-green-700',
+  prospect: 'bg-yellow-100 text-yellow-700',
+  churned: 'bg-gray-100 text-gray-500',
+}
+
+interface ClientDetail extends Client {
+  stats: { service_location_count: number; portfolio_count: number; total_serviceable_sqft: number }
+  recent_uploads: { upload_batch_id: string; filename: string; created_at: string; status: string; row_count: number }[]
+}
+
+export default function ClientDetailPage() {
+  const { id } = useParams<{ id: string }>()
+  const { getToken } = useAuth()
+  const navigate = useNavigate()
+  const { reloadClients } = useClient()
+
+  const [client, setClient] = useState<ClientDetail | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [editing, setEditing] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [archiving, setArchiving] = useState(false)
+  const [confirmArchive, setConfirmArchive] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  // Edit form state
+  const [editName, setEditName] = useState('')
+  const [editDisplayName, setEditDisplayName] = useState('')
+  const [editStatus, setEditStatus] = useState<'active' | 'prospect' | 'churned'>('active')
+  const [editContactName, setEditContactName] = useState('')
+  const [editContactEmail, setEditContactEmail] = useState('')
+  const [editContactPhone, setEditContactPhone] = useState('')
+  const [editNotes, setEditNotes] = useState('')
+  const [editBrandColor, setEditBrandColor] = useState('')
+
+  async function loadClient() {
+    setLoading(true)
+    try {
+      const token = await getToken()
+      const res = await fetch(`/api/v1/clients/${id}`, {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      if (!res.ok) throw new Error('Client not found')
+      const data: ClientDetail = await res.json()
+      setClient(data)
+      setEditName(data.name)
+      setEditDisplayName(data.display_name ?? '')
+      setEditStatus(data.status)
+      setEditContactName(data.primary_contact_name ?? '')
+      setEditContactEmail(data.primary_contact_email ?? '')
+      setEditContactPhone(data.primary_contact_phone ?? '')
+      setEditNotes(data.notes ?? '')
+      setEditBrandColor(data.brand_color ?? '')
+    } catch {
+      setError('Failed to load client')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => { if (id) loadClient() }, [id])
+
+  async function handleSave() {
+    setSaving(true)
+    setError(null)
+    try {
+      const token = await getToken()
+      const res = await fetch(`/api/v1/clients/${id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        body: JSON.stringify({
+          name: editName.trim(),
+          display_name: editDisplayName.trim() || null,
+          status: editStatus,
+          primary_contact_name: editContactName.trim() || null,
+          primary_contact_email: editContactEmail.trim() || null,
+          primary_contact_phone: editContactPhone.trim() || null,
+          notes: editNotes.trim() || null,
+          brand_color: editBrandColor || null,
+        }),
+      })
+      if (!res.ok) throw new Error((await res.json()).error ?? 'Save failed')
+      await loadClient()
+      await reloadClients()
+      setEditing(false)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Save failed')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  async function handleArchive() {
+    setArchiving(true)
+    try {
+      const token = await getToken()
+      await fetch(`/api/v1/clients/${id}/archive`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      await reloadClients()
+      navigate('/clients')
+    } catch {
+      setError('Archive failed')
+    } finally {
+      setArchiving(false)
+      setConfirmArchive(false)
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex flex-col h-full bg-gray-50">
+        <Navbar />
+        <div className="flex-1 flex items-center justify-center text-gray-400">Loading…</div>
+      </div>
+    )
+  }
+
+  if (!client) {
+    return (
+      <div className="flex flex-col h-full bg-gray-50">
+        <Navbar />
+        <div className="flex-1 flex items-center justify-center">
+          <div className="text-center space-y-3">
+            <p className="text-gray-500">Client not found.</p>
+            <Link to="/clients" className="text-blue-600 text-sm hover:underline">← Back to clients</Link>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  const clientColor = client.brand_color ?? hashColor(client.id)
+
+  return (
+    <div className="flex flex-col h-full bg-gray-50">
+      <Navbar />
+      <div className="flex-1 overflow-y-auto">
+        <div className="max-w-4xl mx-auto px-6 py-8 space-y-6">
+          {error && (
+            <div className="p-3 bg-red-50 border border-red-200 rounded-lg text-red-700 text-sm">{error}</div>
+          )}
+
+          {/* Header */}
+          <div className="flex items-start justify-between">
+            <div className="flex items-center gap-3">
+              <div
+                className="w-10 h-10 rounded-lg flex items-center justify-center text-white font-bold text-lg"
+                style={{ backgroundColor: clientColor }}
+              >
+                {(client.display_name ?? client.name).charAt(0).toUpperCase()}
+              </div>
+              <div>
+                <div className="flex items-center gap-2">
+                  <h1 className="text-2xl font-bold text-gray-900">{client.display_name ?? client.name}</h1>
+                  <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${STATUS_BADGE[client.status] ?? 'bg-gray-100 text-gray-500'}`}>
+                    {client.status}
+                  </span>
+                </div>
+                {client.display_name && <p className="text-sm text-gray-400">{client.name}</p>}
+              </div>
+            </div>
+            <div className="flex gap-2">
+              <Link
+                to={`/map?client_id=${client.id}`}
+                className="px-3 py-1.5 text-sm font-medium border border-gray-300 rounded-lg text-gray-700 hover:bg-gray-50"
+              >
+                View on map
+              </Link>
+              <Button size="sm" onClick={() => setEditing(true)}>Edit</Button>
+            </div>
+          </div>
+
+          {/* Stats */}
+          <div className="grid grid-cols-3 gap-4">
+            <StatCard label="Service Locations" value={client.stats.service_location_count.toLocaleString()} />
+            <StatCard label="Portfolios" value={client.stats.portfolio_count.toLocaleString()} />
+            <StatCard
+              label="Total Sqft"
+              value={client.stats.total_serviceable_sqft > 0
+                ? client.stats.total_serviceable_sqft.toLocaleString()
+                : '—'}
+            />
+          </div>
+
+          {/* Contact info */}
+          {(client.primary_contact_name || client.primary_contact_email || client.notes) && (
+            <div className="bg-white rounded-xl shadow-sm border p-5">
+              <h2 className="font-semibold text-gray-800 mb-3">Contact</h2>
+              <dl className="space-y-2 text-sm">
+                {client.primary_contact_name && (
+                  <div className="flex gap-2">
+                    <dt className="text-gray-500 w-24 shrink-0">Name</dt>
+                    <dd>{client.primary_contact_name}</dd>
+                  </div>
+                )}
+                {client.primary_contact_email && (
+                  <div className="flex gap-2">
+                    <dt className="text-gray-500 w-24 shrink-0">Email</dt>
+                    <dd><a href={`mailto:${client.primary_contact_email}`} className="text-blue-600 hover:underline">{client.primary_contact_email}</a></dd>
+                  </div>
+                )}
+                {client.primary_contact_phone && (
+                  <div className="flex gap-2">
+                    <dt className="text-gray-500 w-24 shrink-0">Phone</dt>
+                    <dd>{client.primary_contact_phone}</dd>
+                  </div>
+                )}
+                {client.notes && (
+                  <div className="flex gap-2">
+                    <dt className="text-gray-500 w-24 shrink-0">Notes</dt>
+                    <dd className="whitespace-pre-line">{client.notes}</dd>
+                  </div>
+                )}
+              </dl>
+            </div>
+          )}
+
+          {/* Recent uploads */}
+          {client.recent_uploads.length > 0 && (
+            <div className="bg-white rounded-xl shadow-sm border overflow-hidden">
+              <div className="px-5 py-4 border-b">
+                <h2 className="font-semibold text-gray-800">Recent Uploads</h2>
+              </div>
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b bg-gray-50">
+                    <th className="text-left px-4 py-2 font-medium text-gray-600">File</th>
+                    <th className="text-left px-4 py-2 font-medium text-gray-600">Rows</th>
+                    <th className="text-left px-4 py-2 font-medium text-gray-600">Status</th>
+                    <th className="text-left px-4 py-2 font-medium text-gray-600">Date</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y">
+                  {client.recent_uploads.map((u) => (
+                    <tr key={u.upload_batch_id} className="hover:bg-gray-50">
+                      <td className="px-4 py-2 font-mono text-xs text-gray-700">{u.filename}</td>
+                      <td className="px-4 py-2">{u.row_count.toLocaleString()}</td>
+                      <td className="px-4 py-2">
+                        <span className={`text-xs font-medium ${u.status === 'completed' ? 'text-green-600' : u.status === 'failed' ? 'text-red-600' : 'text-yellow-600'}`}>
+                          {u.status}
+                        </span>
+                      </td>
+                      <td className="px-4 py-2 text-gray-500">
+                        {new Date(u.created_at).toLocaleDateString()}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+
+          {/* Danger zone */}
+          <div className="bg-white rounded-xl shadow-sm border border-red-200 p-5">
+            <h2 className="font-semibold text-red-700 mb-2">Danger Zone</h2>
+            <p className="text-sm text-gray-600 mb-4">
+              Archiving sets status to "churned" but does not delete any data.
+            </p>
+            {confirmArchive ? (
+              <div className="flex items-center gap-3">
+                <p className="text-sm text-gray-700">Are you sure? This will mark the client as churned.</p>
+                <Button variant="danger" size="sm" loading={archiving} onClick={handleArchive}>
+                  Confirm Archive
+                </Button>
+                <Button variant="secondary" size="sm" onClick={() => setConfirmArchive(false)}>
+                  Cancel
+                </Button>
+              </div>
+            ) : (
+              <Button variant="danger" size="sm" onClick={() => setConfirmArchive(true)}>
+                Archive Client
+              </Button>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Edit modal */}
+      {editing && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
+          <div className="bg-white rounded-xl shadow-xl w-full max-w-lg max-h-[90vh] overflow-y-auto">
+            <div className="px-6 py-4 border-b flex items-center justify-between">
+              <h2 className="font-semibold text-gray-900">Edit Client</h2>
+              <button onClick={() => setEditing(false)} className="text-gray-400 hover:text-gray-600">✕</button>
+            </div>
+            <div className="px-6 py-4 space-y-4">
+              {error && <div className="p-3 bg-red-50 border border-red-200 rounded-lg text-red-700 text-sm">{error}</div>}
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Name *</label>
+                <input type="text" value={editName} onChange={(e) => setEditName(e.target.value)} className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Display Name</label>
+                <input type="text" value={editDisplayName} onChange={(e) => setEditDisplayName(e.target.value)} className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" />
+              </div>
+              <div className="grid grid-cols-2 gap-3">
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">Status</label>
+                  <select value={editStatus} onChange={(e) => setEditStatus(e.target.value as 'active' | 'prospect' | 'churned')} className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500">
+                    <option value="active">Active</option>
+                    <option value="prospect">Prospect</option>
+                    <option value="churned">Churned</option>
+                  </select>
+                </div>
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">Brand Color</label>
+                  <div className="flex gap-2">
+                    <input type="color" value={editBrandColor || '#3b82f6'} onChange={(e) => setEditBrandColor(e.target.value)} className="w-9 h-9 rounded border border-gray-300 cursor-pointer p-0.5" />
+                    <input type="text" value={editBrandColor} onChange={(e) => setEditBrandColor(e.target.value)} placeholder="#3b82f6" className="flex-1 border border-gray-300 rounded-lg px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-blue-500" />
+                  </div>
+                </div>
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Contact Name</label>
+                <input type="text" value={editContactName} onChange={(e) => setEditContactName(e.target.value)} className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Contact Email</label>
+                <input type="email" value={editContactEmail} onChange={(e) => setEditContactEmail(e.target.value)} className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Contact Phone</label>
+                <input type="tel" value={editContactPhone} onChange={(e) => setEditContactPhone(e.target.value)} className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Notes</label>
+                <textarea value={editNotes} onChange={(e) => setEditNotes(e.target.value)} rows={3} className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none" />
+              </div>
+            </div>
+            <div className="px-6 py-4 border-t flex justify-end gap-3">
+              <Button variant="secondary" onClick={() => setEditing(false)}>Cancel</Button>
+              <Button loading={saving} onClick={handleSave}>Save Changes</Button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function StatCard({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="bg-white rounded-xl shadow-sm border p-4">
+      <p className="text-2xl font-bold text-gray-900">{value}</p>
+      <p className="text-sm text-gray-500 mt-0.5">{label}</p>
+    </div>
+  )
+}
+
+function hashColor(str: string): string {
+  let hash = 0
+  for (let i = 0; i < str.length; i++) {
+    hash = str.charCodeAt(i) + ((hash << 5) - hash)
+    hash |= 0
+  }
+  const h = Math.abs(hash) % 360
+  return `hsl(${h}, 65%, 50%)`
+}

--- a/src/pages/clients/ClientsList.tsx
+++ b/src/pages/clients/ClientsList.tsx
@@ -1,0 +1,153 @@
+import { useState, useEffect } from 'react'
+import { Link } from 'react-router-dom'
+import { useAuth } from '../../hooks/useAuth'
+import Navbar from '../../components/ui/Navbar'
+import type { Client } from '../../types'
+
+const STATUS_BADGE: Record<string, string> = {
+  active: 'bg-green-100 text-green-700',
+  prospect: 'bg-yellow-100 text-yellow-700',
+  churned: 'bg-gray-100 text-gray-500',
+}
+
+export default function ClientsListPage() {
+  const { getToken } = useAuth()
+  const [clients, setClients] = useState<(Client & { service_location_count?: number; portfolio_count?: number })[]>([])
+  const [loading, setLoading] = useState(true)
+  const [statusFilter, setStatusFilter] = useState<string>('active')
+  const [search, setSearch] = useState('')
+
+  useEffect(() => {
+    let cancelled = false
+    async function load() {
+      setLoading(true)
+      try {
+        const token = await getToken()
+        const params = new URLSearchParams()
+        if (statusFilter) params.set('status', statusFilter)
+        if (search) params.set('search', search)
+        const res = await fetch(`/api/v1/clients?${params}`, {
+          headers: { Authorization: `Bearer ${token}` },
+        })
+        if (res.ok && !cancelled) setClients(await res.json())
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+    const t = setTimeout(load, search ? 300 : 0)
+    return () => { cancelled = true; clearTimeout(t) }
+  }, [statusFilter, search, getToken])
+
+  return (
+    <div className="flex flex-col h-full bg-gray-50">
+      <Navbar />
+      <div className="flex-1 overflow-y-auto">
+        <div className="max-w-6xl mx-auto px-6 py-8">
+          <div className="flex items-center justify-between mb-6">
+            <h1 className="text-2xl font-bold text-gray-900">Clients</h1>
+            <Link
+              to="/clients/new"
+              className="px-4 py-2 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 transition-colors"
+            >
+              + New Client
+            </Link>
+          </div>
+
+          {/* Filters */}
+          <div className="flex gap-3 mb-6">
+            <input
+              type="text"
+              placeholder="Search by name…"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              className="flex-1 max-w-xs border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+            <select
+              value={statusFilter}
+              onChange={(e) => setStatusFilter(e.target.value)}
+              className="border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            >
+              <option value="">All statuses</option>
+              <option value="active">Active</option>
+              <option value="prospect">Prospect</option>
+              <option value="churned">Churned</option>
+            </select>
+          </div>
+
+          {/* Table */}
+          <div className="bg-white rounded-xl shadow-sm border overflow-hidden">
+            {loading ? (
+              <div className="flex items-center justify-center py-16 text-gray-400 text-sm">Loading…</div>
+            ) : clients.length === 0 ? (
+              <div className="flex flex-col items-center justify-center py-16 gap-3">
+                <p className="text-gray-500">No clients found.</p>
+                <Link to="/clients/new" className="text-blue-600 text-sm hover:underline">
+                  Create your first client →
+                </Link>
+              </div>
+            ) : (
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b bg-gray-50">
+                    <th className="text-left px-4 py-3 font-semibold text-gray-600">Name</th>
+                    <th className="text-left px-4 py-3 font-semibold text-gray-600">Status</th>
+                    <th className="text-left px-4 py-3 font-semibold text-gray-600">Contact</th>
+                    <th className="text-left px-4 py-3 font-semibold text-gray-600">Actions</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y">
+                  {clients.map((c) => (
+                    <tr key={c.id} className="hover:bg-gray-50 transition-colors">
+                      <td className="px-4 py-3">
+                        <div className="flex items-center gap-2">
+                          <span
+                            className="w-3 h-3 rounded-full shrink-0"
+                            style={{ backgroundColor: c.brand_color ?? hashColor(c.id) }}
+                          />
+                          <div>
+                            <Link to={`/clients/${c.id}`} className="font-medium text-gray-900 hover:text-blue-600">
+                              {c.display_name ?? c.name}
+                            </Link>
+                            {c.display_name && (
+                              <p className="text-xs text-gray-400">{c.name}</p>
+                            )}
+                          </div>
+                        </div>
+                      </td>
+                      <td className="px-4 py-3">
+                        <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${STATUS_BADGE[c.status] ?? 'bg-gray-100 text-gray-500'}`}>
+                          {c.status}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3 text-gray-500">
+                        {c.primary_contact_name ?? '—'}
+                        {c.primary_contact_email && (
+                          <div className="text-xs">{c.primary_contact_email}</div>
+                        )}
+                      </td>
+                      <td className="px-4 py-3">
+                        <Link to={`/clients/${c.id}`} className="text-blue-600 hover:underline">
+                          View
+                        </Link>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function hashColor(str: string): string {
+  let hash = 0
+  for (let i = 0; i < str.length; i++) {
+    hash = str.charCodeAt(i) + ((hash << 5) - hash)
+    hash |= 0
+  }
+  const h = Math.abs(hash) % 360
+  return `hsl(${h}, 65%, 50%)`
+}

--- a/src/pages/clients/NewClient.tsx
+++ b/src/pages/clients/NewClient.tsx
@@ -1,0 +1,183 @@
+import { useState } from 'react'
+import { useNavigate, Link } from 'react-router-dom'
+import { useAuth } from '../../hooks/useAuth'
+import Navbar from '../../components/ui/Navbar'
+import Button from '../../components/ui/Button'
+import { useClient } from '../../context/ClientContext'
+
+export default function NewClientPage() {
+  const { getToken } = useAuth()
+  const navigate = useNavigate()
+  const { reloadClients } = useClient()
+
+  const [name, setName] = useState('')
+  const [displayName, setDisplayName] = useState('')
+  const [status, setStatus] = useState<'active' | 'prospect' | 'churned'>('active')
+  const [contactName, setContactName] = useState('')
+  const [contactEmail, setContactEmail] = useState('')
+  const [contactPhone, setContactPhone] = useState('')
+  const [notes, setNotes] = useState('')
+  const [brandColor, setBrandColor] = useState('')
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!name.trim()) return setError('Name is required')
+    setSaving(true)
+    setError(null)
+    try {
+      const token = await getToken()
+      const res = await fetch('/api/v1/clients', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        body: JSON.stringify({
+          name: name.trim(),
+          display_name: displayName.trim() || null,
+          status,
+          primary_contact_name: contactName.trim() || null,
+          primary_contact_email: contactEmail.trim() || null,
+          primary_contact_phone: contactPhone.trim() || null,
+          notes: notes.trim() || null,
+          brand_color: brandColor || null,
+        }),
+      })
+      if (!res.ok) {
+        const body = await res.json()
+        throw new Error(body.error ?? 'Failed to create client')
+      }
+      const client = await res.json()
+      await reloadClients()
+      navigate(`/clients/${client.id}`)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create client')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="flex flex-col h-full bg-gray-50">
+      <Navbar />
+      <div className="flex-1 overflow-y-auto">
+        <div className="max-w-2xl mx-auto px-6 py-8">
+          <div className="flex items-center gap-3 mb-6">
+            <Link to="/clients" className="text-gray-400 hover:text-gray-600 text-sm">← Clients</Link>
+            <h1 className="text-2xl font-bold text-gray-900">New Client</h1>
+          </div>
+
+          <form onSubmit={handleSubmit} className="bg-white rounded-xl shadow-sm border p-6 space-y-6">
+            {error && (
+              <div className="p-3 bg-red-50 border border-red-200 rounded-lg text-red-700 text-sm">{error}</div>
+            )}
+
+            <div className="grid grid-cols-2 gap-4">
+              <div className="col-span-2 sm:col-span-1">
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Name <span className="text-red-500">*</span>
+                </label>
+                <input
+                  type="text"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  placeholder="JLL"
+                  required
+                  className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                />
+              </div>
+              <div className="col-span-2 sm:col-span-1">
+                <label className="block text-sm font-medium text-gray-700 mb-1">Display Name</label>
+                <input
+                  type="text"
+                  value={displayName}
+                  onChange={(e) => setDisplayName(e.target.value)}
+                  placeholder="JLL (optional override)"
+                  className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                />
+              </div>
+            </div>
+
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Status</label>
+                <select
+                  value={status}
+                  onChange={(e) => setStatus(e.target.value as 'active' | 'prospect' | 'churned')}
+                  className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                >
+                  <option value="active">Active</option>
+                  <option value="prospect">Prospect</option>
+                  <option value="churned">Churned</option>
+                </select>
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Brand Color</label>
+                <div className="flex gap-2 items-center">
+                  <input
+                    type="color"
+                    value={brandColor || '#3b82f6'}
+                    onChange={(e) => setBrandColor(e.target.value)}
+                    className="w-10 h-9 rounded border border-gray-300 cursor-pointer p-0.5"
+                  />
+                  <input
+                    type="text"
+                    value={brandColor}
+                    onChange={(e) => setBrandColor(e.target.value)}
+                    placeholder="#3b82f6"
+                    className="flex-1 border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 font-mono"
+                  />
+                </div>
+              </div>
+            </div>
+
+            <fieldset>
+              <legend className="text-sm font-semibold text-gray-700 mb-3">Primary Contact</legend>
+              <div className="grid grid-cols-1 gap-3">
+                <input
+                  type="text"
+                  value={contactName}
+                  onChange={(e) => setContactName(e.target.value)}
+                  placeholder="Contact name"
+                  className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                />
+                <input
+                  type="email"
+                  value={contactEmail}
+                  onChange={(e) => setContactEmail(e.target.value)}
+                  placeholder="Email"
+                  className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                />
+                <input
+                  type="tel"
+                  value={contactPhone}
+                  onChange={(e) => setContactPhone(e.target.value)}
+                  placeholder="Phone"
+                  className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                />
+              </div>
+            </fieldset>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">Notes</label>
+              <textarea
+                value={notes}
+                onChange={(e) => setNotes(e.target.value)}
+                rows={3}
+                className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
+              />
+            </div>
+
+            <div className="flex justify-end gap-3 pt-2">
+              <Button variant="secondary" type="button" onClick={() => navigate('/clients')}>
+                Cancel
+              </Button>
+              <Button type="submit" loading={saving}>
+                Create Client
+              </Button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,20 @@
+export interface Client {
+  id: string
+  name: string
+  display_name?: string | null
+  status: 'active' | 'prospect' | 'churned'
+  notes?: string | null
+  primary_contact_name?: string | null
+  primary_contact_email?: string | null
+  primary_contact_phone?: string | null
+  brand_color?: string | null
+  logo_url?: string | null
+  metadata?: Record<string, unknown>
+  created_at: string
+  updated_at: string
+  created_by?: string | null
+}
+
 export type ColumnMapping = {
   address_line1: string
   address_line2?: string

--- a/supabase/migrations/20260428050000_clients.sql
+++ b/supabase/migrations/20260428050000_clients.sql
@@ -1,0 +1,79 @@
+-- Clients table: first-class entity scoping all service data
+CREATE TABLE IF NOT EXISTS clients (
+  id                    UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name                  TEXT NOT NULL,
+  display_name          TEXT,
+  status                TEXT NOT NULL DEFAULT 'active', -- active | prospect | churned
+  notes                 TEXT,
+  primary_contact_name  TEXT,
+  primary_contact_email TEXT,
+  primary_contact_phone TEXT,
+  brand_color           TEXT,
+  logo_url              TEXT,
+  metadata              JSONB NOT NULL DEFAULT '{}',
+  created_at            TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at            TIMESTAMPTZ NOT NULL DEFAULT now(),
+  created_by            TEXT
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_clients_name_lower ON clients(LOWER(name));
+CREATE INDEX IF NOT EXISTS idx_clients_status ON clients(status);
+
+-- updated_at trigger
+CREATE OR REPLACE FUNCTION set_updated_at()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN NEW.updated_at = now(); RETURN NEW; END;
+$$;
+
+DROP TRIGGER IF EXISTS clients_set_updated_at ON clients;
+CREATE TRIGGER clients_set_updated_at
+  BEFORE UPDATE ON clients
+  FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+-- Ensure service_locations has a UUID client_id referencing clients
+-- Production columns may be TEXT; convert if safe (no non-UUID data yet).
+DO $$ BEGIN
+  -- If client_id is TEXT, drop and re-add as UUID
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'service_locations'
+      AND column_name = 'client_id' AND data_type = 'text'
+  ) THEN
+    ALTER TABLE service_locations DROP COLUMN client_id;
+  END IF;
+  ALTER TABLE service_locations ADD COLUMN IF NOT EXISTS client_id UUID REFERENCES clients(id);
+EXCEPTION WHEN OTHERS THEN NULL;
+END $$;
+
+-- portfolios.client_id
+DO $$ BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'portfolios'
+      AND column_name = 'client_id' AND data_type = 'text'
+  ) THEN
+    ALTER TABLE portfolios DROP COLUMN client_id;
+  END IF;
+  ALTER TABLE portfolios ADD COLUMN IF NOT EXISTS client_id UUID REFERENCES clients(id);
+EXCEPTION WHEN OTHERS THEN NULL;
+END $$;
+
+-- upload_batches.client_id
+DO $$ BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'upload_batches'
+      AND column_name = 'client_id' AND data_type = 'text'
+  ) THEN
+    ALTER TABLE upload_batches DROP COLUMN client_id;
+  END IF;
+  ALTER TABLE upload_batches ADD COLUMN IF NOT EXISTS client_id UUID REFERENCES clients(id);
+EXCEPTION WHEN OTHERS THEN NULL;
+END $$;
+
+-- custom_field_definitions.client_id (if table exists)
+DO $$ BEGIN
+  ALTER TABLE custom_field_definitions ADD COLUMN IF NOT EXISTS client_id UUID REFERENCES clients(id);
+EXCEPTION WHEN undefined_table THEN NULL;
+WHEN OTHERS THEN NULL;
+END $$;


### PR DESCRIPTION
Closes #20

Adds Clients as a first-class entity to RBM Routing, scoping all service data to a specific client.

## Changes
- DB migration: `clients` table + UUID FK columns on service_locations/portfolios/upload_batches
- Full CRUD API for `/api/v1/clients`
- `ClientContext` with localStorage persistence
- Client switcher in top nav (All Clients / specific client)
- /clients list, /clients/new, /clients/:id pages
- Upload wizard Step 0 requires client selection
- Map auto-filters by selected client; color-codes pins by client in All Clients mode
- /admin/dangerous for wiping test data

Generated with [Claude Code](https://claude.ai/code)