### PR TITLE
Fix accounts loading, cascading client dropdown, sample file upload zone + fetch timeout safety

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,4 @@
+import React from 'react'
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
 import { ClientProvider } from './context/ClientContext'
 import AuthGuard from './components/auth/AuthGuard'
@@ -25,8 +26,45 @@ import NewClientPage from './pages/clients/NewClient'
 import ClientDetailPage from './pages/clients/ClientDetail'
 import ClientSetupPage from './pages/clients/ClientSetup'
 
+class ErrorBoundary extends React.Component<
+  { children: React.ReactNode },
+  { hasError: boolean; error: Error | null }
+> {
+  constructor(props: { children: React.ReactNode }) {
+    super(props)
+    this.state = { hasError: false, error: null }
+  }
+
+  static getDerivedStateFromError(error: Error) {
+    return { hasError: true, error }
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="flex flex-col items-center justify-center h-screen bg-gray-50 p-8 text-center">
+          <div className="max-w-md">
+            <h1 className="text-xl font-semibold text-gray-900 mb-2">Something went wrong</h1>
+            <p className="text-sm text-gray-500 mb-4">
+              {this.state.error?.message ?? 'An unexpected error occurred.'}
+            </p>
+            <button
+              onClick={() => { this.setState({ hasError: false, error: null }); window.location.reload() }}
+              className="px-4 py-2 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700"
+            >
+              Reload Page
+            </button>
+          </div>
+        </div>
+      )
+    }
+    return this.props.children
+  }
+}
+
 export default function App() {
   return (
+    <ErrorBoundary>
     <BrowserRouter>
       <ClientProvider>
         <Routes>
@@ -68,5 +106,6 @@ export default function App() {
         </Routes>
       </ClientProvider>
     </BrowserRouter>
+    </ErrorBoundary>
   )
 }

--- a/src/pages/Upload.tsx
+++ b/src/pages/Upload.tsx
@@ -102,6 +102,8 @@ export default function UploadPage() {
   const [selectedUploadAccountId, setSelectedUploadAccountId] = useState<string>('')
   const [selectedUploadClientId, setSelectedUploadClientId] = useState<string>(selectedClientId ?? '')
   const [accountClients, setAccountClients] = useState<Client[]>([])
+  const [loadingClients, setLoadingClients] = useState(false)
+  const [clientsError, setClientsError] = useState<string | null>(null)
   const [showNewClientModal, setShowNewClientModal] = useState(false)
   const [newClientName, setNewClientName] = useState('')
   const [creatingClient, setCreatingClient] = useState(false)
@@ -128,17 +130,28 @@ export default function UploadPage() {
 
   // Load clients for selected account
   useEffect(() => {
-    if (!selectedUploadAccountId) { setAccountClients([]); return }
+    if (!selectedUploadAccountId) {
+      setAccountClients([])
+      setClientsError(null)
+      return
+    }
+    let cancelled = false
+    const controller = new AbortController()
+    const abortTimeout = setTimeout(() => controller.abort(), 10000)
+
     async function loadAccountClients() {
+      setLoadingClients(true)
+      setClientsError(null)
       try {
         const token = await getToken()
-        const res = await fetch(`/api/v1/clients?account_id=${selectedUploadAccountId}&status=active`, {
+        const res = await fetch(`/api/v1/accounts/${selectedUploadAccountId}/clients`, {
           headers: { Authorization: `Bearer ${token}` },
+          signal: controller.signal,
         })
-        if (res.ok) {
+        if (!res.ok) throw new Error(`Server error (${res.status})`)
+        if (!cancelled) {
           const data: Client[] = await res.json()
           setAccountClients(data)
-          // Auto-resolve for self_managed (single client)
           const account = accounts.find((a) => a.id === selectedUploadAccountId)
           if (account?.account_type === 'self_managed' && data.length === 1) {
             setSelectedUploadClientId(data[0].id)
@@ -146,9 +159,18 @@ export default function UploadPage() {
             setSelectedUploadClientId('')
           }
         }
-      } catch { /* ignore */ }
+      } catch (err) {
+        if (!cancelled) {
+          const isTimeout = err instanceof DOMException && err.name === 'AbortError'
+          setClientsError(isTimeout ? 'Request timed out' : 'Failed to load clients')
+        }
+      } finally {
+        clearTimeout(abortTimeout)
+        if (!cancelled) setLoadingClients(false)
+      }
     }
     loadAccountClients()
+    return () => { cancelled = true; clearTimeout(abortTimeout); controller.abort() }
   }, [selectedUploadAccountId, accounts, getToken])
 
   // Sync selected client when nav switcher changes
@@ -401,35 +423,67 @@ export default function UploadPage() {
                 </Link>
               </div>
 
-              {/* Client selector — only for property_manager with 2+ clients */}
+              {/* Client selector */}
               {selectedUploadAccountId && (() => {
                 const acct = accounts.find((a) => a.id === selectedUploadAccountId)
                 if (!acct) return null
+
+                if (loadingClients) {
+                  return <div className="text-sm text-gray-400 py-1">Loading clients…</div>
+                }
+
+                if (clientsError) {
+                  return (
+                    <div className="p-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-700">
+                      {clientsError}
+                    </div>
+                  )
+                }
+
                 if (acct.account_type === 'self_managed') {
                   const selfClient = accountClients[0]
                   return selfClient ? (
                     <div className="p-3 bg-gray-50 border border-gray-200 rounded-lg text-sm text-gray-700">
                       Client: <strong>{selfClient.display_name ?? selfClient.name}</strong> (auto-resolved)
                     </div>
-                  ) : null
+                  ) : (
+                    <div className="p-3 bg-yellow-50 border border-yellow-200 rounded-lg text-sm text-yellow-800">
+                      This account has no clients yet.{' '}
+                      <Link to={`/accounts/${selectedUploadAccountId}/clients/new`} className="underline font-medium">
+                        + Add Client
+                      </Link>
+                    </div>
+                  )
                 }
+
                 // property_manager
                 return (
                   <div>
                     <label className="block text-sm font-medium text-gray-700 mb-1">Client</label>
-                    <select
-                      value={selectedUploadClientId}
-                      onChange={(e) => setSelectedUploadClientId(e.target.value)}
-                      className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-                    >
-                      <option value="">— select client —</option>
-                      {accountClients.map((c) => (
-                        <option key={c.id} value={c.id}>{c.display_name ?? c.name}</option>
-                      ))}
-                    </select>
-                    <Link to={`/accounts/${selectedUploadAccountId}/clients/new`} className="text-xs text-blue-600 hover:underline mt-1 inline-block">
-                      + New Client
-                    </Link>
+                    {accountClients.length === 0 ? (
+                      <div className="p-3 bg-yellow-50 border border-yellow-200 rounded-lg text-sm text-yellow-800">
+                        This account has no clients yet.{' '}
+                        <Link to={`/accounts/${selectedUploadAccountId}/clients/new`} className="underline font-medium">
+                          + Add Client
+                        </Link>
+                      </div>
+                    ) : (
+                      <>
+                        <select
+                          value={selectedUploadClientId}
+                          onChange={(e) => setSelectedUploadClientId(e.target.value)}
+                          className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                        >
+                          <option value="">— select client —</option>
+                          {accountClients.map((c) => (
+                            <option key={c.id} value={c.id}>{c.display_name ?? c.name}</option>
+                          ))}
+                        </select>
+                        <Link to={`/accounts/${selectedUploadAccountId}/clients/new`} className="text-xs text-blue-600 hover:underline mt-1 inline-block">
+                          + New Client
+                        </Link>
+                      </>
+                    )}
                   </div>
                 )
               })()}

--- a/src/pages/accounts/AccountsList.tsx
+++ b/src/pages/accounts/AccountsList.tsx
@@ -22,27 +22,51 @@ export default function AccountsListPage() {
   const { getToken } = useAuth()
   const [accounts, setAccounts] = useState<AccountRow[]>([])
   const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
   const [search, setSearch] = useState('')
+  const [retryCount, setRetryCount] = useState(0)
 
   useEffect(() => {
     let cancelled = false
+    const controller = new AbortController()
+    const abortTimeout = setTimeout(() => controller.abort(), 10000)
+
     async function load() {
       setLoading(true)
+      setError(null)
       try {
         const token = await getToken()
         const params = new URLSearchParams()
         if (search) params.set('search', search)
         const res = await fetch(`/api/v1/accounts?${params}`, {
           headers: { Authorization: `Bearer ${token}` },
+          signal: controller.signal,
         })
-        if (res.ok && !cancelled) setAccounts(await res.json())
+        if (!res.ok) throw new Error(`Server error (${res.status})`)
+        if (!cancelled) setAccounts(await res.json())
+      } catch (err) {
+        if (!cancelled) {
+          const isTimeout = err instanceof DOMException && err.name === 'AbortError'
+          setError(
+            isTimeout
+              ? 'Request timed out — the server is taking too long to respond.'
+              : err instanceof Error ? err.message : 'Failed to load accounts'
+          )
+        }
       } finally {
+        clearTimeout(abortTimeout)
         if (!cancelled) setLoading(false)
       }
     }
-    const t = setTimeout(load, search ? 300 : 0)
-    return () => { cancelled = true; clearTimeout(t) }
-  }, [search, getToken])
+
+    const debounce = setTimeout(load, search ? 300 : 0)
+    return () => {
+      cancelled = true
+      clearTimeout(debounce)
+      clearTimeout(abortTimeout)
+      controller.abort()
+    }
+  }, [search, getToken, retryCount])
 
   return (
     <div className="flex flex-col h-full bg-gray-50">
@@ -72,9 +96,19 @@ export default function AccountsListPage() {
           <div className="bg-white rounded-xl shadow-sm border overflow-hidden">
             {loading ? (
               <div className="flex items-center justify-center py-16 text-gray-400 text-sm">Loading…</div>
+            ) : error ? (
+              <div className="flex flex-col items-center justify-center py-16 gap-3">
+                <p className="text-red-600 text-sm">{error}</p>
+                <button
+                  onClick={() => setRetryCount((c) => c + 1)}
+                  className="text-blue-600 text-sm hover:underline"
+                >
+                  Retry
+                </button>
+              </div>
             ) : accounts.length === 0 ? (
               <div className="flex flex-col items-center justify-center py-16 gap-3">
-                <p className="text-gray-500">No accounts yet.</p>
+                <p className="text-gray-500">No accounts yet — create your first account</p>
                 <Link to="/accounts/new" className="text-blue-600 text-sm hover:underline">
                   Create your first account →
                 </Link>

--- a/src/pages/clients/ClientSetup.tsx
+++ b/src/pages/clients/ClientSetup.tsx
@@ -1,8 +1,10 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { useParams, useNavigate, Link } from 'react-router-dom'
 import { useAuth } from '../../hooks/useAuth'
 import Navbar from '../../components/ui/Navbar'
 import Button from '../../components/ui/Button'
+import Papa from 'papaparse'
+import * as XLSX from 'xlsx'
 import type { Client, ServiceOffering, CustomFieldDefinition, ClientTemplate, PricingModel, CustomFieldType } from '../../types'
 
 type WizardStep = 1 | 2 | 3 | 4 | 5
@@ -71,6 +73,13 @@ export default function ClientSetupPage() {
   const [colMappingRows, setColMappingRows] = useState<{ src: string; target: string; required: boolean }[]>([])
   const [sheetMappingRows, setSheetMappingRows] = useState<{ pattern: string; offeringId: string }[]>([])
   const [defaultCountry, setDefaultCountry] = useState('')
+
+  // Step 4: Sample file validation
+  const [sampleFile, setSampleFile] = useState<File | null>(null)
+  const [sampleMappedCols, setSampleMappedCols] = useState<string[]>([])
+  const [sampleUnmappedCols, setSampleUnmappedCols] = useState<string[]>([])
+  const [isDragging, setIsDragging] = useState(false)
+  const sampleInputRef = useRef<HTMLInputElement>(null)
 
   async function loadData() {
     setLoading(true)
@@ -189,6 +198,45 @@ export default function ClientSetupPage() {
         is_configured: isConfigured,
       }),
     })
+  }
+
+  function parseSampleFile(file: File) {
+    setSampleFile(file)
+    setSampleMappedCols([])
+    setSampleUnmappedCols([])
+    const templateSrcCols = new Set(colMappingRows.map((r) => r.src.toLowerCase()))
+
+    function processCols(cols: string[]) {
+      const mapped: string[] = []
+      const unmapped: string[] = []
+      cols.forEach((c) => {
+        if (templateSrcCols.has(c.toLowerCase())) mapped.push(c)
+        else unmapped.push(c)
+      })
+      setSampleMappedCols(mapped)
+      setSampleUnmappedCols(unmapped)
+    }
+
+    const ext = file.name.split('.').pop()?.toLowerCase()
+    if (ext === 'csv') {
+      Papa.parse(file, {
+        header: true,
+        preview: 1,
+        skipEmptyLines: true,
+        complete: (results) => processCols(results.meta.fields ?? []),
+      })
+    } else {
+      const reader = new FileReader()
+      reader.onload = (e) => {
+        try {
+          const wb = XLSX.read(e.target?.result, { type: 'binary' })
+          const ws = wb.Sheets[wb.SheetNames[0]]
+          const rows = XLSX.utils.sheet_to_json<Record<string, unknown>>(ws, { defval: '' })
+          processCols(rows.length ? Object.keys(rows[0]) : [])
+        } catch { /* ignore parse errors */ }
+      }
+      reader.readAsBinaryString(file)
+    }
   }
 
   async function goToStep(next: WizardStep) {
@@ -524,12 +572,76 @@ export default function ClientSetupPage() {
             <div className="bg-white rounded-xl shadow-sm border p-6 space-y-4">
               <div>
                 <h2 className="text-lg font-semibold text-gray-900">Validate Template (Optional)</h2>
-                <p className="text-sm text-gray-500 mt-1">Drop a sample file here to preview how the template maps to it. You can skip this step.</p>
+                <p className="text-sm text-gray-500 mt-1">Drop a sample file to preview how the template maps to it. You can skip this step.</p>
               </div>
 
-              <div className="flex items-center justify-center h-32 border-2 border-dashed border-gray-300 rounded-xl text-sm text-gray-400">
-                Sample file upload (optional) — skip to continue
-              </div>
+              <input
+                ref={sampleInputRef}
+                type="file"
+                accept=".csv,.xlsx,.xls"
+                className="hidden"
+                onChange={(e) => { const f = e.target.files?.[0]; if (f) parseSampleFile(f) }}
+              />
+
+              {!sampleFile ? (
+                <div
+                  role="button"
+                  tabIndex={0}
+                  onClick={() => sampleInputRef.current?.click()}
+                  onKeyDown={(e) => e.key === 'Enter' && sampleInputRef.current?.click()}
+                  onDragEnter={(e) => { e.preventDefault(); setIsDragging(true) }}
+                  onDragOver={(e) => { e.preventDefault(); setIsDragging(true) }}
+                  onDragLeave={(e) => { e.preventDefault(); setIsDragging(false) }}
+                  onDrop={(e) => {
+                    e.preventDefault()
+                    setIsDragging(false)
+                    const f = e.dataTransfer.files[0]
+                    if (f) parseSampleFile(f)
+                  }}
+                  className={`flex items-center justify-center h-32 border-2 border-dashed rounded-xl cursor-pointer transition-colors text-sm select-none
+                    ${isDragging
+                      ? 'border-blue-400 bg-blue-50 text-blue-600'
+                      : 'border-gray-300 text-gray-400 hover:border-gray-400 hover:text-gray-500'
+                    }`}
+                >
+                  {isDragging ? 'Drop file here' : 'Click or drag a sample file (.csv, .xlsx) — optional'}
+                </div>
+              ) : (
+                <div className="border border-gray-200 rounded-xl p-4 space-y-3">
+                  <div className="flex items-center justify-between">
+                    <p className="text-sm font-medium text-gray-700">{sampleFile.name}</p>
+                    <button
+                      onClick={() => { setSampleFile(null); setSampleMappedCols([]); setSampleUnmappedCols([]) }}
+                      className="text-xs text-gray-400 hover:text-gray-600"
+                    >
+                      ✕ Remove
+                    </button>
+                  </div>
+                  {sampleMappedCols.length > 0 && (
+                    <div>
+                      <p className="text-xs font-semibold text-green-700 mb-1">Auto-mapped ({sampleMappedCols.length})</p>
+                      <div className="flex flex-wrap gap-1">
+                        {sampleMappedCols.map((c) => (
+                          <span key={c} className="px-2 py-0.5 bg-green-100 text-green-700 text-xs rounded-full">{c}</span>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+                  {sampleUnmappedCols.length > 0 && (
+                    <div>
+                      <p className="text-xs font-semibold text-gray-500 mb-1">Unmapped ({sampleUnmappedCols.length})</p>
+                      <div className="flex flex-wrap gap-1">
+                        {sampleUnmappedCols.map((c) => (
+                          <span key={c} className="px-2 py-0.5 bg-gray-100 text-gray-500 text-xs rounded-full">{c}</span>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+                  {sampleMappedCols.length === 0 && sampleUnmappedCols.length === 0 && (
+                    <p className="text-sm text-gray-400">No columns detected — file may be empty.</p>
+                  )}
+                </div>
+              )}
 
               <div className="flex justify-between pt-2">
                 <Button variant="secondary" onClick={() => setStep(3)}>← Back</Button>


### PR DESCRIPTION
Fixes #3 three coordinated bugs in the Accounts/Clients/Service Offerings rollout:

- **Bug 1**: /accounts page no longer hangs indefinitely — 10s AbortController timeout + error state with retry button
- **Bug 2**: Upload wizard Step 0 client dropdown now shows loading state, propagates errors, and displays empty-state when no clients exist
- **Bug 3**: ClientSetup Step 4 upload zone is now clickable and supports drag-and-drop with auto-mapped vs unmapped column preview
- Added global ErrorBoundary at app root

Generated with [Claude Code](https://claude.ai/code)