### PR TITLE
Fix infinite useEffect loop — stabilize getToken reference in useAuth

### DIFF
--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,10 +1,11 @@
+import { useCallback } from 'react'
 import { supabase } from '../lib/supabase/client'
 
 export function useAuth() {
-  const getToken = async (): Promise<string | null> => {
+  const getToken = useCallback(async (): Promise<string | null> => {
     const { data: { session } } = await supabase.auth.getSession()
     return session?.access_token ?? null
-  }
+  }, [])
 
   return { getToken }
 }


### PR DESCRIPTION
Fixes #38

Wraps `getToken` in `useCallback(fn, [])` so it has a stable reference across renders. Every useEffect that listed `getToken` as a dependency was re-firing on every render, producing the infinite API request loop on /accounts and /upload.

Generated with [Claude Code](https://claude.ai/code)