### PR TITLE
Fix Admin nav link to point to /admin hub

### DIFF
--- a/src/components/ui/Navbar.tsx
+++ b/src/components/ui/Navbar.tsx
@@ -131,7 +131,7 @@ export default function Navbar() {
             Uploads
           </Link>
           <Link
-            to="/admin/dangerous"
+            to="/admin"
             className="px-3 py-1.5 rounded-md text-sm font-medium text-gray-400 hover:bg-gray-100 transition-colors"
           >
             Admin


### PR DESCRIPTION
Fix the navbar "Admin" link to route to `/admin` (AdminHub) instead of `/admin/dangerous`, so the Property Enrichment / geocoding UI is reachable.

Related to #62

Generated with [Claude Code](https://claude.ai/code)