### PR TITLE
fix: remove redundant API rewrite causing url.parse() deprecation warning

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -23,7 +23,6 @@
     }
   ],
   "rewrites": [
-    { "source": "/api/(.*)", "destination": "/api/$1" },
     { "source": "/embed/map", "destination": "/api/embed/map" },
     { "source": "/portfolio/:share_token", "destination": "/api/portfolio/[share_token]" }
   ],


### PR DESCRIPTION
Removes the no-op `/api/(.*)` → `/api/$1` rewrite from vercel.json. Vercel already auto-routes the api/ directory as serverless functions, so this rewrite was redundant and was causing Vercel's routing engine to invoke url.parse() on every API request, triggering the Node.js DEP0169 deprecation warning.

Closes #32

Generated with [Claude Code](https://claude.ai/code)