### PR TITLE
Fix ESM import paths — add .js extensions for Vercel runtime compatibility

### DIFF
--- a/api/_lib/auth.ts
+++ b/api/_lib/auth.ts
@@ -1,6 +1,6 @@
 import crypto from 'crypto'
 import type { VercelRequest } from '@vercel/node'
-import { createAdminClient } from './supabase'
+import { createAdminClient } from './supabase.js'
 
 // Legacy return type kept for backward compat with upload.ts
 export type AuthResult =

--- a/api/_lib/webhooks.ts
+++ b/api/_lib/webhooks.ts
@@ -1,5 +1,5 @@
 import crypto from 'crypto'
-import { createAdminClient } from './supabase'
+import { createAdminClient } from './supabase.js'
 
 export type WebhookEvent =
   | 'property.enriched'

--- a/api/embed/map.ts
+++ b/api/embed/map.ts
@@ -1,5 +1,5 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
-import { createAdminClient } from '../_lib/supabase'
+import { createAdminClient } from '../_lib/supabase.js'
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method === 'OPTIONS') return res.status(200).end()

--- a/api/portfolio/[share_token].ts
+++ b/api/portfolio/[share_token].ts
@@ -1,5 +1,5 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
-import { createAdminClient } from '../_lib/supabase'
+import { createAdminClient } from '../_lib/supabase.js'
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method === 'OPTIONS') return res.status(200).end()

--- a/api/scrub/[batchId]/approve.ts
+++ b/api/scrub/[batchId]/approve.ts
@@ -1,9 +1,9 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
 import crypto from 'crypto'
-import { createAdminClient } from '../../_lib/supabase'
-import { verifyAuth, unauthorized } from '../../_lib/auth'
-import { runEnrichmentJob } from '../../../src/lib/enrichment/orchestrator'
-import { parcelLookup } from '../../../src/lib/parcel/lookup'
+import { createAdminClient } from '../../_lib/supabase.js'
+import { verifyAuth, unauthorized } from '../../_lib/auth.js'
+import { runEnrichmentJob } from '../../../src/lib/enrichment/orchestrator.js'
+import { parcelLookup } from '../../../src/lib/parcel/lookup.js'
 
 function hashAddress(addr: string, city: string, state: string, zip: string): string {
   const normalized = [addr, city, state, zip]

--- a/api/scrub/[batchId]/review.ts
+++ b/api/scrub/[batchId]/review.ts
@@ -1,6 +1,6 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
-import { createAdminClient } from '../../_lib/supabase'
-import { verifyAuth, unauthorized } from '../../_lib/auth'
+import { createAdminClient } from '../../_lib/supabase.js'
+import { verifyAuth, unauthorized } from '../../_lib/auth.js'
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method === 'OPTIONS') return res.status(200).end()

--- a/api/scrub/[batchId]/rows/[rowId].ts
+++ b/api/scrub/[batchId]/rows/[rowId].ts
@@ -1,6 +1,6 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
-import { createAdminClient } from '../../../_lib/supabase'
-import { verifyAuth, unauthorized } from '../../../_lib/auth'
+import { createAdminClient } from '../../../_lib/supabase.js'
+import { verifyAuth, unauthorized } from '../../../_lib/auth.js'
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method === 'OPTIONS') return res.status(200).end()

--- a/api/upload.ts
+++ b/api/upload.ts
@@ -1,6 +1,6 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
-import { createAdminClient } from './_lib/supabase'
-import { verifyAuth, unauthorized } from './_lib/auth'
+import { createAdminClient } from './_lib/supabase.js'
+import { verifyAuth, unauthorized } from './_lib/auth.js'
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method === 'OPTIONS') return res.status(200).end()

--- a/api/uploads/[batchId]/process.ts
+++ b/api/uploads/[batchId]/process.ts
@@ -1,7 +1,7 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
-import { createAdminClient } from '../../_lib/supabase'
-import { verifyAuth, unauthorized } from '../../_lib/auth'
-import { runScrubPipeline } from '../../../src/lib/scrub/pipeline'
+import { createAdminClient } from '../../_lib/supabase.js'
+import { verifyAuth, unauthorized } from '../../_lib/auth.js'
+import { runScrubPipeline } from '../../../src/lib/scrub/pipeline.js'
 
 const CHUNK_SIZE = 100
 

--- a/api/uploads/[batchId]/status.ts
+++ b/api/uploads/[batchId]/status.ts
@@ -1,6 +1,6 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
-import { createAdminClient } from '../../_lib/supabase'
-import { verifyAuth, unauthorized } from '../../_lib/auth'
+import { createAdminClient } from '../../_lib/supabase.js'
+import { verifyAuth, unauthorized } from '../../_lib/auth.js'
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method === 'OPTIONS') return res.status(200).end()

--- a/api/v1/accounts/[id].ts
+++ b/api/v1/accounts/[id].ts
@@ -1,6 +1,6 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
-import { createAdminClient } from '../../_lib/supabase'
-import { authenticateRequest } from '../../_lib/auth'
+import { createAdminClient } from '../../_lib/supabase.js'
+import { authenticateRequest } from '../../_lib/auth.js'
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method === 'OPTIONS') return res.status(200).end()

--- a/api/v1/accounts/[id]/clients/index.ts
+++ b/api/v1/accounts/[id]/clients/index.ts
@@ -1,6 +1,6 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
-import { createAdminClient } from '../../../../_lib/supabase'
-import { authenticateRequest } from '../../../../_lib/auth'
+import { createAdminClient } from '../../../../_lib/supabase.js'
+import { authenticateRequest } from '../../../../_lib/auth.js'
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method === 'OPTIONS') return res.status(200).end()

--- a/api/v1/accounts/index.ts
+++ b/api/v1/accounts/index.ts
@@ -1,6 +1,6 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
-import { createAdminClient } from '../../_lib/supabase'
-import { authenticateRequest } from '../../_lib/auth'
+import { createAdminClient } from '../../_lib/supabase.js'
+import { authenticateRequest } from '../../_lib/auth.js'
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method === 'OPTIONS') return res.status(200).end()

--- a/api/v1/admin/dangerous.ts
+++ b/api/v1/admin/dangerous.ts
@@ -1,6 +1,6 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
-import { createAdminClient } from '../../_lib/supabase'
-import { authenticateRequest } from '../../_lib/auth'
+import { createAdminClient } from '../../_lib/supabase.js'
+import { authenticateRequest } from '../../_lib/auth.js'
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method === 'OPTIONS') return res.status(200).end()

--- a/api/v1/admin/parcels/counties.ts
+++ b/api/v1/admin/parcels/counties.ts
@@ -3,8 +3,8 @@
  * DELETE /api/v1/admin/parcels/counties?county_fips=XXXXX — remove all parcels for a county
  */
 import type { VercelRequest, VercelResponse } from '@vercel/node'
-import { createAdminClient } from '../../../_lib/supabase'
-import { authenticateRequest } from '../../../_lib/auth'
+import { createAdminClient } from '../../../_lib/supabase.js'
+import { authenticateRequest } from '../../../_lib/auth.js'
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method === 'OPTIONS') return res.status(200).end()

--- a/api/v1/admin/parcels/fallbacks.ts
+++ b/api/v1/admin/parcels/fallbacks.ts
@@ -6,8 +6,8 @@
  * Body: { county_fips }  — redirects to import flow (no-op here; client handles navigation)
  */
 import type { VercelRequest, VercelResponse } from '@vercel/node'
-import { createAdminClient } from '../../../_lib/supabase'
-import { authenticateRequest } from '../../../_lib/auth'
+import { createAdminClient } from '../../../_lib/supabase.js'
+import { authenticateRequest } from '../../../_lib/auth.js'
 
 const FALLBACK_THRESHOLD = parseInt(process.env.PARCEL_FALLBACK_THRESHOLD ?? '50', 10)
 

--- a/api/v1/admin/parcels/import/[importId].ts
+++ b/api/v1/admin/parcels/import/[importId].ts
@@ -3,8 +3,8 @@
  * Returns the current status of an import job (for live polling).
  */
 import type { VercelRequest, VercelResponse } from '@vercel/node'
-import { createAdminClient } from '../../../../_lib/supabase'
-import { authenticateRequest } from '../../../../_lib/auth'
+import { createAdminClient } from '../../../../_lib/supabase.js'
+import { authenticateRequest } from '../../../../_lib/auth.js'
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method === 'OPTIONS') return res.status(200).end()

--- a/api/v1/admin/parcels/import/_processor.ts
+++ b/api/v1/admin/parcels/import/_processor.ts
@@ -3,7 +3,7 @@
  * All formats are processed in 500-row batches to stay within Supabase limits.
  */
 import type { SupabaseClient } from '@supabase/supabase-js'
-import { mapRegridFields } from '../../../../../src/lib/parcel/fieldMapper'
+import { mapRegridFields } from '../../../../../src/lib/parcel/fieldMapper.js'
 
 const BATCH_SIZE = 500
 

--- a/api/v1/admin/parcels/import/index.ts
+++ b/api/v1/admin/parcels/import/index.ts
@@ -10,9 +10,9 @@
  */
 import type { VercelRequest, VercelResponse } from '@vercel/node'
 import Busboy from 'busboy'
-import { createAdminClient } from '../../../../_lib/supabase'
-import { authenticateRequest } from '../../../../_lib/auth'
-import { processImportJob } from './_processor'
+import { createAdminClient } from '../../../../_lib/supabase.js'
+import { authenticateRequest } from '../../../../_lib/auth.js'
+import { processImportJob } from './_processor.js'
 
 export const config = {
   api: { bodyParser: false },

--- a/api/v1/admin/service-api-keys/[id]/revoke.ts
+++ b/api/v1/admin/service-api-keys/[id]/revoke.ts
@@ -1,6 +1,6 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
-import { createAdminClient } from '../../../../_lib/supabase'
-import { authenticateRequest } from '../../../../_lib/auth'
+import { createAdminClient } from '../../../../_lib/supabase.js'
+import { authenticateRequest } from '../../../../_lib/auth.js'
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method === 'OPTIONS') return res.status(200).end()

--- a/api/v1/admin/service-api-keys/index.ts
+++ b/api/v1/admin/service-api-keys/index.ts
@@ -1,7 +1,7 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
 import crypto from 'crypto'
-import { createAdminClient } from '../../../_lib/supabase'
-import { authenticateRequest } from '../../../_lib/auth'
+import { createAdminClient } from '../../../_lib/supabase.js'
+import { authenticateRequest } from '../../../_lib/auth.js'
 
 function hashKey(raw: string): string {
   return crypto.createHash('sha256').update(raw).digest('hex')

--- a/api/v1/admin/webhook-deliveries.ts
+++ b/api/v1/admin/webhook-deliveries.ts
@@ -1,7 +1,7 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
-import { createAdminClient } from '../../_lib/supabase'
-import { authenticateRequest } from '../../_lib/auth'
-import { fireWebhook } from '../../_lib/webhooks'
+import { createAdminClient } from '../../_lib/supabase.js'
+import { authenticateRequest } from '../../_lib/auth.js'
+import { fireWebhook } from '../../_lib/webhooks.js'
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method === 'OPTIONS') return res.status(200).end()

--- a/api/v1/categories/index.ts
+++ b/api/v1/categories/index.ts
@@ -1,6 +1,6 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
-import { createAdminClient } from '../../_lib/supabase'
-import { authenticateRequest } from '../../_lib/auth'
+import { createAdminClient } from '../../_lib/supabase.js'
+import { authenticateRequest } from '../../_lib/auth.js'
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method === 'OPTIONS') return res.status(200).end()

--- a/api/v1/clients/[id].ts
+++ b/api/v1/clients/[id].ts
@@ -1,6 +1,6 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
-import { createAdminClient } from '../../_lib/supabase'
-import { authenticateRequest } from '../../_lib/auth'
+import { createAdminClient } from '../../_lib/supabase.js'
+import { authenticateRequest } from '../../_lib/auth.js'
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method === 'OPTIONS') return res.status(200).end()

--- a/api/v1/clients/[id]/archive.ts
+++ b/api/v1/clients/[id]/archive.ts
@@ -1,6 +1,6 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
-import { createAdminClient } from '../../../_lib/supabase'
-import { authenticateRequest } from '../../../_lib/auth'
+import { createAdminClient } from '../../../_lib/supabase.js'
+import { authenticateRequest } from '../../../_lib/auth.js'
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method === 'OPTIONS') return res.status(200).end()

--- a/api/v1/clients/[id]/template.ts
+++ b/api/v1/clients/[id]/template.ts
@@ -1,6 +1,6 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
-import { createAdminClient } from '../../../_lib/supabase'
-import { authenticateRequest } from '../../../_lib/auth'
+import { createAdminClient } from '../../../_lib/supabase.js'
+import { authenticateRequest } from '../../../_lib/auth.js'
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method === 'OPTIONS') return res.status(200).end()

--- a/api/v1/clients/[id]/template/validate.ts
+++ b/api/v1/clients/[id]/template/validate.ts
@@ -1,6 +1,6 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
-import { createAdminClient } from '../../../../_lib/supabase'
-import { authenticateRequest } from '../../../../_lib/auth'
+import { createAdminClient } from '../../../../_lib/supabase.js'
+import { authenticateRequest } from '../../../../_lib/auth.js'
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method === 'OPTIONS') return res.status(200).end()

--- a/api/v1/clients/index.ts
+++ b/api/v1/clients/index.ts
@@ -1,6 +1,6 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
-import { createAdminClient } from '../../_lib/supabase'
-import { authenticateRequest } from '../../_lib/auth'
+import { createAdminClient } from '../../_lib/supabase.js'
+import { authenticateRequest } from '../../_lib/auth.js'
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method === 'OPTIONS') return res.status(200).end()

--- a/api/v1/custom-field-definitions/[id].ts
+++ b/api/v1/custom-field-definitions/[id].ts
@@ -1,6 +1,6 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
-import { createAdminClient } from '../../_lib/supabase'
-import { authenticateRequest } from '../../_lib/auth'
+import { createAdminClient } from '../../_lib/supabase.js'
+import { authenticateRequest } from '../../_lib/auth.js'
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method === 'OPTIONS') return res.status(200).end()

--- a/api/v1/custom-field-definitions/index.ts
+++ b/api/v1/custom-field-definitions/index.ts
@@ -1,6 +1,6 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
-import { createAdminClient } from '../../_lib/supabase'
-import { authenticateRequest } from '../../_lib/auth'
+import { createAdminClient } from '../../_lib/supabase.js'
+import { authenticateRequest } from '../../_lib/auth.js'
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method === 'OPTIONS') return res.status(200).end()

--- a/api/v1/embed-tokens.ts
+++ b/api/v1/embed-tokens.ts
@@ -1,7 +1,7 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
 import crypto from 'crypto'
-import { createAdminClient } from '../_lib/supabase'
-import { authenticateRequest } from '../_lib/auth'
+import { createAdminClient } from '../_lib/supabase.js'
+import { authenticateRequest } from '../_lib/auth.js'
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method === 'OPTIONS') return res.status(200).end()

--- a/api/v1/enrichment-jobs/[id].ts
+++ b/api/v1/enrichment-jobs/[id].ts
@@ -1,6 +1,6 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
-import { createAdminClient } from '../../_lib/supabase'
-import { authenticateRequest } from '../../_lib/auth'
+import { createAdminClient } from '../../_lib/supabase.js'
+import { authenticateRequest } from '../../_lib/auth.js'
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method === 'OPTIONS') return res.status(200).end()

--- a/api/v1/enrichment-jobs/index.ts
+++ b/api/v1/enrichment-jobs/index.ts
@@ -1,8 +1,8 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
-import { createAdminClient } from '../../_lib/supabase'
-import { authenticateRequest } from '../../_lib/auth'
-import { runEnrichmentJob } from '../../../src/lib/enrichment/orchestrator'
-import { parcelLookup } from '../../../src/lib/parcel/lookup'
+import { createAdminClient } from '../../_lib/supabase.js'
+import { authenticateRequest } from '../../_lib/auth.js'
+import { runEnrichmentJob } from '../../../src/lib/enrichment/orchestrator.js'
+import { parcelLookup } from '../../../src/lib/parcel/lookup.js'
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method === 'OPTIONS') return res.status(200).end()

--- a/api/v1/parcels/coverage.ts
+++ b/api/v1/parcels/coverage.ts
@@ -3,8 +3,8 @@
  * Returns all counties with purchased local parcel data and aggregate totals.
  */
 import type { VercelRequest, VercelResponse } from '@vercel/node'
-import { createAdminClient } from '../../_lib/supabase'
-import { authenticateRequest } from '../../_lib/auth'
+import { createAdminClient } from '../../_lib/supabase.js'
+import { authenticateRequest } from '../../_lib/auth.js'
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method === 'OPTIONS') return res.status(200).end()

--- a/api/v1/parcels/coverage/check.ts
+++ b/api/v1/parcels/coverage/check.ts
@@ -8,9 +8,9 @@
  * Response: { covered: boolean, county_fips: string|null, source_refresh_date: string|null }
  */
 import type { VercelRequest, VercelResponse } from '@vercel/node'
-import { createAdminClient } from '../../../_lib/supabase'
-import { authenticateRequest } from '../../../_lib/auth'
-import { getCountyFips } from '../../../../src/lib/parcel/fips'
+import { createAdminClient } from '../../../_lib/supabase.js'
+import { authenticateRequest } from '../../../_lib/auth.js'
+import { getCountyFips } from '../../../../src/lib/parcel/fips.js'
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method === 'OPTIONS') return res.status(200).end()

--- a/api/v1/portfolios/[id].ts
+++ b/api/v1/portfolios/[id].ts
@@ -1,6 +1,6 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
-import { createAdminClient } from '../../_lib/supabase'
-import { authenticateRequest } from '../../_lib/auth'
+import { createAdminClient } from '../../_lib/supabase.js'
+import { authenticateRequest } from '../../_lib/auth.js'
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method === 'OPTIONS') return res.status(200).end()

--- a/api/v1/portfolios/[id]/locations.ts
+++ b/api/v1/portfolios/[id]/locations.ts
@@ -1,6 +1,6 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
-import { createAdminClient } from '../../../_lib/supabase'
-import { authenticateRequest } from '../../../_lib/auth'
+import { createAdminClient } from '../../../_lib/supabase.js'
+import { authenticateRequest } from '../../../_lib/auth.js'
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method === 'OPTIONS') return res.status(200).end()

--- a/api/v1/portfolios/[id]/share.ts
+++ b/api/v1/portfolios/[id]/share.ts
@@ -1,7 +1,7 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
 import crypto from 'crypto'
-import { createAdminClient } from '../../../_lib/supabase'
-import { authenticateRequest } from '../../../_lib/auth'
+import { createAdminClient } from '../../../_lib/supabase.js'
+import { authenticateRequest } from '../../../_lib/auth.js'
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method === 'OPTIONS') return res.status(200).end()

--- a/api/v1/portfolios/index.ts
+++ b/api/v1/portfolios/index.ts
@@ -1,6 +1,6 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
-import { createAdminClient } from '../../_lib/supabase'
-import { authenticateRequest } from '../../_lib/auth'
+import { createAdminClient } from '../../_lib/supabase.js'
+import { authenticateRequest } from '../../_lib/auth.js'
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method === 'OPTIONS') return res.status(200).end()

--- a/api/v1/properties/[id].ts
+++ b/api/v1/properties/[id].ts
@@ -1,7 +1,7 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
-import { createAdminClient } from '../../_lib/supabase'
-import { authenticateRequest } from '../../_lib/auth'
-import { fireWebhook } from '../../_lib/webhooks'
+import { createAdminClient } from '../../_lib/supabase.js'
+import { authenticateRequest } from '../../_lib/auth.js'
+import { fireWebhook } from '../../_lib/webhooks.js'
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method === 'OPTIONS') return res.status(200).end()

--- a/api/v1/properties/index.ts
+++ b/api/v1/properties/index.ts
@@ -1,8 +1,8 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
 import crypto from 'crypto'
-import { createAdminClient } from '../../_lib/supabase'
-import { authenticateRequest } from '../../_lib/auth'
-import { fireWebhook } from '../../_lib/webhooks'
+import { createAdminClient } from '../../_lib/supabase.js'
+import { authenticateRequest } from '../../_lib/auth.js'
+import { fireWebhook } from '../../_lib/webhooks.js'
 
 function hashAddress(addr: string, city: string, state: string, zip: string): string {
   const normalized = [addr, city, state, zip]

--- a/api/v1/proximity.ts
+++ b/api/v1/proximity.ts
@@ -1,6 +1,6 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
-import { createAdminClient } from '../_lib/supabase'
-import { authenticateRequest } from '../_lib/auth'
+import { createAdminClient } from '../_lib/supabase.js'
+import { authenticateRequest } from '../_lib/auth.js'
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method === 'OPTIONS') return res.status(200).end()

--- a/api/v1/service-locations/[id].ts
+++ b/api/v1/service-locations/[id].ts
@@ -1,7 +1,7 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
-import { createAdminClient } from '../../_lib/supabase'
-import { authenticateRequest } from '../../_lib/auth'
-import { fireWebhook } from '../../_lib/webhooks'
+import { createAdminClient } from '../../_lib/supabase.js'
+import { authenticateRequest } from '../../_lib/auth.js'
+import { fireWebhook } from '../../_lib/webhooks.js'
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method === 'OPTIONS') return res.status(200).end()

--- a/api/v1/service-locations/[id]/changes.ts
+++ b/api/v1/service-locations/[id]/changes.ts
@@ -1,6 +1,6 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
-import { createAdminClient } from '../../../_lib/supabase'
-import { authenticateRequest } from '../../../_lib/auth'
+import { createAdminClient } from '../../../_lib/supabase.js'
+import { authenticateRequest } from '../../../_lib/auth.js'
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method === 'OPTIONS') return res.status(200).end()

--- a/api/v1/service-locations/index.ts
+++ b/api/v1/service-locations/index.ts
@@ -1,7 +1,7 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
-import { createAdminClient } from '../../_lib/supabase'
-import { authenticateRequest } from '../../_lib/auth'
-import { fireWebhook } from '../../_lib/webhooks'
+import { createAdminClient } from '../../_lib/supabase.js'
+import { authenticateRequest } from '../../_lib/auth.js'
+import { fireWebhook } from '../../_lib/webhooks.js'
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method === 'OPTIONS') return res.status(200).end()

--- a/api/v1/service-offerings/[id].ts
+++ b/api/v1/service-offerings/[id].ts
@@ -1,6 +1,6 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
-import { createAdminClient } from '../../_lib/supabase'
-import { authenticateRequest } from '../../_lib/auth'
+import { createAdminClient } from '../../_lib/supabase.js'
+import { authenticateRequest } from '../../_lib/auth.js'
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method === 'OPTIONS') return res.status(200).end()

--- a/api/v1/service-offerings/index.ts
+++ b/api/v1/service-offerings/index.ts
@@ -1,6 +1,6 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
-import { createAdminClient } from '../../_lib/supabase'
-import { authenticateRequest } from '../../_lib/auth'
+import { createAdminClient } from '../../_lib/supabase.js'
+import { authenticateRequest } from '../../_lib/auth.js'
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method === 'OPTIONS') return res.status(200).end()

--- a/api/v1/shared-portfolios/[token].ts
+++ b/api/v1/shared-portfolios/[token].ts
@@ -1,5 +1,5 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
-import { createAdminClient } from '../../_lib/supabase'
+import { createAdminClient } from '../../_lib/supabase.js'
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method === 'OPTIONS') return res.status(200).end()


### PR DESCRIPTION
Fixes #026

Adds explicit `.js` extensions to all relative imports in the `/api` directory so Vercel's Node ESM runtime can resolve modules correctly. Affects 48 files; no frontend or bare-module imports were modified.

Generated with [Claude Code](https://claude.ai/code)