### PR TITLE
Design Phase C — top bar + collapsible sidebar navigation

### DIFF
--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -1,0 +1,153 @@
+// AppShell — page wrapper for any page that uses the new chrome.
+//
+// Composition:
+//   <AppShell breadcrumb={…} sidebar={<MySidebar />}>
+//     <PageBody />
+//   </AppShell>
+//
+// On desktop (>= md), sidebar is always docked. On mobile it lives inside
+// a Radix Dialog that the TopBar's hamburger toggles. The collapse state
+// is desktop-only — collapsing on mobile would just hide everything.
+//
+// Pages without a sidebar (Login, public, simple admin pages) can pass
+// `sidebar={null}` or just omit the prop. The shell still renders the
+// TopBar so the chrome stays consistent.
+import { useSyncExternalStore, useState } from 'react'
+import * as DialogPrimitive from '@radix-ui/react-dialog'
+import { X } from 'lucide-react'
+import TopBar, { type BreadcrumbItem } from './TopBar'
+import {
+  SidebarCollapseToggle,
+  SidebarFooter,
+  SidebarProvider,
+} from './Sidebar'
+import {
+  getCollapsed,
+  subscribe as subscribeCollapsed,
+  toggleCollapsed,
+} from '../../lib/sidebar-state'
+import { cn } from '../../lib/cn'
+
+export interface AppShellProps {
+  breadcrumb?: BreadcrumbItem[]
+  /** Sidebar content. Pass undefined or null for pages without a sidebar. */
+  sidebar?: React.ReactNode
+  /** Main content body. Renders inside a scrollable region. */
+  children: React.ReactNode
+  /** Skip the default scroll wrapper for full-bleed pages (Map). */
+  fullBleed?: boolean
+}
+
+export default function AppShell({
+  breadcrumb,
+  sidebar,
+  children,
+  fullBleed,
+}: AppShellProps) {
+  const collapsed = useSyncExternalStore(
+    subscribeCollapsed,
+    getCollapsed,
+    getCollapsed
+  )
+  const [mobileOpen, setMobileOpen] = useState(false)
+  const hasSidebar = !!sidebar
+
+  return (
+    <div className="flex h-screen flex-col bg-surface text-fg">
+      <TopBar
+        breadcrumb={breadcrumb}
+        onMobileMenuClick={hasSidebar ? () => setMobileOpen(true) : undefined}
+      />
+
+      <div className="flex flex-1 overflow-hidden">
+        {/* Desktop sidebar (docked) */}
+        {hasSidebar && (
+          <aside
+            className={cn(
+              'hidden md:flex shrink-0 border-r border-border',
+              'h-full overflow-hidden'
+            )}
+          >
+            <SidebarProvider
+              collapsed={collapsed}
+              onToggleCollapsed={toggleCollapsed}
+            >
+              <div className="flex h-full w-full flex-col">
+                <div className="flex-1 overflow-y-auto">{sidebar}</div>
+                {/* Pin a default collapse toggle at the bottom unless the page's
+                    own SidebarFooter already includes one — pages that need
+                    extra footer items render their own SidebarFooter and the
+                    collapse toggle still tucks in via this default block. */}
+                <SidebarFooter>
+                  <SidebarCollapseToggle />
+                </SidebarFooter>
+              </div>
+            </SidebarProvider>
+          </aside>
+        )}
+
+        {/* Mobile drawer */}
+        {hasSidebar && (
+          <DialogPrimitive.Root open={mobileOpen} onOpenChange={setMobileOpen}>
+            <DialogPrimitive.Portal>
+              <DialogPrimitive.Overlay
+                className={cn(
+                  'fixed inset-0 z-40 bg-fg/30 backdrop-blur-sm md:hidden',
+                  'data-[state=open]:animate-in data-[state=open]:fade-in-0',
+                  'data-[state=closed]:animate-out data-[state=closed]:fade-out-0'
+                )}
+              />
+              <DialogPrimitive.Content
+                aria-label="Navigation menu"
+                className={cn(
+                  'fixed inset-y-0 left-0 z-50 w-[260px] border-r border-border bg-surface md:hidden',
+                  'data-[state=open]:animate-in data-[state=open]:slide-in-from-left',
+                  'data-[state=closed]:animate-out data-[state=closed]:slide-out-to-left'
+                )}
+              >
+                <DialogPrimitive.Title className="sr-only">
+                  Navigation
+                </DialogPrimitive.Title>
+                <SidebarProvider collapsed={false}>
+                  <div className="flex h-full flex-col">
+                    <div className="flex h-12 items-center justify-between border-b border-border px-4">
+                      <span className="text-sm font-semibold tracking-tight">
+                        Menu
+                      </span>
+                      <DialogPrimitive.Close
+                        className="text-fg-muted hover:text-fg"
+                        aria-label="Close menu"
+                      >
+                        <X className="h-4 w-4" />
+                      </DialogPrimitive.Close>
+                    </div>
+                    <div
+                      className="flex-1 overflow-y-auto"
+                      // Auto-close the drawer when the user taps a nav item
+                      onClick={(e) => {
+                        const target = e.target as HTMLElement
+                        if (target.closest('a, button')) setMobileOpen(false)
+                      }}
+                    >
+                      {sidebar}
+                    </div>
+                  </div>
+                </SidebarProvider>
+              </DialogPrimitive.Content>
+            </DialogPrimitive.Portal>
+          </DialogPrimitive.Root>
+        )}
+
+        {/* Main content */}
+        <main
+          className={cn(
+            'flex-1 min-w-0',
+            fullBleed ? 'overflow-hidden' : 'overflow-y-auto'
+          )}
+        >
+          {children}
+        </main>
+      </div>
+    </div>
+  )
+}

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -1,0 +1,240 @@
+// Sidebar — composable building blocks for the left nav. Pages render
+// their own content using these primitives; the AppShell handles the
+// collapsed / mobile-drawer plumbing.
+//
+// Structure:
+//   <Sidebar>                    — the visible aside (collapsible)
+//     <SidebarSection title=…>   — labeled group of items
+//       <SidebarItem icon=… to=… active=… badge=…>Label</SidebarItem>
+//     </SidebarSection>
+//     <SidebarFooter>            — pinned to the bottom (chat button, etc.)
+//   </Sidebar>
+//
+// Collapsed mode hides labels (only icons remain) and centers items.
+// Components inside the sidebar read collapsed via the SidebarContext so
+// individual items don't have to thread props from the AppShell.
+import { createContext, forwardRef, useContext } from 'react'
+import { Link } from 'react-router-dom'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
+import type { LucideIcon } from 'lucide-react'
+import { cn } from '../../lib/cn'
+
+interface SidebarContextValue {
+  collapsed: boolean
+  /** Called by an internal toggle button. AppShell provides this. */
+  onToggleCollapsed?: () => void
+}
+
+const SidebarContext = createContext<SidebarContextValue>({
+  collapsed: false,
+})
+
+export function SidebarProvider({
+  collapsed,
+  onToggleCollapsed,
+  children,
+}: {
+  collapsed: boolean
+  onToggleCollapsed?: () => void
+  children: React.ReactNode
+}) {
+  return (
+    <SidebarContext.Provider value={{ collapsed, onToggleCollapsed }}>
+      {children}
+    </SidebarContext.Provider>
+  )
+}
+
+export function useSidebar() {
+  return useContext(SidebarContext)
+}
+
+// ── Root ─────────────────────────────────────────────────────────────────────
+
+export interface SidebarProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export const Sidebar = forwardRef<HTMLDivElement, SidebarProps>(
+  ({ className, children, ...props }, ref) => {
+    const { collapsed } = useSidebar()
+    return (
+      <div
+        ref={ref}
+        data-collapsed={collapsed || undefined}
+        className={cn(
+          'flex h-full flex-col bg-surface-subtle',
+          'transition-[width] duration-200 ease-out',
+          collapsed ? 'w-14' : 'w-60',
+          className
+        )}
+        {...props}
+      >
+        {children}
+      </div>
+    )
+  }
+)
+Sidebar.displayName = 'Sidebar'
+
+// ── Section ──────────────────────────────────────────────────────────────────
+
+export function SidebarSection({
+  title,
+  children,
+  className,
+}: {
+  title?: React.ReactNode
+  children: React.ReactNode
+  className?: string
+}) {
+  const { collapsed } = useSidebar()
+  return (
+    <section className={cn('px-2 pt-3 pb-1', className)}>
+      {title && !collapsed && (
+        <h2 className="px-2 pb-1.5 text-[10px] font-semibold uppercase tracking-wider text-fg-subtle">
+          {title}
+        </h2>
+      )}
+      {/* When collapsed we drop the heading entirely (icon-only mode) and add a
+          subtle separator so groups remain distinguishable. */}
+      {title && collapsed && (
+        <div className="mx-2 mb-1 h-px bg-border" aria-hidden />
+      )}
+      <ul className="flex flex-col gap-0.5">{children}</ul>
+    </section>
+  )
+}
+
+// ── Item ─────────────────────────────────────────────────────────────────────
+
+export interface SidebarItemProps {
+  icon?: LucideIcon
+  /** Render a small element on the trailing edge (badge, status dot, count). */
+  trailing?: React.ReactNode
+  /** Highlight as the active route. AppShell consumers compute this from useLocation. */
+  active?: boolean
+  /** Disable interaction; renders muted, not clickable. */
+  disabled?: boolean
+  /** Internal (Link) destination. */
+  to?: string
+  /** External / button mode. */
+  onClick?: () => void
+  children: React.ReactNode
+  className?: string
+}
+
+export function SidebarItem({
+  icon: Icon,
+  trailing,
+  active,
+  disabled,
+  to,
+  onClick,
+  children,
+  className,
+}: SidebarItemProps) {
+  const { collapsed } = useSidebar()
+
+  const baseClass = cn(
+    'group flex h-8 items-center gap-2 rounded-md px-2 text-sm transition-colors duration-150',
+    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent',
+    active
+      ? 'bg-surface-muted text-fg font-medium'
+      : 'text-fg-muted hover:bg-surface-muted hover:text-fg',
+    disabled && 'pointer-events-none opacity-50',
+    collapsed && 'justify-center px-0',
+    className
+  )
+
+  const inner = (
+    <>
+      {Icon && (
+        <Icon
+          className={cn('h-4 w-4 shrink-0', active ? 'text-accent' : 'text-fg-subtle group-hover:text-fg')}
+          strokeWidth={1.75}
+          aria-hidden
+        />
+      )}
+      {!collapsed && (
+        <>
+          <span className="flex-1 truncate">{children}</span>
+          {trailing && <span className="shrink-0">{trailing}</span>}
+        </>
+      )}
+    </>
+  )
+
+  return (
+    <li>
+      {to && !disabled ? (
+        <Link
+          to={to}
+          className={baseClass}
+          aria-current={active ? 'page' : undefined}
+          title={collapsed && typeof children === 'string' ? children : undefined}
+        >
+          {inner}
+        </Link>
+      ) : (
+        <button
+          type="button"
+          onClick={disabled ? undefined : onClick}
+          disabled={disabled}
+          className={cn(baseClass, 'w-full text-left')}
+          title={collapsed && typeof children === 'string' ? children : undefined}
+        >
+          {inner}
+        </button>
+      )}
+    </li>
+  )
+}
+
+// ── Footer (pinned bottom) ───────────────────────────────────────────────────
+
+export function SidebarFooter({
+  children,
+  className,
+}: {
+  children: React.ReactNode
+  className?: string
+}) {
+  return (
+    <div
+      className={cn(
+        'mt-auto border-t border-border px-2 py-2 flex flex-col gap-0.5',
+        className
+      )}
+    >
+      {children}
+    </div>
+  )
+}
+
+// ── Collapse toggle (used inside SidebarFooter) ──────────────────────────────
+
+export function SidebarCollapseToggle() {
+  const { collapsed, onToggleCollapsed } = useSidebar()
+  if (!onToggleCollapsed) return null
+  return (
+    <button
+      type="button"
+      onClick={onToggleCollapsed}
+      aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+      className={cn(
+        'inline-flex h-7 items-center gap-2 rounded-md px-2 text-xs',
+        'text-fg-subtle hover:bg-surface-muted hover:text-fg transition-colors',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent',
+        collapsed && 'justify-center px-0'
+      )}
+    >
+      {collapsed ? (
+        <ChevronRight className="h-3.5 w-3.5" />
+      ) : (
+        <>
+          <ChevronLeft className="h-3.5 w-3.5" />
+          <span>Collapse</span>
+        </>
+      )}
+    </button>
+  )
+}

--- a/src/components/layout/TopBar.tsx
+++ b/src/components/layout/TopBar.tsx
@@ -1,0 +1,199 @@
+// TopBar — 48px sticky bar shown on every AppShell page. Replaces the
+// legacy <Navbar> visually but only for pages that have migrated.
+//
+// Layout:
+//   [hamburger]  [logo · breadcrumb]                [theme] [user]
+//                                                ^^ flex spacer
+//
+// The hamburger only appears on screens < md and toggles the sidebar
+// drawer. On desktop the sidebar is always docked, so no hamburger.
+import { useEffect, useState } from 'react'
+import { Link, useNavigate } from 'react-router-dom'
+import { ChevronRight, LogOut, Menu, Settings, User } from 'lucide-react'
+import ThemeToggle from '../ui/ThemeToggle'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '../ui/DropdownMenu'
+import { cn } from '../../lib/cn'
+import { supabase } from '../../lib/supabase/client'
+
+export interface BreadcrumbItem {
+  label: React.ReactNode
+  /** Falsy = render as plain text (final segment). */
+  to?: string | null
+}
+
+export interface TopBarProps {
+  breadcrumb?: BreadcrumbItem[]
+  /** Called by AppShell when the hamburger is tapped on mobile. */
+  onMobileMenuClick?: () => void
+}
+
+export default function TopBar({ breadcrumb, onMobileMenuClick }: TopBarProps) {
+  return (
+    <header
+      className={cn(
+        'h-12 shrink-0 border-b border-border bg-surface',
+        'flex items-center gap-3 px-4'
+      )}
+    >
+      {onMobileMenuClick && (
+        <button
+          type="button"
+          onClick={onMobileMenuClick}
+          aria-label="Open navigation menu"
+          className={cn(
+            'inline-flex h-8 w-8 items-center justify-center rounded-md',
+            'text-fg-muted hover:text-fg hover:bg-surface-muted transition-colors',
+            'md:hidden'
+          )}
+        >
+          <Menu className="h-4 w-4" />
+        </button>
+      )}
+
+      <Link
+        to="/accounts"
+        className="flex items-center gap-2 text-sm font-semibold tracking-tight text-fg shrink-0"
+      >
+        <LogoMark />
+        <span>PortfolioIQ</span>
+      </Link>
+
+      {breadcrumb && breadcrumb.length > 0 && (
+        <nav
+          aria-label="Breadcrumb"
+          className="hidden sm:flex items-center gap-1.5 text-sm text-fg-muted min-w-0"
+        >
+          <span className="text-fg-subtle" aria-hidden>
+            <ChevronRight className="h-3.5 w-3.5" />
+          </span>
+          <ol className="flex items-center gap-1.5 min-w-0">
+            {breadcrumb.map((item, i) => {
+              const isLast = i === breadcrumb.length - 1
+              const content = (
+                <span
+                  className={cn(
+                    'truncate',
+                    isLast ? 'text-fg' : 'text-fg-muted hover:text-fg'
+                  )}
+                >
+                  {item.label}
+                </span>
+              )
+              return (
+                <li
+                  key={i}
+                  className="flex items-center gap-1.5 min-w-0"
+                  aria-current={isLast ? 'page' : undefined}
+                >
+                  {item.to && !isLast ? (
+                    <Link to={item.to}>{content}</Link>
+                  ) : (
+                    content
+                  )}
+                  {!isLast && (
+                    <span className="text-fg-subtle" aria-hidden>
+                      <ChevronRight className="h-3.5 w-3.5" />
+                    </span>
+                  )}
+                </li>
+              )
+            })}
+          </ol>
+        </nav>
+      )}
+
+      <div className="ml-auto flex items-center gap-1">
+        <ThemeToggle />
+        <UserMenu />
+      </div>
+    </header>
+  )
+}
+
+// Minimal logo mark — square with a simple accent corner. Avoids the
+// gradient-pin-icon look from the legacy Navbar (which read as a brand
+// asset for "RBM Geo", not a software product).
+function LogoMark() {
+  return (
+    <span
+      aria-hidden="true"
+      className="inline-flex h-5 w-5 items-center justify-center rounded-sm bg-accent text-accent-fg text-[11px] font-semibold"
+    >
+      P
+    </span>
+  )
+}
+
+// Read the supabase user once on mount. Async fetch so we don't widen the
+// useAuth contract just for a label.
+function useCurrentUserEmail(): string | null {
+  const [email, setEmail] = useState<string | null>(null)
+  useEffect(() => {
+    let cancelled = false
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      if (!cancelled) setEmail(session?.user?.email ?? null)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+  return email
+}
+
+function UserMenu() {
+  const email = useCurrentUserEmail()
+  const navigate = useNavigate()
+  const initial = (email ?? '?').charAt(0).toUpperCase()
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          aria-label="Open user menu"
+          className={cn(
+            'inline-flex h-8 w-8 items-center justify-center rounded-full',
+            'border border-border bg-surface-subtle text-fg-muted',
+            'text-xs font-medium hover:bg-surface-muted hover:text-fg transition-colors',
+            'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent'
+          )}
+        >
+          {initial}
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="min-w-[14rem]">
+        {email && (
+          <>
+            <DropdownMenuLabel className="normal-case font-normal text-fg-muted text-xs">
+              {email}
+            </DropdownMenuLabel>
+            <DropdownMenuSeparator />
+          </>
+        )}
+        <DropdownMenuItem disabled>
+          <User className="h-4 w-4" /> Profile
+          <span className="ml-auto text-[10px] text-fg-subtle uppercase">
+            Soon
+          </span>
+        </DropdownMenuItem>
+        <DropdownMenuItem disabled>
+          <Settings className="h-4 w-4" /> Settings
+          <span className="ml-auto text-[10px] text-fg-subtle uppercase">
+            Soon
+          </span>
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem onSelect={() => navigate('/logout')}>
+          <LogOut className="h-4 w-4" /> Sign out
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/src/lib/sidebar-state.ts
+++ b/src/lib/sidebar-state.ts
@@ -1,0 +1,45 @@
+// Sidebar collapsed-state manager. Same shape as lib/theme.ts: tiny
+// framework-free runtime, components subscribe via useSyncExternalStore.
+//
+// We persist *only* the collapsed bool. Mobile-drawer open/close is
+// component-local (it's a transient UI state, not a preference).
+const STORAGE_KEY = 'portfolioiq-sidebar-collapsed'
+
+const listeners = new Set<() => void>()
+
+function readStored(): boolean {
+  if (typeof window === 'undefined') return false
+  try {
+    return window.localStorage.getItem(STORAGE_KEY) === '1'
+  } catch {
+    return false
+  }
+}
+
+let cached = readStored()
+
+export function getCollapsed(): boolean {
+  return cached
+}
+
+export function setCollapsed(collapsed: boolean) {
+  cached = collapsed
+  try {
+    if (collapsed) window.localStorage.setItem(STORAGE_KEY, '1')
+    else window.localStorage.removeItem(STORAGE_KEY)
+  } catch {
+    /* storage blocked — still apply for the session */
+  }
+  for (const fn of listeners) fn()
+}
+
+export function toggleCollapsed() {
+  setCollapsed(!cached)
+}
+
+export function subscribe(listener: () => void): () => void {
+  listeners.add(listener)
+  return () => {
+    listeners.delete(listener)
+  }
+}

--- a/src/pages/accounts/AccountAnalysis.tsx
+++ b/src/pages/accounts/AccountAnalysis.tsx
@@ -1,8 +1,21 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { useParams, Link } from 'react-router-dom'
+import {
+  Building2,
+  FileText,
+  LayoutDashboard,
+  Map as MapIcon,
+  Sparkles,
+} from 'lucide-react'
 import { useAuth } from '../../hooks/useAuth'
-import Navbar from '../../components/ui/Navbar'
 import Button from '../../components/ui/Button'
+import AppShell from '../../components/layout/AppShell'
+import {
+  Sidebar,
+  SidebarItem,
+  SidebarSection,
+} from '../../components/layout/Sidebar'
+import { StatusDot, type StatusVariant } from '../../components/ui/StatusDot'
 import AnalysisCard, {
   type AnalysisStatus,
   STUCK_AFTER_MS,
@@ -697,40 +710,48 @@ export default function AccountAnalysisPage() {
     return null
   }
 
-  return (
-    <div className="flex flex-col h-screen bg-gray-50">
-      <Navbar />
-      <div className="flex-1 overflow-y-auto">
-        <div className="max-w-6xl mx-auto px-6 py-8 space-y-6">
+  const moduleStatuses: Array<{ key: ModuleKey; title: string; status: AnalysisStatus }> =
+    MODULES.map((m) => ({ key: m.key, title: m.title, status: statusFor(m.key) }))
 
-          {/* Header */}
-          <div className="flex items-start justify-between gap-4">
-            <div>
-              {/* Breadcrumb */}
-              <div className="text-sm text-gray-400 mb-1 flex items-center gap-1.5 flex-wrap">
-                <Link to="/accounts" className="hover:text-gray-600">Accounts</Link>
-                <span>›</span>
-                <Link to={`/accounts/${accountId}`} className="hover:text-gray-600">
-                  {account?.display_name ?? account?.name ?? '…'}
-                </Link>
-                <span>›</span>
-                <span className="text-gray-700">{client?.display_name ?? client?.name ?? '…'}</span>
-                <span>›</span>
-                <span className="text-gray-700">Analysis</span>
-              </div>
-              <Link to={`/accounts/${accountId}`} className="text-sm text-blue-600 hover:underline">
-                ← Back to {account?.display_name ?? account?.name ?? 'account'}
-              </Link>
-              <h1 className="text-2xl font-bold text-gray-900 mt-1">
-                Smart Analysis
-                {account && (
-                  <span className="text-gray-500 font-normal">
-                    {' · '}{account.display_name ?? account.name}
-                    {client && <> · {client.display_name ?? client.name}</>}
-                  </span>
-                )}
-              </h1>
-            </div>
+  return (
+    <AppShell
+      breadcrumb={[
+        { label: 'Accounts', to: '/accounts' },
+        {
+          label: account?.display_name ?? account?.name ?? '…',
+          to: `/accounts/${accountId}`,
+        },
+        { label: client?.display_name ?? client?.name ?? '…' },
+        { label: 'Analysis' },
+      ]}
+      sidebar={
+        <AnalysisSidebar
+          accountId={accountId!}
+          clientId={clientId!}
+          moduleStatuses={moduleStatuses}
+        />
+      }
+    >
+      <div className="mx-auto max-w-6xl px-6 py-8 space-y-6">
+        {/* Header */}
+        <div className="flex items-start justify-between gap-4">
+          <div className="space-y-1">
+            <Link
+              to={`/accounts/${accountId}`}
+              className="text-sm text-accent hover:underline"
+            >
+              ← Back to {account?.display_name ?? account?.name ?? 'account'}
+            </Link>
+            <h1 className="text-2xl font-semibold tracking-tight text-fg">
+              Smart Analysis
+              {account && (
+                <span className="text-fg-muted font-normal">
+                  {' · '}{account.display_name ?? account.name}
+                  {client && <> · {client.display_name ?? client.name}</>}
+                </span>
+              )}
+            </h1>
+          </div>
             <Button onClick={runAll} disabled={Object.values(running).some(Boolean)}>
               Run All Analyses
             </Button>
@@ -927,8 +948,9 @@ export default function AccountAnalysisPage() {
                 margin: baselineMargin,
               })
               return (
+                // id anchor lets the AnalysisSidebar deep-link with #module-…
+                <div key={m.key} id={`module-${m.key}`} className="scroll-mt-16">
                 <AnalysisCard
-                  key={m.key}
                   title={m.title}
                   description={description}
                   status={status}
@@ -954,6 +976,7 @@ export default function AccountAnalysisPage() {
                 >
                   {renderModuleBody(m.key)}
                 </AnalysisCard>
+                </div>
               )
             })}
           </div>
@@ -974,10 +997,86 @@ export default function AccountAnalysisPage() {
             />
           )}
 
-        </div>
       </div>
-    </div>
+    </AppShell>
   )
+}
+
+// Sidebar shown on the Analysis Dashboard. Modules section uses anchor
+// links (#module-…) so clicking scrolls to the matching card on the page.
+// Anchors live on a wrapper div added inside the MODULES.map render.
+function AnalysisSidebar({
+  accountId,
+  clientId,
+  moduleStatuses,
+}: {
+  accountId: string
+  clientId: string
+  moduleStatuses: Array<{ key: ModuleKey; title: string; status: AnalysisStatus }>
+}) {
+  return (
+    <Sidebar>
+      <SidebarSection title="Analysis">
+        <SidebarItem
+          icon={LayoutDashboard}
+          to={`/accounts/${accountId}/clients/${clientId}/analysis`}
+          active
+        >
+          Dashboard
+        </SidebarItem>
+        <SidebarItem icon={MapIcon} disabled>
+          Map
+        </SidebarItem>
+        <SidebarItem icon={Building2} disabled>
+          Properties
+        </SidebarItem>
+        <SidebarItem icon={Sparkles} disabled>
+          Bid Pricing
+        </SidebarItem>
+      </SidebarSection>
+
+      <SidebarSection title="Modules">
+        {moduleStatuses.map((m) => (
+          <SidebarItem
+            key={m.key}
+            icon={FileText}
+            // Hash-only links scroll to the on-page anchor without unmounting.
+            to={`#module-${m.key}`}
+            trailing={
+              <StatusDot
+                variant={moduleSidebarStatus(m.status)}
+                label={false}
+                size="sm"
+              />
+            }
+          >
+            {m.title}
+          </SidebarItem>
+        ))}
+      </SidebarSection>
+
+      <SidebarSection title="Saved Scenarios">
+        <li className="px-2 py-1 text-xs text-fg-subtle">
+          Coming in Phase D
+        </li>
+      </SidebarSection>
+    </Sidebar>
+  )
+}
+
+function moduleSidebarStatus(s: AnalysisStatus): StatusVariant {
+  switch (s) {
+    case 'completed':
+      return 'fresh'
+    case 'running':
+      return 'running'
+    case 'failed':
+      return 'failed'
+    case 'stuck':
+      return 'stale'
+    default:
+      return 'never'
+  }
 }
 
 // Phase 3.5 — per-module "Using: …" line + which Cost Assumptions group to

--- a/src/pages/accounts/AccountDetail.tsx
+++ b/src/pages/accounts/AccountDetail.tsx
@@ -1,8 +1,15 @@
 import { useState, useEffect } from 'react'
 import { useParams, Link, useNavigate, useSearchParams } from 'react-router-dom'
+import { Building2, Home, Settings, Users } from 'lucide-react'
 import { useAuth } from '../../hooks/useAuth'
-import Navbar from '../../components/ui/Navbar'
 import Button from '../../components/ui/Button'
+import { Badge } from '../../components/ui/Badge'
+import AppShell from '../../components/layout/AppShell'
+import {
+  Sidebar,
+  SidebarItem,
+  SidebarSection,
+} from '../../components/layout/Sidebar'
 import type { Account, Client } from '../../types'
 
 // Phase 3.6 — Account Overview shape returned by /api/accounts/[id]/overview
@@ -130,49 +137,70 @@ export default function AccountDetailPage() {
   }
 
   if (loading) return (
-    <div className="flex flex-col h-full bg-gray-50"><Navbar />
-      <div className="flex-1 flex items-center justify-center text-gray-400">Loading…</div>
-    </div>
+    <AppShell breadcrumb={[{ label: 'Accounts', to: '/accounts' }, { label: 'Loading…' }]}>
+      <div className="flex h-full items-center justify-center text-fg-subtle">
+        Loading…
+      </div>
+    </AppShell>
   )
 
   if (!account) return (
-    <div className="flex flex-col h-full bg-gray-50"><Navbar />
-      <div className="flex-1 flex items-center justify-center">
-        <div className="text-center space-y-3">
-          <p className="text-gray-500">Account not found.</p>
-          <Link to="/accounts" className="text-blue-600 text-sm hover:underline">← Back to accounts</Link>
+    <AppShell breadcrumb={[{ label: 'Accounts', to: '/accounts' }, { label: 'Not found' }]}>
+      <div className="flex h-full items-center justify-center">
+        <div className="space-y-3 text-center">
+          <p className="text-fg-muted">Account not found.</p>
+          <Link to="/accounts" className="text-sm text-accent hover:underline">
+            ← Back to accounts
+          </Link>
         </div>
       </div>
-    </div>
+    </AppShell>
   )
 
   const isPM = account.account_type === 'property_manager'
   const selfClient = !isPM ? clients[0] : null
 
   return (
-    <div className="flex flex-col h-full bg-gray-50">
-      <Navbar />
-      <div className="flex-1 overflow-y-auto">
-        <div className="max-w-5xl mx-auto px-6 py-8 space-y-6">
-          {error && <div className="p-3 bg-red-50 border border-red-200 rounded-lg text-red-700 text-sm">{error}</div>}
-
-          {/* Header */}
-          <div className="flex items-start justify-between">
-            <div>
-              <div className="flex items-center gap-2 mb-1">
-                <Link to="/accounts" className="text-gray-400 hover:text-gray-600 text-sm">Accounts</Link>
-                <span className="text-gray-300">›</span>
-                <h1 className="text-2xl font-bold text-gray-900">{account.display_name ?? account.name}</h1>
-                <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${TYPE_BADGE[account.account_type]}`}>
-                  {TYPE_LABEL[account.account_type]}
-                </span>
-              </div>
-              {account.display_name && <p className="text-sm text-gray-400">{account.name}</p>}
-            </div>
-            <div className="flex items-center gap-2">
-              <Button size="sm" variant="secondary" onClick={() => setEditing(true)}>Edit</Button>
-            </div>
+    <AppShell
+      breadcrumb={[
+        { label: 'Accounts', to: '/accounts' },
+        { label: account.display_name ?? account.name },
+      ]}
+      sidebar={
+        <AccountOverviewSidebar
+          accountId={id!}
+          accountName={account.display_name ?? account.name}
+          clients={overview?.clients ?? clients.map(toOverviewLite)}
+          isPropertyManager={isPM}
+        />
+      }
+    >
+      <div className="mx-auto max-w-5xl px-6 py-8 space-y-6">
+        {error && (
+          <div className="p-3 bg-danger-subtle border border-danger/20 rounded-md text-danger text-sm">
+            {error}
           </div>
+        )}
+
+        {/* Header */}
+        <div className="flex items-start justify-between">
+          <div className="space-y-1">
+            <div className="flex items-center gap-2">
+              <h1 className="text-2xl font-semibold tracking-tight text-fg">
+                {account.display_name ?? account.name}
+              </h1>
+              <Badge variant={isPM ? 'accent' : 'default'}>
+                {TYPE_LABEL[account.account_type]}
+              </Badge>
+            </div>
+            {account.display_name && (
+              <p className="text-sm text-fg-subtle">{account.name}</p>
+            )}
+          </div>
+          <Button size="sm" variant="secondary" onClick={() => setEditing(true)}>
+            Edit
+          </Button>
+        </div>
 
           {/* Phase 3.6 — banner when bounced from old /analysis URL */}
           {fromLegacyAnalysis && (
@@ -307,7 +335,6 @@ export default function AccountDetailPage() {
               </table>
             </div>
           )}
-        </div>
       </div>
 
       {/* Edit modal */}
@@ -359,7 +386,7 @@ export default function AccountDetailPage() {
           </div>
         </div>
       )}
-    </div>
+    </AppShell>
   )
 }
 
@@ -370,6 +397,82 @@ function StatCard({ label, value }: { label: string; value: string }) {
       <p className="text-sm text-gray-500 mt-0.5">{label}</p>
     </div>
   )
+}
+
+// Sidebar shown next to the Account Overview page. Lives in this file
+// because the data shape is page-specific; if it grows, factor out.
+function AccountOverviewSidebar({
+  accountId,
+  accountName,
+  clients,
+  isPropertyManager,
+}: {
+  accountId: string
+  accountName: string
+  clients: Pick<OverviewClient, 'id' | 'name' | 'display_name' | 'property_count'>[]
+  isPropertyManager: boolean
+}) {
+  return (
+    <Sidebar>
+      <SidebarSection title="Account">
+        <SidebarItem icon={Home} to={`/accounts/${accountId}`} active>
+          Overview
+        </SidebarItem>
+        <SidebarItem icon={Settings} disabled>
+          Settings
+        </SidebarItem>
+        <SidebarItem icon={Users} disabled>
+          Team
+        </SidebarItem>
+      </SidebarSection>
+
+      <SidebarSection title={`Clients · ${accountName}`}>
+        {clients.length === 0 ? (
+          <li className="px-2 py-1 text-xs text-fg-subtle">
+            No clients on this account.
+          </li>
+        ) : (
+          clients.map((c) => (
+            <SidebarItem
+              key={c.id}
+              icon={Building2}
+              to={`/accounts/${accountId}/clients/${c.id}/analysis`}
+              trailing={
+                c.property_count > 0 ? (
+                  <Badge variant="default">{c.property_count}</Badge>
+                ) : null
+              }
+            >
+              {c.display_name ?? c.name}
+            </SidebarItem>
+          ))
+        )}
+        {isPropertyManager && (
+          <SidebarItem
+            icon={Users}
+            to={`/accounts/${accountId}/clients/new`}
+            className="text-fg-subtle"
+          >
+            + Add client
+          </SidebarItem>
+        )}
+      </SidebarSection>
+    </Sidebar>
+  )
+}
+
+// Adapter so the sidebar can render before /overview returns by falling
+// back to the bare clients list. property_count = 0 hides the badge.
+function toOverviewLite(c: Client): Pick<
+  OverviewClient,
+  'id' | 'name' | 'display_name' | 'property_count'
+> {
+  return {
+    id: c.id,
+    name: c.name,
+    display_name: c.display_name ?? null,
+    property_count: 0,
+  }
 }
 
 function ClientSetupBanner({ client }: { client: Client }) {


### PR DESCRIPTION
## Summary

Ships the new chrome (TopBar + collapsible Sidebar inside an AppShell wrapper) and migrates the two data-heavy pages to it. Remaining pages stay on the legacy `<Navbar>` for now — Phase D sweeps them.

### Layout primitives (`src/components/layout/`)

- **AppShell** — page wrapper. `<AppShell breadcrumb={…} sidebar={…}>{body}</AppShell>`. Mobile drawer uses Radix Dialog with slide-in-from-left; desktop sidebar is always docked.
- **TopBar** — 48px sticky bar: logo, breadcrumb, theme toggle (moved here from legacy Navbar), user menu (avatar dropdown with email + Sign out). Hamburger only renders < md and only when a sidebar exists.
- **Sidebar** — composable: `Sidebar`, `SidebarSection`, `SidebarItem` (icon / trailing / active / disabled), `SidebarFooter`, `SidebarCollapseToggle`. SidebarProvider exposes `collapsed` to nested items so they don't thread props.

### Collapse state (`src/lib/sidebar-state.ts`)

Mirrors `lib/theme.ts` — tiny framework-free runtime, persisted as `portfolioiq-sidebar-collapsed`. Mobile drawer open/close stays component-local (transient).

### Pages migrated

| Page | Sidebar contents |
|---|---|
| **AccountDetail** (`/accounts/:id`, Account Overview) | Account section + Clients list with property-count badges deep-linking to per-client analysis |
| **AccountAnalysis** (`/accounts/:accountId/clients/:clientId/analysis`) | Analysis section + Modules with per-module status dots (`fresh`/`running`/`stale`/`failed`/`never`) hash-linking to module anchors on the page + Saved Scenarios placeholder |

Module cards now wrap in `<div id="module-{key}">` so sidebar items scroll to them.

## What I verified

- [x] `npx tsc --noEmit` passes silently
- [x] `vite build` succeeds. CSS bundle: 88.40 kB → 89.58 kB (+1.18 kB raw, +0.23 kB gz). JS bundle: +14 kB raw, +6 kB gz from layout components.
- [x] Dev server serves `/design-system` (200) and `/accounts/foo` (200, redirects through auth)

## Test plan — please verify locally on the preview

- [ ] `npm run dev` → visit `/accounts/[JLL]`. New chrome appears: TopBar with breadcrumb `Accounts › JLL`, left sidebar with Account + Clients sections. Property Reserve appears in sidebar with property-count badge.
- [ ] Click "Property Reserve" in sidebar → navigates to `/accounts/[JLL]/clients/[Property-Reserve]/analysis`. Breadcrumb expands to 4 segments. Analysis sidebar shows Modules with status dots.
- [ ] Click a module name in sidebar (e.g. Branch Optimization) → page scrolls to that module card.
- [ ] Click the collapse chevron at the bottom of the sidebar → sidebar shrinks to 56px icon-only mode. localStorage gets `portfolioiq-sidebar-collapsed=1`. Reload → sidebar stays collapsed.
- [ ] Resize window < 768px → sidebar disappears, hamburger icon appears in TopBar. Tap hamburger → drawer slides in. Tap a nav item → drawer auto-closes.
- [ ] Toggle theme via TopBar avatar's neighbor → both light + dark look polished on Account Overview and Analysis pages.
- [ ] Visit a page that hasn't migrated yet (e.g. `/accounts`, `/map`, `/admin`) → still uses legacy Navbar but otherwise unchanged.
- [ ] User menu (top-right avatar) → dropdown shows email + Profile/Settings (disabled stubs) + Sign out.

## Out of scope (Phase D)

- Migrating other pages to AppShell (`/accounts`, `/clients`, `/properties/:id`, `/map`, `/admin/*`, etc.)
- In-nav client switcher dropdown (was on legacy Navbar — will be re-added to TopBar)
- Wiring Saved Scenarios into the AnalysisSidebar (needs scenario state lifted out of ScenarioPanel)
- Page-level visual cleanup (the existing `bg-white` / `text-gray-*` cards on these pages still need to be migrated to design tokens — Phase D)

## Next phase

Phase D: page redesigns — apply the design system to Account Overview, Client Analysis Dashboard, Map, and Property Detail. This is also where remaining pages get the AppShell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)