### PR TITLE
fix: resolve account creation failures and stats bugs

### DIFF
--- a/api/v1/accounts/[id].ts
+++ b/api/v1/accounts/[id].ts
@@ -25,15 +25,20 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     if (error || !account) return res.status(404).json({ error: 'Account not found' })
 
     // Attach stats
-    const { count: clientCount } = await db
+    const { count: clientCount, data: accountClients } = await db
       .from('clients')
-      .select('id', { count: 'exact', head: true })
+      .select('id', { count: 'exact' })
       .eq('account_id', id)
 
-    const { count: slCount } = await db
-      .from('service_locations')
-      .select('service_location_id', { count: 'exact', head: true })
-      .eq('client_id', id)
+    const clientIds = (accountClients ?? []).map((c) => c.id)
+    let slCount = 0
+    if (clientIds.length > 0) {
+      const { count } = await db
+        .from('service_locations')
+        .select('service_location_id', { count: 'exact', head: true })
+        .in('client_id', clientIds)
+      slCount = count ?? 0
+    }
 
     const { data: recentUploads } = await db
       .from('upload_batches')
@@ -46,7 +51,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       ...account,
       stats: {
         client_count: clientCount ?? 0,
-        service_location_count: slCount ?? 0,
+        service_location_count: slCount,
       },
       recent_uploads: recentUploads ?? [],
     })

--- a/api/v1/accounts/index.ts
+++ b/api/v1/accounts/index.ts
@@ -75,9 +75,16 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         .select('id')
         .single()
 
-      if (!clientErr && client) {
-        return res.status(201).json({ ...account, auto_client_id: client.id })
+      if (clientErr) {
+        // Roll back the account we just created so the user can retry cleanly
+        await db.from('accounts').delete().eq('id', account.id)
+        if (clientErr.code === '23505') {
+          return res.status(409).json({ error: 'A client with this name already exists. Please choose a different account name.' })
+        }
+        return res.status(500).json({ error: clientErr.message })
       }
+
+      return res.status(201).json({ ...account, auto_client_id: client!.id })
     }
 
     return res.status(201).json(account)

--- a/supabase/migrations/20260428070000_fix_client_name_uniqueness.sql
+++ b/supabase/migrations/20260428070000_fix_client_name_uniqueness.sql
@@ -1,0 +1,10 @@
+-- Fix client name uniqueness for multi-account model.
+-- The old global unique index prevented different accounts from having
+-- clients with the same name. Replace it with:
+--   - A partial index for legacy clients with no account (preserves old behavior)
+--   - The existing per-account scoped index handles clients with an account_id
+DROP INDEX IF EXISTS idx_clients_name_lower;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_clients_name_no_account
+  ON clients(LOWER(name))
+  WHERE account_id IS NULL;


### PR DESCRIPTION
Fixes #24

- Add migration to drop global unique index on clients(name) and replace with a partial index scoped to clients without an account_id, allowing different accounts to have clients with the same name
- Fix service location count in account detail API (was filtering by account UUID on client_id column, always returning 0)
- Surface client creation errors properly with account rollback instead of silently swallowing them

Generated with [Claude Code](https://claude.ai/code)) | [View job run](https://github.com/joerickson/Mapping-Tool/actions/runs/25069550694