### PR TITLE
Design Phase A — tokens, fonts, theme toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,39 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>RBM Geo — Portfolio Intelligence</title>
+
+    <!-- Geist + Geist Mono. Preconnect avoids a chained DNS+TLS handshake
+         on first paint, which matters because the body's font-family falls
+         back to system-ui until Geist arrives. -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&family=Geist+Mono:wght@400;500;600&display=swap"
+    />
+
+    <!-- Theme bootstrap — runs synchronously before React mounts so we set
+         data-theme="dark" (when applicable) on <html> in the same tick the
+         page paints. Without this, a dark-mode user gets a white flash on
+         every reload while React hydrates. -->
+    <script>
+      (function () {
+        try {
+          var stored = localStorage.getItem('portfolioiq-theme')
+          var theme =
+            stored === 'light' || stored === 'dark'
+              ? stored
+              : window.matchMedia('(prefers-color-scheme: dark)').matches
+                ? 'dark'
+                : 'light'
+          document.documentElement.setAttribute('data-theme', theme)
+        } catch (e) {
+          /* localStorage blocked (private mode, embedded contexts) — fall
+             through to default light. */
+          document.documentElement.setAttribute('data-theme', 'light')
+        }
+      })()
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/components/ui/Navbar.tsx
+++ b/src/components/ui/Navbar.tsx
@@ -2,6 +2,7 @@ import { Link, useLocation } from 'react-router-dom'
 import { useState, useRef, useEffect } from 'react'
 import { clsx } from 'clsx'
 import { useClient } from '../../context/ClientContext'
+import ThemeToggle from './ThemeToggle'
 
 const links = [
   { to: '/map', label: 'Map' },
@@ -136,6 +137,7 @@ export default function Navbar() {
           >
             Admin
           </Link>
+          <ThemeToggle />
           <Link
             to="/logout"
             className="px-3 py-1.5 rounded-md text-sm font-medium text-gray-600 hover:bg-gray-100 transition-colors"

--- a/src/components/ui/ThemeToggle.tsx
+++ b/src/components/ui/ThemeToggle.tsx
@@ -1,0 +1,107 @@
+// Phase A theme toggle — sun/moon button cycling light → dark → system.
+//
+// Three-state cycle (instead of binary light↔dark) lets the user opt back
+// into "follow OS" without clearing localStorage by hand. The button shows
+// the icon for the *current resolved* theme; the tooltip + aria-label
+// describe what clicking will do next.
+import { useSyncExternalStore } from 'react'
+import {
+  getMode,
+  getResolvedTheme,
+  setMode,
+  subscribe,
+  type ThemeMode,
+} from '../../lib/theme'
+
+const NEXT: Record<ThemeMode, ThemeMode> = {
+  light: 'dark',
+  dark: 'system',
+  system: 'light',
+}
+
+const NEXT_LABEL: Record<ThemeMode, string> = {
+  light: 'Switch to dark theme',
+  dark: 'Switch to system theme',
+  system: 'Switch to light theme',
+}
+
+// SSR-safe initial value. The bootstrap script has already set data-theme
+// before React mounts, so getResolvedTheme() returns the right value
+// synchronously on first render.
+function snapshot() {
+  return `${getMode()}|${getResolvedTheme()}`
+}
+
+export default function ThemeToggle({ className }: { className?: string }) {
+  // We don't actually use the snapshot string — useSyncExternalStore just
+  // gives us a re-render trigger when the theme changes from anywhere.
+  useSyncExternalStore(subscribe, snapshot, snapshot)
+  const mode = getMode()
+  const resolved = getResolvedTheme()
+
+  return (
+    <button
+      type="button"
+      onClick={() => setMode(NEXT[mode])}
+      title={NEXT_LABEL[mode]}
+      aria-label={NEXT_LABEL[mode]}
+      className={
+        'inline-flex h-8 w-8 items-center justify-center rounded-md ' +
+        'text-fg-muted hover:text-fg hover:bg-surface-muted ' +
+        'transition-colors duration-150 focus-visible:outline-none ' +
+        'focus-visible:ring-2 focus-visible:ring-accent ' +
+        (className ?? '')
+      }
+    >
+      {resolved === 'dark' ? <MoonIcon /> : <SunIcon />}
+      {mode === 'system' && <SystemDot />}
+    </button>
+  )
+}
+
+function SunIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <circle cx="12" cy="12" r="4" />
+      <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41" />
+    </svg>
+  )
+}
+
+function MoonIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+    </svg>
+  )
+}
+
+// Tiny dot indicating "follow system" — appears in the corner of the icon.
+function SystemDot() {
+  return (
+    <span
+      aria-hidden="true"
+      className="absolute mt-3 ml-3 h-1.5 w-1.5 rounded-full bg-accent"
+    />
+  )
+}

--- a/src/index.css
+++ b/src/index.css
@@ -2,9 +2,54 @@
 @tailwind components;
 @tailwind utilities;
 
+/* Token sheet — must come AFTER Tailwind's base reset so the cascade lets
+   our `:root` color-scheme + custom properties override Tailwind's defaults. */
+@import './styles/tokens.css';
+
 @layer base {
-  html, body, #root {
+  html,
+  body,
+  #root {
     height: 100%;
+  }
+
+  /* Default to the design system surface + font. Individual components can
+     opt out by overriding `font-mono` or `bg-surface-subtle` etc. */
+  body {
+    background-color: var(--color-bg);
+    color: var(--color-fg);
+    font-family:
+      'Geist', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+      sans-serif;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    text-rendering: optimizeLegibility;
+  }
+
+  /* Numbers in tables/data should align in columns and read decisively. */
+  .font-mono,
+  code,
+  pre,
+  kbd,
+  samp {
+    font-family: 'Geist Mono', 'JetBrains Mono', Menlo, Consolas, monospace;
+    font-feature-settings: 'tnum';
+    font-variant-numeric: tabular-nums;
+  }
+
+  /* Make every focusable element show the accent ring on keyboard focus.
+     Mouse focus is suppressed via :focus-visible. */
+  :focus-visible {
+    outline: 2px solid var(--color-ring);
+    outline-offset: 2px;
+    border-radius: 4px;
+  }
+
+  /* Native form-control colors should follow the active theme so date
+     pickers / scrollbars / autofill don't look out of place in dark mode. */
+  ::selection {
+    background-color: var(--color-accent-subtle);
+    color: var(--color-fg);
   }
 }
 

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -1,0 +1,88 @@
+// Theme manager — small, framework-free runtime that the React tree
+// subscribes to via useSyncExternalStore.
+//
+// Storage contract:
+//   localStorage['portfolioiq-theme'] = 'light' | 'dark' | (absent = 'system')
+// The bootstrap script in index.html resolves this to 'light' or 'dark' at
+// page load and sets data-theme on <html>. After mount, calls to setTheme()
+// here keep the attribute and the storage in sync.
+//
+// We intentionally don't track the system preference inside React state —
+// the OS-level media query is the source of truth when mode is 'system'.
+// Components just observe the resolved attribute on <html> via the listener.
+
+export type ThemeMode = 'light' | 'dark' | 'system'
+export type ResolvedTheme = 'light' | 'dark'
+
+const STORAGE_KEY = 'portfolioiq-theme'
+
+const listeners = new Set<() => void>()
+
+function readSystemTheme(): ResolvedTheme {
+  if (typeof window === 'undefined') return 'light'
+  return window.matchMedia('(prefers-color-scheme: dark)').matches
+    ? 'dark'
+    : 'light'
+}
+
+function readStoredMode(): ThemeMode {
+  if (typeof window === 'undefined') return 'system'
+  try {
+    const v = window.localStorage.getItem(STORAGE_KEY)
+    if (v === 'light' || v === 'dark') return v
+    return 'system'
+  } catch {
+    return 'system'
+  }
+}
+
+function applyResolved(resolved: ResolvedTheme) {
+  if (typeof document === 'undefined') return
+  document.documentElement.setAttribute('data-theme', resolved)
+}
+
+export function getMode(): ThemeMode {
+  return readStoredMode()
+}
+
+export function getResolvedTheme(): ResolvedTheme {
+  const mode = readStoredMode()
+  return mode === 'system' ? readSystemTheme() : mode
+}
+
+export function setMode(mode: ThemeMode) {
+  try {
+    if (mode === 'system') window.localStorage.removeItem(STORAGE_KEY)
+    else window.localStorage.setItem(STORAGE_KEY, mode)
+  } catch {
+    /* storage blocked — still apply for the session */
+  }
+  const resolved: ResolvedTheme = mode === 'system' ? readSystemTheme() : mode
+  applyResolved(resolved)
+  for (const fn of listeners) fn()
+}
+
+// React adapter — used by ThemeToggle (and any other component that needs to
+// reflect the active mode in its UI).
+export function subscribe(listener: () => void): () => void {
+  listeners.add(listener)
+  // Also listen for OS-level pref changes when mode === 'system'.
+  let mql: MediaQueryList | null = null
+  if (typeof window !== 'undefined' && window.matchMedia) {
+    mql = window.matchMedia('(prefers-color-scheme: dark)')
+    const onSystemChange = () => {
+      if (readStoredMode() === 'system') {
+        applyResolved(readSystemTheme())
+        for (const fn of listeners) fn()
+      }
+    }
+    mql.addEventListener('change', onSystemChange)
+    return () => {
+      listeners.delete(listener)
+      mql?.removeEventListener('change', onSystemChange)
+    }
+  }
+  return () => {
+    listeners.delete(listener)
+  }
+}

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -1,0 +1,91 @@
+/*
+ * PortfolioIQ design tokens — Phase A.
+ *
+ * Light is the implicit default (no [data-theme] attribute needed). Dark
+ * activates via [data-theme="dark"] on <html>. The bootstrap script in
+ * index.html sets that attribute before first paint, so there's no
+ * theme-flash on reload.
+ *
+ * Naming: --color-{role}[-{variant}] where role is one of:
+ *   bg / fg / border / accent / success / warning / danger
+ *
+ * Tailwind reads these via tailwind.config.js (colors keyed to the same names).
+ * If you add a new token, add the matching key in tailwind.config.js so a
+ * `bg-foo` / `text-foo` utility comes along for free.
+ */
+
+:root,
+[data-theme='light'] {
+  /* Surfaces */
+  --color-bg: #ffffff;
+  --color-bg-subtle: #fafafa;
+  --color-bg-muted: #f4f4f5;
+  --color-bg-elevated: #ffffff;
+
+  /* Text */
+  --color-fg: #09090b;
+  --color-fg-muted: #52525b;
+  --color-fg-subtle: #71717a;
+
+  /* Borders */
+  --color-border: #e4e4e7;
+  --color-border-strong: #d4d4d8;
+  --color-border-focus: var(--color-accent);
+
+  /* Accent (indigo). Used sparingly — primary CTAs, links, focus, active nav. */
+  --color-accent: #4f46e5;
+  --color-accent-hover: #4338ca;
+  --color-accent-fg: #ffffff;
+  --color-accent-subtle: #eef2ff;
+
+  /* Semantic — sparingly. */
+  --color-success: #16a34a;
+  --color-success-subtle: #dcfce7;
+  --color-warning: #d97706;
+  --color-warning-subtle: #fef3c7;
+  --color-danger: #dc2626;
+  --color-danger-subtle: #fee2e2;
+
+  /* Focus ring color (used by Tailwind's ring utility via arbitrary values
+     where we want explicit control). */
+  --color-ring: var(--color-accent);
+
+  color-scheme: light;
+}
+
+[data-theme='dark'] {
+  /* Surfaces — zinc scale, slightly compressed contrast vs light to reduce
+     eye strain on emissive displays. */
+  --color-bg: #09090b;
+  --color-bg-subtle: #18181b;
+  --color-bg-muted: #27272a;
+  --color-bg-elevated: #18181b;
+
+  /* Text */
+  --color-fg: #fafafa;
+  --color-fg-muted: #a1a1aa;
+  --color-fg-subtle: #71717a;
+
+  /* Borders */
+  --color-border: #27272a;
+  --color-border-strong: #3f3f46;
+  --color-border-focus: var(--color-accent);
+
+  /* Accent — slightly brighter on dark to keep perceptual punch. */
+  --color-accent: #6366f1;
+  --color-accent-hover: #818cf8;
+  --color-accent-fg: #ffffff;
+  --color-accent-subtle: #1e1b4b;
+
+  /* Semantic */
+  --color-success: #22c55e;
+  --color-success-subtle: #052e16;
+  --color-warning: #f59e0b;
+  --color-warning-subtle: #451a03;
+  --color-danger: #ef4444;
+  --color-danger-subtle: #450a0a;
+
+  --color-ring: var(--color-accent);
+
+  color-scheme: dark;
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,12 +1,70 @@
 /** @type {import('tailwindcss').Config} */
 export default {
-  content: [
-    "./index.html",
-    "./src/**/*.{js,ts,jsx,tsx}",
-  ],
+  content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
+  // Phase A theme switch is driven by [data-theme="dark"] on <html>, which is
+  // set by an inline bootstrap script in index.html before React mounts.
+  darkMode: ['selector', '[data-theme="dark"]'],
   theme: {
+    // Override Tailwind's defaults for radius — the design system caps at
+    // 12px (rounded-xl) and we don't want rounded-2xl/3xl available.
+    borderRadius: {
+      none: '0',
+      sm: '4px',
+      DEFAULT: '6px',
+      md: '6px',
+      lg: '8px',
+      xl: '12px',
+      full: '9999px', // only for avatars + status dots
+    },
     extend: {
       colors: {
+        // Surfaces. Tailwind utility names: bg-surface, bg-surface-subtle, …
+        surface: {
+          DEFAULT: 'var(--color-bg)',
+          subtle: 'var(--color-bg-subtle)',
+          muted: 'var(--color-bg-muted)',
+          elevated: 'var(--color-bg-elevated)',
+        },
+
+        // Text. text-fg, text-fg-muted, text-fg-subtle
+        fg: {
+          DEFAULT: 'var(--color-fg)',
+          muted: 'var(--color-fg-muted)',
+          subtle: 'var(--color-fg-subtle)',
+        },
+
+        // Borders. border-border, border-border-strong, border-border-focus
+        border: {
+          DEFAULT: 'var(--color-border)',
+          strong: 'var(--color-border-strong)',
+          focus: 'var(--color-border-focus)',
+        },
+
+        // Accent. bg-accent, bg-accent-hover, text-accent-fg, bg-accent-subtle
+        accent: {
+          DEFAULT: 'var(--color-accent)',
+          hover: 'var(--color-accent-hover)',
+          fg: 'var(--color-accent-fg)',
+          subtle: 'var(--color-accent-subtle)',
+        },
+
+        // Semantic — paired with -subtle background for badges/banners.
+        success: {
+          DEFAULT: 'var(--color-success)',
+          subtle: 'var(--color-success-subtle)',
+        },
+        warning: {
+          DEFAULT: 'var(--color-warning)',
+          subtle: 'var(--color-warning-subtle)',
+        },
+        danger: {
+          DEFAULT: 'var(--color-danger)',
+          subtle: 'var(--color-danger-subtle)',
+        },
+
+        // Legacy palette kept for now — Phases B–E will migrate consumers
+        // off these. Once the last hard-coded `bg-rbm-blue` is gone, drop
+        // this block.
         rbm: {
           blue: '#1a56db',
           navy: '#1e3a5f',
@@ -18,9 +76,41 @@ export default {
           teal: '#0694a2',
           pink: '#e74694',
           gray: '#6b7280',
-        }
-      }
+        },
+      },
+
+      fontFamily: {
+        sans: [
+          'Geist',
+          'system-ui',
+          '-apple-system',
+          'BlinkMacSystemFont',
+          'Segoe UI',
+          'sans-serif',
+        ],
+        mono: [
+          '"Geist Mono"',
+          '"JetBrains Mono"',
+          'Menlo',
+          'Consolas',
+          'monospace',
+        ],
+      },
+
+      ringColor: {
+        DEFAULT: 'var(--color-ring)',
+      },
     },
   },
-  plugins: [],
+  plugins: [
+    // Tiny plugin: expose `font-tabular` utility that turns on tabular figures.
+    function ({ addUtilities }) {
+      addUtilities({
+        '.font-tabular': {
+          fontFeatureSettings: '"tnum"',
+          fontVariantNumeric: 'tabular-nums',
+        },
+      })
+    },
+  ],
 }


### PR DESCRIPTION
## Summary

Ships the foundation for the design refresh. **No visual changes** to existing pages yet — this PR is pure plumbing that Phases B–E will build on.

- **Tokens** (`src/styles/tokens.css`): light + dark CSS variables for surfaces, text, borders, accent (indigo), and semantic success/warning/danger. Light is `:root`; dark is `[data-theme="dark"]`. Dark mode tunes contrast independently (e.g. indigo-500 vs indigo-600) rather than inverting.
- **Tailwind** (`tailwind.config.js`): `darkMode: ['selector', '[data-theme="dark"]']`. CSS variables exposed as utilities — `bg-surface`, `text-fg`, `border-border`, `bg-accent`, etc. `borderRadius` overridden (not extended) to cap at 12px — `rounded-2xl`/`3xl` are intentionally unavailable per design rules. New `font-tabular` utility for tabular figures in tables.
- **Fonts**: Geist + Geist Mono via Google Fonts with preconnect. Mono used for `code`/`pre`/`.font-mono` and gets tabular figures by default.
- **Theme manager** (`src/lib/theme.ts`): three-state cycle (light → dark → system). 'system' mode subscribes to `prefers-color-scheme` so OS changes flip live without a refresh. Framework-free; React consumes via `useSyncExternalStore`.
- **Theme bootstrap** (`index.html` inline script): resolves stored mode + system pref into a concrete `data-theme` value before React mounts. Without this, dark-mode users get a white flash on every reload.
- **ThemeToggle** (`src/components/ui/ThemeToggle.tsx`): sun/moon button slotted into the legacy Navbar's right side. Tooltip + `aria-label` describe what the next click does. A small accent dot overlays the icon when mode is 'system' so the user can tell at a glance whether they've explicitly chosen.

## What I verified

- [x] `npx tsc --noEmit` passes silently
- [x] `vite build` succeeds (CSS bundle: 76.65 kB → 77.91 kB, +1.26 kB for tokens + Tailwind utility expansion)
- [x] Dev server serves HTML with the bootstrap script and Geist preconnect/stylesheet links

## Test plan — please verify locally

- [ ] `npm run dev` → light theme renders; toggle in top-right Navbar cycles light → dark → system
- [ ] Reload while in dark mode → no white flash before React mounts (the `data-theme` should be set in the inline `<script>` before first paint)
- [ ] Set OS to dark mode while toggle is on 'system' → app flips without a refresh
- [ ] localStorage shows `portfolioiq-theme` set to `light` or `dark` after explicit choice; key removed when 'system' selected
- [ ] Open `/accounts` → verify no visual regressions (existing pages still use legacy `bg-white` / `text-gray-*` utilities — those stay until Phase D)

## Out of scope

- Migrating existing pages off `rbm.*` / hard-coded `gray-N` / `blue-N` utilities — Phases B–D
- Navbar redesign — Phase C
- shadcn/ui integration — start of Phase B

## Next phase

Phase B: shared component library (`src/components/ui/{Card,Input,Badge,Dialog,…}`) using the tokens shipped here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)