### PR TITLE
fix: guard against undefined property_id in map pin click handler

### DIFF
--- a/src/components/map/MapView.tsx
+++ b/src/components/map/MapView.tsx
@@ -218,7 +218,8 @@ export default function MapView({
       m.on('click', 'unclustered-point', (e) => {
         const feature = e.features?.[0]
         if (!feature) return
-        const propertyId = feature.properties?.property_id
+        const propertyId = feature.properties?.property_id as string | undefined
+        if (!propertyId) return
         const pin = pinsRef.current.find((p) => p.property.property_id === propertyId)
         if (!pin) return
 

--- a/src/pages/Map.tsx
+++ b/src/pages/Map.tsx
@@ -76,13 +76,15 @@ export default function MapPage() {
 
   const pins = useMemo(
     () =>
-      propertiesWithLocations.map((p) => ({
-        property: p as Property,
-        locations: p.service_locations,
-        clientColor: p.service_locations[0]?.client_id
-          ? (clientColorMap[p.service_locations[0].client_id] ?? null)
-          : null,
-      })),
+      propertiesWithLocations
+        .filter((p) => p.property_id)
+        .map((p) => ({
+          property: p as Property,
+          locations: p.service_locations,
+          clientColor: p.service_locations?.[0]?.client_id
+            ? (clientColorMap[p.service_locations[0].client_id] ?? null)
+            : null,
+        })),
     [propertiesWithLocations, clientColorMap]
   )
 


### PR DESCRIPTION
The previous fix stored the full property object directly but missed a subtler bug in MapView.tsx. If a GeoJSON feature's property_id is undefined, the find() call would silently match any other pin with undefined property_id, resulting in navigation to /properties/undefined.

Fixes the remaining issue from #69

Generated with [Claude Code](https://claude.ai/code)