### PR TITLE
fix: use nullish checks to allow property_id 0 and other falsy values

### DIFF
--- a/src/components/map/MapView.tsx
+++ b/src/components/map/MapView.tsx
@@ -219,7 +219,7 @@ export default function MapView({
         const feature = e.features?.[0]
         if (!feature) return
         const propertyId = feature.properties?.property_id as string | undefined
-        if (!propertyId) return
+        if (propertyId == null) return
         const pin = pinsRef.current.find((p) => p.property.property_id === propertyId)
         if (!pin) return
 

--- a/src/pages/Map.tsx
+++ b/src/pages/Map.tsx
@@ -77,7 +77,7 @@ export default function MapPage() {
   const pins = useMemo(
     () =>
       propertiesWithLocations
-        .filter((p) => p.property_id)
+        .filter((p) => p.property_id != null)
         .map((p) => ({
           property: p as Property,
           locations: p.service_locations,


### PR DESCRIPTION
The previous fix in PR #70 used falsy checks (`!propertyId` and `.filter(p => p.property_id)`) which incorrectly filtered out properties with `property_id === 0`, a valid database ID.

### Changes
- **Map.tsx**: Changed `.filter(p => p.property_id)` to `.filter(p => p.property_id != null)`
- **MapView.tsx**: Changed `if (!propertyId)` to `if (propertyId == null)`

This allows property_id values of `0`, `""`, and `false` while still filtering out `null`/`undefined`.

Fixes #70

Generated with [Claude Code](https://claude.ai/code)