### PR TITLE
Add address_hash column to properties table

### DIFF
--- a/supabase/migrations/20260429000000_add_address_hash_to_properties.sql
+++ b/supabase/migrations/20260429000000_add_address_hash_to_properties.sql
@@ -1,0 +1,8 @@
+-- Add address_hash for upload deduplication
+ALTER TABLE public.properties
+ADD COLUMN IF NOT EXISTS address_hash text;
+
+-- Unique per client so two clients can have same address (different ownership/relationship)
+CREATE UNIQUE INDEX IF NOT EXISTS properties_client_address_hash_unique
+ON public.properties(client_id, address_hash)
+WHERE address_hash IS NOT NULL;


### PR DESCRIPTION
Fixes #53

The commit endpoint inserts `address_hash` (mapped from `dedupe_hash`) into the `properties` table, but the column was missing, causing all commits to fail with a column-does-not-exist error.

## Migration

Run in Supabase SQL Editor:

```sql
ALTER TABLE public.properties
ADD COLUMN IF NOT EXISTS address_hash text;

CREATE UNIQUE INDEX IF NOT EXISTS properties_client_address_hash_unique
ON public.properties(client_id, address_hash)
WHERE address_hash IS NOT NULL;
```

Generated with [Claude Code](https://claude.ai/code)