### PR TITLE
Add Google Address Validation + Geocoding enrichment pipeline

### DIFF
--- a/api/_lib/google-address.ts
+++ b/api/_lib/google-address.ts
@@ -1,0 +1,156 @@
+interface AddressInput {
+  address_line1: string
+  address_line2?: string | null
+  city: string
+  state: string
+  postal_code: string
+  country: string
+}
+
+interface ValidationResult {
+  verdict: 'CONFIRMED' | 'CONFIRMED_WITH_CORRECTIONS' | 'UNCONFIRMED' | 'UNCONFIRMED_BUT_PLAUSIBLE' | 'INFERRED'
+  validated: AddressInput
+  formatted_address: string
+  raw_response: any
+}
+
+interface GeocodeResult {
+  latitude: number
+  longitude: number
+  source: 'google'
+  confidence: 'rooftop' | 'range_interpolated' | 'geometric_center' | 'approximate'
+  place_id: string | null
+  formatted_address: string
+}
+
+function getApiKey(): string {
+  const key = process.env.GOOGLE_MAPS_API_KEY
+  if (!key) throw new Error('GOOGLE_MAPS_API_KEY is not set')
+  return key
+}
+
+// Maps Google's validationGranularity to our verdict enum
+function mapGranularityToVerdict(
+  granularity: string,
+  hasUnconfirmedComponents: boolean
+): ValidationResult['verdict'] {
+  switch (granularity) {
+    case 'PREMISE':
+    case 'SUB_PREMISE':
+      return hasUnconfirmedComponents ? 'CONFIRMED_WITH_CORRECTIONS' : 'CONFIRMED'
+    case 'PREMISE_PROXIMITY':
+      return 'UNCONFIRMED_BUT_PLAUSIBLE'
+    case 'BLOCK':
+    case 'ROUTE':
+      return 'INFERRED'
+    default:
+      return 'UNCONFIRMED'
+  }
+}
+
+export async function validateAddress(input: AddressInput): Promise<ValidationResult | null> {
+  const key = getApiKey()
+
+  const addressLines = [input.address_line1]
+  if (input.address_line2) addressLines.push(input.address_line2)
+
+  const body = {
+    address: {
+      regionCode: input.country || 'US',
+      addressLines,
+      locality: input.city,
+      administrativeArea: input.state,
+      postalCode: input.postal_code,
+    },
+  }
+
+  const resp = await fetch(
+    `https://addressvalidation.googleapis.com/v1:validateAddress?key=${key}`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }
+  )
+
+  if (!resp.ok) {
+    const text = await resp.text().catch(() => '')
+    throw new Error(`Address Validation API error ${resp.status}: ${text}`)
+  }
+
+  const data = await resp.json()
+  const result = data?.result
+  if (!result) return null
+
+  const granularity: string = result.verdict?.validationGranularity ?? 'OTHER'
+  const hasUnconfirmed = !!(result.verdict?.hasUnconfirmedComponents)
+  const verdict = mapGranularityToVerdict(granularity, hasUnconfirmed)
+
+  const postalAddress = result.address?.postalAddress ?? {}
+  const addressLineOut: string[] = postalAddress.addressLines ?? addressLines
+
+  const validated: AddressInput = {
+    address_line1: addressLineOut[0] ?? input.address_line1,
+    address_line2: addressLineOut[1] ?? input.address_line2 ?? null,
+    city: postalAddress.locality ?? input.city,
+    state: postalAddress.administrativeArea ?? input.state,
+    postal_code: postalAddress.postalCode ?? input.postal_code,
+    country: postalAddress.regionCode ?? input.country,
+  }
+
+  return {
+    verdict,
+    validated,
+    formatted_address: result.address?.formattedAddress ?? addressLineOut.join(', '),
+    raw_response: data,
+  }
+}
+
+export async function geocodeAddress(input: AddressInput): Promise<GeocodeResult | null> {
+  const key = getApiKey()
+
+  const parts = [input.address_line1]
+  if (input.address_line2) parts.push(input.address_line2)
+  parts.push(input.city, input.state, input.postal_code)
+  const addressStr = encodeURIComponent(parts.join(', '))
+
+  const resp = await fetch(
+    `https://maps.googleapis.com/maps/api/geocode/json?address=${addressStr}&key=${key}`
+  )
+
+  if (!resp.ok) {
+    const text = await resp.text().catch(() => '')
+    throw new Error(`Geocoding API HTTP error ${resp.status}: ${text}`)
+  }
+
+  const data = await resp.json()
+
+  if (data.status === 'ZERO_RESULTS') return null
+  if (data.status === 'OVER_QUERY_LIMIT') {
+    throw new Error('Geocoding API rate limit exceeded (OVER_QUERY_LIMIT). Retry later.')
+  }
+  if (data.status !== 'OK') {
+    throw new Error(`Geocoding API error: ${data.status} — ${data.error_message ?? ''}`)
+  }
+
+  const top = data.results?.[0]
+  if (!top) return null
+
+  const locType: string = top.geometry?.location_type ?? ''
+  const confidenceMap: Record<string, GeocodeResult['confidence']> = {
+    ROOFTOP: 'rooftop',
+    RANGE_INTERPOLATED: 'range_interpolated',
+    GEOMETRIC_CENTER: 'geometric_center',
+    APPROXIMATE: 'approximate',
+  }
+  const confidence: GeocodeResult['confidence'] = confidenceMap[locType] ?? 'approximate'
+
+  return {
+    latitude: top.geometry.location.lat,
+    longitude: top.geometry.location.lng,
+    source: 'google',
+    confidence,
+    place_id: top.place_id ?? null,
+    formatted_address: top.formatted_address ?? '',
+  }
+}

--- a/api/admin/enrich-pending.ts
+++ b/api/admin/enrich-pending.ts
@@ -1,0 +1,61 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { createAdminClient } from '../_lib/supabase.js'
+import { authenticateRequest } from '../_lib/auth.js'
+
+// 5-minute timeout — processing 1000 properties at 10 concurrency takes ~2 min
+export const config = { maxDuration: 300 }
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'POST') return res.status(405).json({ error: 'Method not allowed' })
+
+  try {
+    await authenticateRequest(req)
+  } catch (err) {
+    const e = err as { statusCode?: number; message?: string }
+    return res.status(e.statusCode ?? 401).json({ error: e.message ?? 'Unauthorized' })
+  }
+
+  const db = createAdminClient()
+  const baseUrl = process.env.VITE_APP_URL || `https://${req.headers.host}`
+
+  const { data: properties, error } = await db
+    .from('properties')
+    .select('id')
+    .in('enrichment_status', ['pending', 'failed'])
+    .limit(1000)
+
+  if (error) return res.status(500).json({ error: error.message })
+  if (!properties?.length) return res.status(200).json({ message: 'No pending properties', count: 0 })
+
+  let succeeded = 0
+  let failed = 0
+  const concurrency = 10 // Google Address Validation rate limit is 50 QPS
+
+  for (let i = 0; i < properties.length; i += concurrency) {
+    const chunk = properties.slice(i, i + concurrency)
+    const results = await Promise.allSettled(
+      chunk.map((p) =>
+        fetch(`${baseUrl}/api/properties/${p.id}/enrich`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-RBM-Service-Key': process.env.SERVICE_API_KEY ?? '',
+          },
+        }).then((r) => r.ok)
+      )
+    )
+    succeeded += results.filter((r) => r.status === 'fulfilled' && r.value).length
+    failed += results.filter(
+      (r) => r.status === 'rejected' || (r.status === 'fulfilled' && !r.value)
+    ).length
+
+    // Small delay to stay well under 50 QPS
+    await new Promise((r) => setTimeout(r, 200))
+  }
+
+  return res.status(200).json({
+    total: properties.length,
+    succeeded,
+    failed,
+  })
+}

--- a/api/admin/enrichment-stats.ts
+++ b/api/admin/enrichment-stats.ts
@@ -1,0 +1,29 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { createAdminClient } from '../_lib/supabase.js'
+import { authenticateRequest } from '../_lib/auth.js'
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'GET') return res.status(405).json({ error: 'Method not allowed' })
+
+  try {
+    await authenticateRequest(req)
+  } catch (err) {
+    const e = err as { statusCode?: number; message?: string }
+    return res.status(e.statusCode ?? 401).json({ error: e.message ?? 'Unauthorized' })
+  }
+
+  const db = createAdminClient()
+
+  const { data, error } = await db.from('properties').select('enrichment_status')
+
+  if (error) return res.status(500).json({ error: error.message })
+
+  const counts: Record<string, number> = { pending: 0, enriched: 0, failed: 0, total: 0 }
+  for (const p of data ?? []) {
+    counts.total++
+    const status = p.enrichment_status as string
+    counts[status] = (counts[status] ?? 0) + 1
+  }
+
+  return res.status(200).json(counts)
+}

--- a/api/properties/[propertyId]/enrich.ts
+++ b/api/properties/[propertyId]/enrich.ts
@@ -1,0 +1,102 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { createAdminClient } from '../../_lib/supabase.js'
+import { authenticateRequest } from '../../_lib/auth.js'
+import { validateAddress, geocodeAddress } from '../../_lib/google-address.js'
+
+export const config = { maxDuration: 30 }
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'POST') return res.status(405).json({ error: 'Method not allowed' })
+
+  try {
+    await authenticateRequest(req)
+  } catch (err) {
+    const e = err as { statusCode?: number; message?: string }
+    return res.status(e.statusCode ?? 401).json({ error: e.message ?? 'Unauthorized' })
+  }
+
+  const propertyId = req.query.propertyId as string
+  const db = createAdminClient()
+
+  const { data: property, error: fetchErr } = await db
+    .from('properties')
+    .select('id, address_line1, address_line2, city, state, postal_code, country')
+    .eq('id', propertyId)
+    .single()
+
+  if (fetchErr || !property) return res.status(404).json({ error: 'Property not found' })
+
+  const result: any = { property_id: propertyId }
+
+  try {
+    // Step 1: Validate address
+    const validation = await validateAddress({
+      address_line1: property.address_line1,
+      address_line2: property.address_line2,
+      city: property.city,
+      state: property.state,
+      postal_code: property.postal_code,
+      country: property.country ?? 'US',
+    })
+
+    if (validation) {
+      await db.from('properties').update({
+        address_validation_result: validation.raw_response,
+        address_validation_verdict: validation.verdict,
+        address_validated_at: new Date().toISOString(),
+        validated_address_line1: validation.validated.address_line1,
+        validated_city: validation.validated.city,
+        validated_state: validation.validated.state,
+        validated_postal_code: validation.validated.postal_code,
+        validated_country: validation.validated.country,
+      }).eq('id', propertyId)
+      result.validation = { verdict: validation.verdict, formatted: validation.formatted_address }
+    } else {
+      result.validation = { skipped: true }
+    }
+
+    // Step 2: Geocode using validated address if available, else original
+    const geoInput = validation?.validated ?? {
+      address_line1: property.address_line1,
+      address_line2: property.address_line2,
+      city: property.city,
+      state: property.state,
+      postal_code: property.postal_code,
+      country: property.country ?? 'US',
+    }
+
+    const geo = await geocodeAddress(geoInput)
+
+    if (geo) {
+      await db.from('properties').update({
+        latitude: geo.latitude,
+        longitude: geo.longitude,
+        geocode_source: geo.source,
+        geocode_confidence: geo.confidence,
+        geocoded_at: new Date().toISOString(),
+        google_place_id: geo.place_id,
+        enrichment_status: 'enriched',
+        last_enriched_at: new Date().toISOString(),
+      }).eq('id', propertyId)
+      result.geocode = { lat: geo.latitude, lng: geo.longitude, confidence: geo.confidence }
+    } else {
+      // Validation may have run but geocoding found no results.
+      // Still mark as failed — lat/lng is the minimum requirement for the map.
+      await db.from('properties').update({
+        enrichment_status: 'failed',
+        enrichment_errors: { geocode: 'No geocoding results' },
+        last_enriched_at: new Date().toISOString(),
+      }).eq('id', propertyId)
+      result.geocode = { skipped: true, reason: 'No results' }
+    }
+
+    return res.status(200).json(result)
+  } catch (err: any) {
+    await db.from('properties').update({
+      enrichment_status: 'failed',
+      enrichment_errors: { error: err.message ?? String(err) },
+      last_enriched_at: new Date().toISOString(),
+    }).eq('id', propertyId)
+    return res.status(500).json({ error: err.message ?? String(err), property_id: propertyId })
+  }
+}

--- a/api/uploads/[batchId]/commit.ts
+++ b/api/uploads/[batchId]/commit.ts
@@ -246,6 +246,32 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     })
     .eq('upload_batch_id', batchId)
 
+  // Fire-and-forget enrichment for newly-created properties.
+  // Note: Vercel Node functions may not reliably execute async work after res.send().
+  // If this proves unreliable, use the manual "Enrich Pending Properties" button on /admin.
+  const newPropertyIds = Array.from(dedupeCache.values())
+  if (newPropertyIds.length > 0) {
+    const baseUrl = process.env.VITE_APP_URL || `https://${req.headers.host}`
+    const enrichInBackground = async () => {
+      const concurrency = 10
+      for (let i = 0; i < newPropertyIds.length; i += concurrency) {
+        const chunk = newPropertyIds.slice(i, i + concurrency)
+        await Promise.allSettled(
+          chunk.map((propId) =>
+            fetch(`${baseUrl}/api/properties/${propId}/enrich`, {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/json',
+                'X-RBM-Service-Key': process.env.SERVICE_API_KEY ?? '',
+              },
+            }).catch(() => {}) // swallow — admin can retry from /admin
+          )
+        )
+      }
+    }
+    enrichInBackground()
+  }
+
   return res.status(200).json({
     batch_id: batchId,
     status: 'committed',

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ import CountiesPage from './pages/admin/parcels/Counties'
 import FallbacksPage from './pages/admin/parcels/Fallbacks'
 import DangerousAdminPage from './pages/admin/Dangerous'
 import AdminUploadsPage from './pages/admin/Uploads'
+import AdminHubPage from './pages/admin/AdminHub'
 import AccountsListPage from './pages/accounts/AccountsList'
 import NewAccountPage from './pages/accounts/NewAccount'
 import AccountDetailPage from './pages/accounts/AccountDetail'
@@ -102,6 +103,7 @@ export default function App() {
           <Route path="/clients/:id/setup" element={<AuthGuard><ClientSetupPage /></AuthGuard>} />
 
           {/* Admin */}
+          <Route path="/admin" element={<AuthGuard><AdminHubPage /></AuthGuard>} />
           <Route path="/admin/dangerous" element={<AuthGuard><DangerousAdminPage /></AuthGuard>} />
           <Route path="/admin/uploads" element={<AuthGuard><AdminUploadsPage /></AuthGuard>} />
           <Route path="/admin/parcels/import" element={<AuthGuard><ParcelImportPage /></AuthGuard>} />

--- a/src/pages/admin/AdminHub.tsx
+++ b/src/pages/admin/AdminHub.tsx
@@ -1,0 +1,220 @@
+import { useState, useEffect, useRef } from 'react'
+import { Link } from 'react-router-dom'
+import { useAuth } from '../../hooks/useAuth'
+import Navbar from '../../components/ui/Navbar'
+import Button from '../../components/ui/Button'
+
+interface EnrichmentStats {
+  total: number
+  pending: number
+  enriched: number
+  failed: number
+  [key: string]: number
+}
+
+type EnrichState =
+  | { status: 'idle' }
+  | { status: 'running' }
+  | { status: 'done'; total: number; succeeded: number; failed: number }
+  | { status: 'error'; message: string }
+
+export default function AdminHubPage() {
+  const { getToken } = useAuth()
+  const [stats, setStats] = useState<EnrichmentStats | null>(null)
+  const [statsError, setStatsError] = useState<string | null>(null)
+  const [enrichState, setEnrichState] = useState<EnrichState>({ status: 'idle' })
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null)
+
+  async function fetchStats() {
+    try {
+      const token = await getToken()
+      const res = await fetch('/api/admin/enrichment-stats', {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      if (!res.ok) throw new Error((await res.json()).error ?? 'Failed to load stats')
+      setStats(await res.json())
+      setStatsError(null)
+    } catch (err) {
+      setStatsError(err instanceof Error ? err.message : 'Failed to load stats')
+    }
+  }
+
+  useEffect(() => {
+    fetchStats()
+  }, [])
+
+  function startPoll() {
+    if (pollRef.current) return
+    pollRef.current = setInterval(fetchStats, 3000)
+  }
+
+  function stopPoll() {
+    if (pollRef.current) {
+      clearInterval(pollRef.current)
+      pollRef.current = null
+    }
+  }
+
+  useEffect(() => {
+    return () => stopPoll()
+  }, [])
+
+  async function handleEnrichPending() {
+    setEnrichState({ status: 'running' })
+    startPoll()
+    try {
+      const token = await getToken()
+      const res = await fetch('/api/admin/enrich-pending', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      const data = await res.json()
+      stopPoll()
+      await fetchStats()
+      if (!res.ok) {
+        setEnrichState({ status: 'error', message: data.error ?? 'Enrichment failed' })
+        return
+      }
+      if (data.message === 'No pending properties') {
+        setEnrichState({ status: 'done', total: 0, succeeded: 0, failed: 0 })
+        return
+      }
+      setEnrichState({
+        status: 'done',
+        total: data.total ?? 0,
+        succeeded: data.succeeded ?? 0,
+        failed: data.failed ?? 0,
+      })
+    } catch (err) {
+      stopPoll()
+      setEnrichState({
+        status: 'error',
+        message: err instanceof Error ? err.message : 'Enrichment failed',
+      })
+    }
+  }
+
+  const isRunning = enrichState.status === 'running'
+
+  return (
+    <div className="flex flex-col h-full bg-gray-50">
+      <Navbar />
+      <div className="flex-1 overflow-y-auto">
+        <div className="max-w-4xl mx-auto px-6 py-8 space-y-6">
+          <div className="flex items-center gap-3 mb-2">
+            <Link to="/map" className="text-gray-400 hover:text-gray-600 text-sm">← Map</Link>
+            <h1 className="text-2xl font-bold text-gray-900">Admin</h1>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            {/* Upload Batches card */}
+            <div className="bg-white rounded-xl shadow-sm border p-6">
+              <div className="flex items-center gap-3 mb-3">
+                <div className="w-10 h-10 bg-blue-100 rounded-lg flex items-center justify-center">
+                  <svg className="w-5 h-5 text-blue-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                      d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12" />
+                  </svg>
+                </div>
+                <h2 className="text-lg font-semibold text-gray-900">Upload Batches</h2>
+              </div>
+              <p className="text-sm text-gray-500 mb-4">
+                Manage committed and pending upload batches, re-run commits, and view batch details.
+              </p>
+              <Link
+                to="/admin/uploads"
+                className="inline-flex items-center gap-1.5 text-sm font-medium text-blue-600 hover:text-blue-800"
+              >
+                View Upload Batches →
+              </Link>
+            </div>
+
+            {/* Property Enrichment card */}
+            <div className="bg-white rounded-xl shadow-sm border p-6">
+              <div className="flex items-center gap-3 mb-3">
+                <div className="w-10 h-10 bg-green-100 rounded-lg flex items-center justify-center">
+                  <svg className="w-5 h-5 text-green-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                      d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                      d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
+                  </svg>
+                </div>
+                <h2 className="text-lg font-semibold text-gray-900">Property Enrichment</h2>
+              </div>
+
+              {/* Stats */}
+              {statsError ? (
+                <p className="text-sm text-red-600 mb-4">{statsError}</p>
+              ) : stats ? (
+                <div className="grid grid-cols-3 gap-3 mb-4">
+                  {[
+                    { label: 'Pending', value: stats.pending, color: 'text-yellow-700 bg-yellow-50' },
+                    { label: 'Enriched', value: stats.enriched, color: 'text-green-700 bg-green-50' },
+                    { label: 'Failed', value: stats.failed, color: 'text-red-700 bg-red-50' },
+                  ].map(({ label, value, color }) => (
+                    <div key={label} className={`rounded-lg px-3 py-2 text-center ${color}`}>
+                      <div className="text-xl font-bold">{value}</div>
+                      <div className="text-xs font-medium">{label}</div>
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <div className="h-16 flex items-center justify-center mb-4">
+                  <svg className="animate-spin h-5 w-5 text-gray-300" fill="none" viewBox="0 0 24 24">
+                    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                  </svg>
+                </div>
+              )}
+
+              {/* Run state feedback */}
+              {enrichState.status === 'running' && (
+                <div className="flex items-center gap-2 text-sm text-blue-700 bg-blue-50 rounded-lg px-3 py-2 mb-3">
+                  <svg className="animate-spin h-4 w-4" fill="none" viewBox="0 0 24 24">
+                    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                  </svg>
+                  Enriching properties… stats update every 3 s
+                </div>
+              )}
+              {enrichState.status === 'done' && (
+                <div className="text-sm text-green-700 bg-green-50 rounded-lg px-3 py-2 mb-3">
+                  {enrichState.total === 0
+                    ? 'No pending properties found.'
+                    : `Done — ${enrichState.succeeded} succeeded, ${enrichState.failed} failed out of ${enrichState.total}.`}
+                </div>
+              )}
+              {enrichState.status === 'error' && (
+                <div className="text-sm text-red-700 bg-red-50 rounded-lg px-3 py-2 mb-3">
+                  Error: {enrichState.message}
+                </div>
+              )}
+
+              <Button
+                size="sm"
+                variant="primary"
+                loading={isRunning}
+                disabled={isRunning}
+                onClick={handleEnrichPending}
+              >
+                Enrich Pending Properties
+              </Button>
+            </div>
+          </div>
+
+          {/* Other admin links */}
+          <div className="bg-white rounded-xl shadow-sm border p-5">
+            <h2 className="font-semibold text-gray-800 mb-2">Other Admin Tools</h2>
+            <ul className="space-y-1 text-sm">
+              <li><Link to="/admin/dangerous" className="text-blue-600 hover:underline">Dangerous Actions</Link></li>
+              <li><Link to="/admin/parcels/import" className="text-blue-600 hover:underline">Parcel Import</Link></li>
+              <li><Link to="/admin/parcels/counties" className="text-blue-600 hover:underline">County Library</Link></li>
+              <li><Link to="/admin/parcels/fallbacks" className="text-blue-600 hover:underline">Parcel Fallbacks</Link></li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/admin/Dangerous.tsx
+++ b/src/pages/admin/Dangerous.tsx
@@ -45,7 +45,7 @@ export default function DangerousAdminPage() {
       <div className="flex-1 overflow-y-auto">
         <div className="max-w-2xl mx-auto px-6 py-8 space-y-6">
           <div className="flex items-center gap-3 mb-2">
-            <Link to="/map" className="text-gray-400 hover:text-gray-600 text-sm">← Map</Link>
+            <Link to="/admin" className="text-gray-400 hover:text-gray-600 text-sm">← Admin</Link>
             <h1 className="text-2xl font-bold text-gray-900">Admin — Dangerous Actions</h1>
           </div>
 

--- a/src/pages/admin/Uploads.tsx
+++ b/src/pages/admin/Uploads.tsx
@@ -238,7 +238,7 @@ export default function AdminUploadsPage() {
       <div className="flex-1 overflow-y-auto">
         <div className="max-w-7xl mx-auto px-6 py-8 space-y-6">
           <div className="flex items-center gap-3 mb-2">
-            <Link to="/admin/dangerous" className="text-gray-400 hover:text-gray-600 text-sm">← Admin</Link>
+            <Link to="/admin" className="text-gray-400 hover:text-gray-600 text-sm">← Admin</Link>
             <h1 className="text-2xl font-bold text-gray-900">Admin — Upload Batches</h1>
           </div>
 

--- a/supabase/migrations/20260429010000_property_geocoding_columns.sql
+++ b/supabase/migrations/20260429010000_property_geocoding_columns.sql
@@ -1,0 +1,21 @@
+-- Add address validation and geocoding tracking columns to properties
+ALTER TABLE public.properties
+  ADD COLUMN IF NOT EXISTS address_validation_result    jsonb,
+  ADD COLUMN IF NOT EXISTS address_validated_at         timestamp with time zone,
+  ADD COLUMN IF NOT EXISTS address_validation_verdict   text,
+  -- 'CONFIRMED' | 'CONFIRMED_WITH_CORRECTIONS' | 'UNCONFIRMED' | 'UNCONFIRMED_BUT_PLAUSIBLE' | 'INFERRED'
+  ADD COLUMN IF NOT EXISTS validated_address_line1      text,
+  ADD COLUMN IF NOT EXISTS validated_city               text,
+  ADD COLUMN IF NOT EXISTS validated_state              text,
+  ADD COLUMN IF NOT EXISTS validated_postal_code        text,
+  ADD COLUMN IF NOT EXISTS validated_country            text;
+
+-- Also ensure google_place_id and last_enriched_at exist (used by enrichment endpoints)
+ALTER TABLE public.properties
+  ADD COLUMN IF NOT EXISTS google_place_id   text,
+  ADD COLUMN IF NOT EXISTS last_enriched_at  timestamp with time zone;
+
+-- Index to find pending/failed properties quickly during backfill
+CREATE INDEX IF NOT EXISTS properties_enrichment_status_idx
+  ON public.properties(enrichment_status)
+  WHERE enrichment_status IN ('pending', 'failed');

--- a/supabase/migrations/20260429010000_property_geocoding_columns.sql
+++ b/supabase/migrations/20260429010000_property_geocoding_columns.sql
@@ -15,6 +15,14 @@ ALTER TABLE public.properties
   ADD COLUMN IF NOT EXISTS google_place_id   text,
   ADD COLUMN IF NOT EXISTS last_enriched_at  timestamp with time zone;
 
+-- Enrichment tracking columns
+ALTER TABLE public.properties
+  ADD COLUMN IF NOT EXISTS enrichment_status  text NOT NULL DEFAULT 'pending',
+  ADD COLUMN IF NOT EXISTS enrichment_errors  jsonb,
+  ADD COLUMN IF NOT EXISTS geocode_source     text,
+  ADD COLUMN IF NOT EXISTS geocode_confidence text,
+  ADD COLUMN IF NOT EXISTS geocoded_at        timestamp with time zone;
+
 -- Index to find pending/failed properties quickly during backfill
 CREATE INDEX IF NOT EXISTS properties_enrichment_status_idx
   ON public.properties(enrichment_status)


### PR DESCRIPTION
Implements the full geocoding enrichment pipeline from issue #61:

- `api/_lib/google-address.ts`: validateAddress() and geocodeAddress() functions
- `api/properties/[propertyId]/enrich.ts`: idempotent per-property enrichment endpoint
- `api/admin/enrich-pending.ts`: batch backfill for all pending/failed properties
- `api/admin/enrichment-stats.ts`: GET stats endpoint
- Auto-trigger enrichment after commit in commit.ts
- `/admin` hub page with Property Enrichment card
- DB migration with address validation columns

**Before deploying**: run the migration SQL in Supabase SQL Editor (see PR description in issue #61).

Closes #61

Generated with [Claude Code](https://claude.ai/code)