### PR TITLE
Add SPA fallback rewrite to vercel.json — fix 404 on hard refresh

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -24,7 +24,9 @@
   ],
   "rewrites": [
     { "source": "/embed/map", "destination": "/api/embed/map" },
-    { "source": "/portfolio/:share_token", "destination": "/api/portfolio/[share_token]" }
+    { "source": "/portfolio/:share_token", "destination": "/api/portfolio/[share_token]" },
+    { "source": "/api/:path*", "destination": "/api/:path*" },
+    { "source": "/:path*", "destination": "/index.html" }
   ],
   "headers": [
     {


### PR DESCRIPTION
Fix 404 NOT_FOUND errors when hard-refreshing on non-root client routes (/accounts, /upload, /clients/{id}/setup, etc.).

Adds two rewrite rules to the existing vercel.json:
- `/api/:path*` → `/api/:path*` — pass-through to keep API routes on serverless functions
- `/:path*` → `/index.html` — SPA catch-all so React Router handles client-side routing

Existing specific rewrites for `/embed/map` and `/portfolio/:share_token` are preserved at the top of the rewrites array.

Closes #40

Generated with [Claude Code](https://claude.ai/code)