### PR TITLE
fix: add error handling and parameter validation to properties API

### DIFF
--- a/api/v1/properties/index.ts
+++ b/api/v1/properties/index.ts
@@ -53,22 +53,33 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     let propIdsFromServiceLocations: string[] | null = null
 
     // If we have any service_location filters, query them first
-    if (client_id || status || portfolio_id) {
+    // Only apply filters if parameters have truthy values
+    const hasClientFilter = client_id && String(client_id).trim().length > 0
+    const hasStatusFilter = status && String(status).trim().length > 0
+    const hasPortfolioFilter = portfolio_id && String(portfolio_id).trim().length > 0
+
+    if (hasClientFilter || hasStatusFilter || hasPortfolioFilter) {
       let slQuery = db.from('service_locations').select('property_id')
 
-      if (client_id) {
+      if (hasClientFilter) {
         slQuery = slQuery.in('client_id', String(client_id).split(','))
       }
-      if (status) {
+      if (hasStatusFilter) {
         slQuery = slQuery.in('status', String(status).split(','))
       }
-      if (portfolio_id) {
+      if (hasPortfolioFilter) {
         // portfolio_ids is an array field, use containedBy or overlaps
         const portfolioIds = String(portfolio_id).split(',')
         slQuery = slQuery.overlaps('portfolio_ids', portfolioIds)
       }
 
-      const { data: sls } = await slQuery
+      const { data: sls, error: slError } = await slQuery
+
+      // Return error if service_locations query fails
+      if (slError) {
+        return res.status(500).json({ error: `Service location query failed: ${slError.message}` })
+      }
+
       propIdsFromServiceLocations = [...new Set((sls ?? []).map((r: any) => r.property_id).filter((id: any) => id != null))]
 
       if (propIdsFromServiceLocations.length === 0) {


### PR DESCRIPTION
## Summary
Fixesthe issue where properties stopped showing on the map after PR #72.

### Root Cause
The service_location pre-filtering logic added in PR #72 had:
- Missing error handling for the service_locations query
- No parameter validation for filter values
- Silent failures that returned empty results

### Changes
- Add explicit validation for client_id, status, portfolio_id parameters
- Add error handling for service_locations query
- Return meaningful error messages when queries fail
- Only apply filters when parameters have truthy, non-empty values

References PR #73

Generated with [Claude Code](https://claude.ai/code)) • [View job run](https://github.com/joerickson/Mapping-Tool/actions/runs/25109660510) • [Branch: claude/pr-73-20260429-1246](https://github.com/joerickson/Mapping-Tool/tree/claude/pr-73-20260429-1246