### PR TITLE
Fix Bug 2: Promise.allSettled, fetch timeouts, error boundary

### DIFF
--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,34 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react'
+
+interface Props { children: ReactNode }
+interface State { hasError: boolean; error: Error | null }
+
+export default class ErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false, error: null }
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error }
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error('Uncaught error:', error, info)
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="flex flex-col items-center justify-center min-h-screen bg-gray-50 p-8 text-center">
+          <h1 className="text-xl font-semibold text-gray-900 mb-2">Something went wrong</h1>
+          <p className="text-sm text-gray-500 mb-4">{this.state.error?.message ?? 'An unexpected error occurred.'}</p>
+          <button
+            onClick={() => this.setState({ hasError: false, error: null })}
+            className="px-4 py-2 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700"
+          >
+            Try again
+          </button>
+        </div>
+      )
+    }
+    return this.props.children
+  }
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,0 +1,14 @@
+export async function apiFetch(url: string, options: RequestInit = {}, timeoutMs = 10000): Promise<Response> {
+  const controller = new AbortController()
+  const id = setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    return await fetch(url, { ...options, signal: controller.signal })
+  } catch (err) {
+    if (err instanceof DOMException && err.name === 'AbortError') {
+      throw new Error('Request timed out — the server is taking too long to respond.')
+    }
+    throw err
+  } finally {
+    clearTimeout(id)
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,13 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App'
+import ErrorBoundary from './components/ErrorBoundary'
 import './index.css'
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <App />
+    <ErrorBoundary>
+      <App />
+    </ErrorBoundary>
   </React.StrictMode>
 )

--- a/src/pages/Upload.tsx
+++ b/src/pages/Upload.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from 'react'
 import { Link } from 'react-router-dom'
 import { useAuth } from '../hooks/useAuth'
 import { useClient } from '../context/ClientContext'
+import { apiFetch } from '../lib/api'
 import Navbar from '../components/ui/Navbar'
 import UploadDropzone from '../components/upload/UploadDropzone'
 import SheetMappingStep from '../components/upload/SheetMappingStep'
@@ -144,7 +145,7 @@ export default function UploadPage() {
     if (!cid) return
     try {
       const token = await getToken()
-      const res = await fetch(`/api/v1/clients/${cid}/template`, {
+      const res = await apiFetch(`/api/v1/clients/${cid}/template`, {
         headers: { Authorization: `Bearer ${token}` },
       })
       if (res.ok) setClientTemplate(await res.json())
@@ -158,7 +159,7 @@ export default function UploadPage() {
       const params = new URLSearchParams({ include_related: 'true' })
       if (accountId) params.set('account_id', accountId)
       if (clientId) params.set('client_id', clientId)
-      const res = await fetch(`/api/v1/service-offerings?${params}`, {
+      const res = await apiFetch(`/api/v1/service-offerings?${params}`, {
         headers: { Authorization: `Bearer ${token}` },
       })
       if (res.ok) setServiceOfferings(await res.json())
@@ -172,7 +173,7 @@ export default function UploadPage() {
       const params = new URLSearchParams()
       if (accountId) params.set('account_id', accountId)
       if (clientId) params.set('client_id', clientId)
-      const res = await fetch(`/api/v1/custom-field-definitions?${params}`, {
+      const res = await apiFetch(`/api/v1/custom-field-definitions?${params}`, {
         headers: { Authorization: `Bearer ${token}` },
       })
       if (res.ok) setCustomFields(await res.json())
@@ -181,11 +182,14 @@ export default function UploadPage() {
 
   const handleClientConfirmed = async () => {
     setError(null)
-    await Promise.all([
+    const results = await Promise.allSettled([
       loadClientTemplate(selectedClientIdLocal),
       loadServiceOfferings(selectedAccountId, selectedClientIdLocal),
       loadCustomFields(selectedAccountId, selectedClientIdLocal),
     ])
+    results.forEach((r) => {
+      if (r.status === 'rejected') console.error('Preload failed:', r.reason)
+    })
     setStep('upload')
   }
 

--- a/src/pages/clients/ClientSetup.tsx
+++ b/src/pages/clients/ClientSetup.tsx
@@ -5,6 +5,7 @@ import Navbar from '../../components/ui/Navbar'
 import Button from '../../components/ui/Button'
 import Papa from 'papaparse'
 import * as XLSX from 'xlsx'
+import { apiFetch } from '../../lib/api'
 import type { Client, ServiceOffering, CustomFieldDefinition, ClientTemplate, PricingModel, CustomFieldType } from '../../types'
 
 type WizardStep = 1 | 2 | 3 | 4 | 5
@@ -85,17 +86,21 @@ export default function ClientSetupPage() {
     setLoading(true)
     try {
       const token = await getToken()
-      const [clientRes, offeringsRes, fieldsRes, templateRes] = await Promise.all([
-        fetch(`/api/v1/clients/${id}`, { headers: { Authorization: `Bearer ${token}` } }),
-        fetch(`/api/v1/service-offerings?client_id=${id}`, { headers: { Authorization: `Bearer ${token}` } }),
-        fetch(`/api/v1/custom-field-definitions?client_id=${id}`, { headers: { Authorization: `Bearer ${token}` } }),
-        fetch(`/api/v1/clients/${id}/template`, { headers: { Authorization: `Bearer ${token}` } }),
+      const headers = { Authorization: `Bearer ${token}` }
+      const [clientResult, offeringsResult, fieldsResult, templateResult] = await Promise.allSettled([
+        apiFetch(`/api/v1/clients/${id}`, { headers }),
+        apiFetch(`/api/v1/service-offerings?client_id=${id}`, { headers }),
+        apiFetch(`/api/v1/custom-field-definitions?client_id=${id}`, { headers }),
+        apiFetch(`/api/v1/clients/${id}/template`, { headers }),
       ])
-      if (clientRes.ok) setClient(await clientRes.json())
-      if (offeringsRes.ok) setOfferings(await offeringsRes.json())
-      if (fieldsRes.ok) setCustomFields(await fieldsRes.json())
-      if (templateRes.ok) {
-        const t: ClientTemplate = await templateRes.json()
+      if (clientResult.status === 'fulfilled' && clientResult.value.ok)
+        setClient(await clientResult.value.json())
+      if (offeringsResult.status === 'fulfilled' && offeringsResult.value.ok)
+        setOfferings(await offeringsResult.value.json())
+      if (fieldsResult.status === 'fulfilled' && fieldsResult.value.ok)
+        setCustomFields(await fieldsResult.value.json())
+      if (templateResult.status === 'fulfilled' && templateResult.value.ok) {
+        const t: ClientTemplate = await templateResult.value.json()
         setTemplate(t)
         setDefaultCountry(t.default_country ?? '')
         setColMappingRows(


### PR DESCRIPTION
Fixes #34

- Replace Promise.all with Promise.allSettled in Upload wizard and ClientSetup so a single failing request never hangs the UI
- Add apiFetch helper with 10s AbortController timeout on all affected fetch calls
- Add global React ErrorBoundary at app root

Generated with [Claude Code](https://claude.ai/code)