### PR TITLE
fix: hover popup intercepts click on map markers

### DIFF
--- a/src/components/map/MapView.tsx
+++ b/src/components/map/MapView.tsx
@@ -281,6 +281,7 @@ export default function MapView({
             <div style="font-size:11px;color:#6b7280;margin-top:1px">${escHtml(props.city_state ?? '')}</div>
           `)
           .addTo(m)
+        hoverPopupRef.current.getElement().style.pointerEvents = 'none'
       })
 
       m.on('mouseleave', 'unclustered-point', () => {

--- a/src/components/map/MapView.tsx
+++ b/src/components/map/MapView.tsx
@@ -281,7 +281,8 @@ export default function MapView({
             <div style="font-size:11px;color:#6b7280;margin-top:1px">${escHtml(props.city_state ?? '')}</div>
           `)
           .addTo(m)
-        hoverPopupRef.current.getElement().style.pointerEvents = 'none'
+        const popupEl = hoverPopupRef.current.getElement()
+        if (popupEl) popupEl.style.pointerEvents = 'none'
       })
 
       m.on('mouseleave', 'unclustered-point', () => {


### PR DESCRIPTION
Fix map marker click navigation to property detail page.

The hover tooltip popup was intercepting mouse clicks before they reached the Mapbox canvas, preventing the click popup with "View details →" from appearing. Fixed by setting `pointer-events: none` on the hover popup element.

Related to #65

Generated with [Claude Code](https://claude.ai/code)