### PR TITLE
Fix: require account selection before proceeding to upload step

### DIFF
--- a/src/pages/Upload.tsx
+++ b/src/pages/Upload.tsx
@@ -413,7 +413,7 @@ export default function UploadPage() {
               <div className="flex justify-end pt-2">
                 <button
                   onClick={handleClientConfirmed}
-                  disabled={!selectedClientIdLocal}
+                  disabled={!selectedAccountId || !selectedClientIdLocal}
                   className="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-lg hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
                 >
                   Next: Upload File


### PR DESCRIPTION
Fixes #42

The "Next: Upload File" button was only gated on `selectedClientIdLocal`, which could be pre-populated from localStorage even when no account was selected in the current session. This allowed users to reach the upload step with an empty account_id, causing the upload API to return "account_id and client_id are required".

Generated with [Claude Code](https://claude.ai/code)