### PR TITLE
Design Phase E — polish: transitions, errors, count-up

### DIFF
--- a/src/components/analysis/ComparablesPanel.tsx
+++ b/src/components/analysis/ComparablesPanel.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { useAuth } from '../../hooks/useAuth'
 import { Card, CardHeader, CardTitle } from '../ui/Card'
+import { ErrorState } from '../ui/ErrorState'
 import { Skeleton } from '../ui/Skeleton'
 import { cn } from '../../lib/cn'
 
@@ -35,6 +36,10 @@ export default function ComparablesPanel({ propertyId }: { propertyId: string })
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
+  // Bumped on retry to re-trigger the fetch effect.
+  const [retryNonce, setRetryNonce] = useState(0)
+  const retry = useCallback(() => setRetryNonce((n) => n + 1), [])
+
   useEffect(() => {
     let cancelled = false
     async function load() {
@@ -61,7 +66,7 @@ export default function ComparablesPanel({ propertyId }: { propertyId: string })
     return () => {
       cancelled = true
     }
-  }, [propertyId, getToken])
+  }, [propertyId, getToken, retryNonce])
 
   return (
     <Card>
@@ -78,12 +83,11 @@ export default function ComparablesPanel({ propertyId }: { propertyId: string })
           </div>
         )}
         {error && (
-          <p
-            role="alert"
-            className="rounded-md border border-danger/20 bg-danger-subtle px-3 py-2 text-sm text-danger"
-          >
-            Could not load comparables: {error}
-          </p>
+          <ErrorState
+            title="Couldn't load comparables"
+            description={error}
+            onRetry={retry}
+          />
         )}
 
         {!loading && !error && data && (

--- a/src/components/analysis/ServiceMixPanel.tsx
+++ b/src/components/analysis/ServiceMixPanel.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { useAuth } from '../../hooks/useAuth'
 import { Badge } from '../ui/Badge'
 import { Card, CardHeader, CardTitle } from '../ui/Card'
+import { ErrorState } from '../ui/ErrorState'
 import { Skeleton } from '../ui/Skeleton'
 
 interface Recommendation {
@@ -35,6 +36,9 @@ export default function ServiceMixPanel({ propertyId }: { propertyId: string }) 
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
+  const [retryNonce, setRetryNonce] = useState(0)
+  const retry = useCallback(() => setRetryNonce((n) => n + 1), [])
+
   useEffect(() => {
     let cancelled = false
     async function load() {
@@ -61,7 +65,7 @@ export default function ServiceMixPanel({ propertyId }: { propertyId: string }) 
     return () => {
       cancelled = true
     }
-  }, [propertyId, getToken])
+  }, [propertyId, getToken, retryNonce])
 
   return (
     <Card>
@@ -78,12 +82,11 @@ export default function ServiceMixPanel({ propertyId }: { propertyId: string }) 
           </div>
         )}
         {error && (
-          <p
-            role="alert"
-            className="rounded-md border border-danger/20 bg-danger-subtle px-3 py-2 text-sm text-danger"
-          >
-            Could not load service mix: {error}
-          </p>
+          <ErrorState
+            title="Couldn't load service mix"
+            description={error}
+            onRetry={retry}
+          />
         )}
 
         {!loading && !error && data && (

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -13,6 +13,7 @@
 // `sidebar={null}` or just omit the prop. The shell still renders the
 // TopBar so the chrome stays consistent.
 import { useSyncExternalStore, useState } from 'react'
+import { useLocation } from 'react-router-dom'
 import * as DialogPrimitive from '@radix-ui/react-dialog'
 import { X } from 'lucide-react'
 import TopBar, { type BreadcrumbItem } from './TopBar'
@@ -51,6 +52,10 @@ export default function AppShell({
   )
   const [mobileOpen, setMobileOpen] = useState(false)
   const hasSidebar = !!sidebar
+  // Phase E — re-key the <main> on each pathname so the fade-in transition
+  // re-runs between routes. Hash changes (#module-…) don't bump the key,
+  // which is what we want — anchor scroll shouldn't trigger a fade.
+  const { pathname } = useLocation()
 
   return (
     <div className="flex h-screen flex-col bg-surface text-fg">
@@ -138,10 +143,12 @@ export default function AppShell({
           </DialogPrimitive.Root>
         )}
 
-        {/* Main content */}
+        {/* Main content. Re-keyed by pathname so the route-change fade-in
+            replays — see comment in the page-transition CSS in index.css. */}
         <main
+          key={pathname}
           className={cn(
-            'flex-1 min-w-0',
+            'flex-1 min-w-0 motion-safe:animate-page-fade-in',
             fullBleed ? 'overflow-hidden' : 'overflow-y-auto'
           )}
         >

--- a/src/components/ui/ErrorState.tsx
+++ b/src/components/ui/ErrorState.tsx
@@ -1,0 +1,64 @@
+// ErrorState — destructive-card variant for inline failure UI.
+//
+// Pairs with EmptyState semantically. Use when an async section failed
+// to load and you want the user to retry. For toasts (transient,
+// dismissable), use the toast() API instead.
+//
+// Layout matches EmptyState — icon + title + description + single CTA —
+// so the two render at the same height when one is conditionally swapped
+// for the other (e.g. ServiceMixPanel showing EmptyState on no-results
+// vs. ErrorState on fetch failure).
+import { CircleAlert, type LucideIcon } from 'lucide-react'
+import Button from './Button'
+import { cn } from '../../lib/cn'
+
+export interface ErrorStateProps {
+  icon?: LucideIcon
+  title?: React.ReactNode
+  /** The error message — typically the caught error's .message. */
+  description?: React.ReactNode
+  /** Click handler for the retry button. Omit to render no action. */
+  onRetry?: () => void
+  retryLabel?: string
+  className?: string
+}
+
+export function ErrorState({
+  icon: Icon = CircleAlert,
+  title = 'Something went wrong',
+  description,
+  onRetry,
+  retryLabel = 'Try again',
+  className,
+}: ErrorStateProps) {
+  return (
+    <div
+      role="alert"
+      className={cn(
+        'flex flex-col items-center justify-center gap-3 px-6 py-12 text-center',
+        // Subtle danger bg + 1px border. Doesn't shout — fits inside a
+        // larger Card without dominating.
+        'rounded-md border border-danger/20 bg-danger-subtle',
+        className
+      )}
+    >
+      <div
+        className="flex h-10 w-10 items-center justify-center rounded-md bg-surface text-danger"
+        aria-hidden="true"
+      >
+        <Icon className="h-5 w-5" strokeWidth={1.75} />
+      </div>
+      <div className="max-w-sm space-y-1">
+        <p className="text-sm font-semibold text-fg">{title}</p>
+        {description && (
+          <p className="text-xs leading-relaxed text-fg-muted">{description}</p>
+        )}
+      </div>
+      {onRetry && (
+        <Button size="sm" variant="secondary" onClick={onRetry}>
+          {retryLabel}
+        </Button>
+      )}
+    </div>
+  )
+}

--- a/src/hooks/useCountUp.ts
+++ b/src/hooks/useCountUp.ts
@@ -1,0 +1,78 @@
+// useCountUp — animate a numeric display from its previous value to the
+// next over ~300ms.
+//
+// Why: numbers that change (synthesis hero, stat cards, risk score) feel
+// more alive when they tween instead of snapping. Per design rules the
+// effect is subtle — 300ms ease-out, no overshoot, no bounce.
+//
+// Honors prefers-reduced-motion: when reduced motion is on, returns the
+// final value immediately.
+//
+// Re-fires whenever the input value changes, including 0 → N on first
+// mount. Pass animateOnMount: false to suppress the initial tween when
+// the value is loaded synchronously (e.g. from cache).
+import { useEffect, useRef, useState } from 'react'
+
+const DEFAULT_DURATION_MS = 300
+
+export interface CountUpOptions {
+  durationMs?: number
+  /** When false, the first render returns the target value without animating. */
+  animateOnMount?: boolean
+}
+
+export function useCountUp(
+  target: number | null | undefined,
+  options: CountUpOptions = {}
+): number {
+  const { durationMs = DEFAULT_DURATION_MS, animateOnMount = true } = options
+  const [display, setDisplay] = useState<number>(target ?? 0)
+  const previousRef = useRef<number>(animateOnMount ? 0 : (target ?? 0))
+  const rafRef = useRef<number | null>(null)
+
+  useEffect(() => {
+    if (target == null || !Number.isFinite(target)) {
+      setDisplay(0)
+      previousRef.current = 0
+      return
+    }
+
+    const prefersReduced =
+      typeof window !== 'undefined' &&
+      window.matchMedia?.('(prefers-reduced-motion: reduce)').matches
+    if (prefersReduced || durationMs <= 0) {
+      setDisplay(target)
+      previousRef.current = target
+      return
+    }
+
+    const start = previousRef.current
+    const delta = target - start
+    if (delta === 0) {
+      setDisplay(target)
+      return
+    }
+
+    const startTs = performance.now()
+    const tick = (now: number) => {
+      const t = Math.min((now - startTs) / durationMs, 1)
+      // ease-out cubic: matches the "150-200ms ease-out for hovers" voice.
+      const eased = 1 - Math.pow(1 - t, 3)
+      const next = start + delta * eased
+      setDisplay(next)
+      if (t < 1) {
+        rafRef.current = requestAnimationFrame(tick)
+      } else {
+        setDisplay(target)
+        previousRef.current = target
+      }
+    }
+    rafRef.current = requestAnimationFrame(tick)
+
+    return () => {
+      if (rafRef.current != null) cancelAnimationFrame(rafRef.current)
+    }
+  }, [target, durationMs])
+
+  return display
+}

--- a/src/index.css
+++ b/src/index.css
@@ -13,6 +13,18 @@
     height: 100%;
   }
 
+  /* Smooth-scroll for #module-… and other in-page anchors. Honors the
+     user's reduced-motion preference automatically (browsers disable
+     this rule when prefers-reduced-motion is on). */
+  html {
+    scroll-behavior: smooth;
+  }
+  @media (prefers-reduced-motion: reduce) {
+    html {
+      scroll-behavior: auto;
+    }
+  }
+
   /* Default to the design system surface + font. Individual components can
      opt out by overriding `font-mono` or `bg-surface-subtle` etc. */
   body {

--- a/src/pages/PropertyDetail.tsx
+++ b/src/pages/PropertyDetail.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react'
 import { useParams, useNavigate, Link } from 'react-router-dom'
 import { ChevronDown, ExternalLink } from 'lucide-react'
 import { useAuth } from '../hooks/useAuth'
+import { useCountUp } from '../hooks/useCountUp'
 import Button from '../components/ui/Button'
 import { Badge, type BadgeProps } from '../components/ui/Badge'
 import { Card, CardHeader, CardTitle, CardDescription } from '../components/ui/Card'
@@ -82,6 +83,10 @@ export default function PropertyDetailPage() {
   const [enriching, setEnriching] = useState(false)
   const [enrichMsg, setEnrichMsg] = useState<string | null>(null)
   const [reassessing, setReassessing] = useState(false)
+
+  // Phase E — risk score tweens 300ms on each re-assessment so the user
+  // sees the number move rather than snap.
+  const animatedRiskScore = useCountUp(property?.risk_score ?? null)
 
   useEffect(() => {
     async function load() {
@@ -513,7 +518,7 @@ export default function PropertyDetailPage() {
                           Risk score
                         </p>
                         <p className="font-mono text-3xl font-semibold tabular-nums text-fg leading-none mt-1">
-                          {property.risk_score ?? 0}
+                          {Math.round(animatedRiskScore)}
                         </p>
                       </div>
                       <Badge variant={riskVariant(property.risk_score ?? 0)}>

--- a/src/pages/accounts/AccountDetail.tsx
+++ b/src/pages/accounts/AccountDetail.tsx
@@ -37,6 +37,7 @@ import {
   SidebarSection,
 } from '../../components/layout/Sidebar'
 import { cn } from '../../lib/cn'
+import { useCountUp } from '../../hooks/useCountUp'
 import type { Account, Client } from '../../types'
 
 // Phase 3.6 — Account Overview shape returned by /api/accounts/[id]/overview
@@ -468,9 +469,14 @@ function StatCard({
   label: string
   value: number | string | null | undefined
 }) {
+  // Numeric values count up from 0 → final on first hydrate (and tween
+  // between any subsequent updates). Non-numeric stays static — strings
+  // can't be interpolated.
+  const numeric = typeof value === 'number' ? value : null
+  const animated = useCountUp(numeric)
   const display =
-    typeof value === 'number'
-      ? value.toLocaleString()
+    numeric != null
+      ? Math.round(animated).toLocaleString()
       : value && String(value).length > 0
         ? value
         : '—'

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -102,6 +102,20 @@ export default {
       ringColor: {
         DEFAULT: 'var(--color-ring)',
       },
+
+      // Phase E — page-route transition. AppShell re-keys <main> on
+      // pathname change so this animation replays. Tailwind's motion-safe:
+      // variant pairs with prefers-reduced-motion to skip the animation
+      // when the user has requested less motion.
+      keyframes: {
+        'page-fade-in': {
+          '0%': { opacity: '0', transform: 'translateY(2px)' },
+          '100%': { opacity: '1', transform: 'translateY(0)' },
+        },
+      },
+      animation: {
+        'page-fade-in': 'page-fade-in 150ms ease-out',
+      },
     },
   },
   plugins: [


### PR DESCRIPTION
## Summary

The polish layer of the design refresh. Tightens the small-but-visible details that separate "looks fine" from "looks polished". **No new pages. No behavioral changes.**

### What's in

| Polish item | Where it lands |
|---|---|
| **Page transitions** | `AppShell`'s `<main>` re-keys on pathname → 150ms ease-out `page-fade-in` keyframe defined in tailwind.config.js. Hash changes don't trigger it. `motion-safe:` variant respects prefers-reduced-motion. |
| **Smooth scroll** | `scroll-behavior: smooth` on `<html>` with reduced-motion override. Affects the dashboard's sidebar `#module-…` links + any other in-page anchors. |
| **ErrorState component** | New `src/components/ui/ErrorState.tsx` — Card-style destructive-variant container shape-matched to `EmptyState`. Optional retry button. |
| **Retry plumbed into async panels** | `ComparablesPanel` + `ServiceMixPanel` now bump a `retryNonce` that re-fires the fetch when "Try again" is clicked. |
| **useCountUp hook** | New `src/hooks/useCountUp.ts` — subtle 300ms ease-out cubic tween. Honors prefers-reduced-motion. Applied to Account Overview StatCard (stats count up from 0 on `/overview` arrival) and Property Detail risk score (tweens on re-assessment). |

### Out of scope (intentionally deferred)

- **Global loading bar at top of page** — needs broad fetch-state plumbing across every page fetch. Each page has its own loading state today; centralizing into one bar is a separate, larger PR.
- **Empty-state coverage audit** — most surfaces already have `EmptyState` or short inline text where a full EmptyState would feel oversize. Worth a walk-through later.
- **Skeleton coverage audit** — heavy pages already use `Skeleton`; the remaining spinners live inside the deferred D2 follow-up panels (ScenarioPanel, CostAssumptionsPanel, 7 chart components).
- **Number animation on AnalysisHeaderMeta** — dashboard numerics load once and rarely tween between updates, so juice doesn't justify squeeze.

### Files

- `src/components/ui/ErrorState.tsx` (new)
- `src/hooks/useCountUp.ts` (new)
- `src/components/layout/AppShell.tsx`
- `src/components/analysis/ComparablesPanel.tsx`
- `src/components/analysis/ServiceMixPanel.tsx`
- `src/index.css`
- `src/pages/PropertyDetail.tsx`
- `src/pages/accounts/AccountDetail.tsx`
- `tailwind.config.js`

9 files, +214 / -21.

## What I verified

- [x] `npx tsc --noEmit` passes silently
- [x] `vite build` succeeds (CSS bundle steady)

## Test plan — please verify locally

- [ ] Navigate between `/accounts/[JLL]` → `/accounts/[JLL]/clients/[Property-Reserve]/analysis` → `/properties/[id]`. Each page fades in over ~150ms. Quick enough to feel snappy, not jarring.
- [ ] Click a module name in the dashboard sidebar (e.g. Branch Optimization) → page scrolls smoothly to the anchor (not a snap jump).
- [ ] Open `chrome://settings/accessibility` → enable "Reduce motion" → reload. Page transitions skip; smooth scroll falls back to instant.
- [ ] Visit Account Overview when `/overview` is slow (DevTools throttling) → stat cards arrive at "—" then count up from 0 when data lands.
- [ ] Property Detail → click "Re-assess" → risk score number tweens up/down to the new value over 300ms.
- [ ] Property Detail with a deliberately-failing comparables fetch → ErrorState card shows with retry button. Click retry → fetch re-fires and the panel reverts to loading skeleton then to data.
- [ ] Toggle theme → all the new states (page-fade, ErrorState card, count-up numbers) read polished in both.

## Phase status — design refresh substantially complete

A through E all shipped. Remaining work is the deferred D2 follow-ups (chart internals + scenario/constraints panels + Modal-to-Dialog migrations) and any specific polish items the design walkthrough flags. Happy to pick those up next on demand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)