### PR TITLE
Fix vercel.json rewrite — use negative lookahead to exclude /api/* from SPA fallback

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -25,8 +25,7 @@
   "rewrites": [
     { "source": "/embed/map", "destination": "/api/embed/map" },
     { "source": "/portfolio/:share_token", "destination": "/api/portfolio/[share_token]" },
-    { "source": "/api/:path*", "destination": "/api/:path*" },
-    { "source": "/:path*", "destination": "/index.html" }
+    { "source": "/((?!api/).*)", "destination": "/index.html" }
   ],
   "headers": [
     {


### PR DESCRIPTION
Fixes #44

The previous `/api/:path*` passthrough rule was not preventing the SPA fallback from matching API routes. Replace both rules with a single negative lookahead pattern `/((?!api/).*)` that only rewrites non-API paths to index.html.

Generated with [Claude Code](https://claude.ai/code)