### PR TITLE
Design — global navigation + remaining page coverage

### DIFF
--- a/src/components/layout/TopBar.tsx
+++ b/src/components/layout/TopBar.tsx
@@ -8,8 +8,19 @@
 // The hamburger only appears on screens < md and toggles the sidebar
 // drawer. On desktop the sidebar is always docked, so no hamburger.
 import { useEffect, useState } from 'react'
-import { Link, useNavigate } from 'react-router-dom'
-import { ChevronRight, LogOut, Menu, Settings, User } from 'lucide-react'
+import { Link, useLocation, useNavigate } from 'react-router-dom'
+import {
+  ChevronRight,
+  LogOut,
+  Map as MapIcon,
+  Menu,
+  Settings,
+  Shield,
+  Upload,
+  User,
+  Users,
+} from 'lucide-react'
+import type { LucideIcon } from 'lucide-react'
 import ThemeToggle from '../ui/ThemeToggle'
 import {
   DropdownMenu,
@@ -21,6 +32,35 @@ import {
 } from '../ui/DropdownMenu'
 import { cn } from '../../lib/cn'
 import { supabase } from '../../lib/supabase/client'
+
+// Primary nav. Order matches the legacy Navbar so muscle memory still works.
+// `match` decides active state — most pages need a startsWith check so e.g.
+// /accounts/JLL/clients/.../analysis still highlights the Accounts tab.
+const PRIMARY_NAV: Array<{
+  label: string
+  to: string
+  icon: LucideIcon
+  match: (pathname: string) => boolean
+}> = [
+  {
+    label: 'Map',
+    to: '/map',
+    icon: MapIcon,
+    match: (p) => p === '/map' || p.startsWith('/properties/'),
+  },
+  {
+    label: 'Accounts',
+    to: '/accounts',
+    icon: Users,
+    match: (p) => p.startsWith('/accounts') || p.startsWith('/clients'),
+  },
+  {
+    label: 'Upload',
+    to: '/upload',
+    icon: Upload,
+    match: (p) => p === '/upload' || p.startsWith('/upload/') || p.startsWith('/uploads/'),
+  },
+]
 
 export interface BreadcrumbItem {
   label: React.ReactNode
@@ -35,6 +75,8 @@ export interface TopBarProps {
 }
 
 export default function TopBar({ breadcrumb, onMobileMenuClick }: TopBarProps) {
+  const { pathname } = useLocation()
+
   return (
     <header
       className={cn(
@@ -62,13 +104,48 @@ export default function TopBar({ breadcrumb, onMobileMenuClick }: TopBarProps) {
         className="flex items-center gap-2 text-sm font-semibold tracking-tight text-fg shrink-0"
       >
         <LogoMark />
-        <span>PortfolioIQ</span>
+        <span className="hidden sm:inline">PortfolioIQ</span>
       </Link>
+
+      {/* Primary nav. Hidden on tiny screens; the hamburger drawer covers
+          mobile when the page exposes a sidebar, otherwise mobile users
+          drop back to the nav inside the user menu. */}
+      <nav aria-label="Primary" className="hidden md:flex items-center gap-0.5">
+        {PRIMARY_NAV.map((item) => {
+          const Icon = item.icon
+          const active = item.match(pathname)
+          return (
+            <Link
+              key={item.to}
+              to={item.to}
+              aria-current={active ? 'page' : undefined}
+              className={cn(
+                'inline-flex h-8 items-center gap-1.5 rounded-md px-2.5 text-sm font-medium',
+                'transition-colors duration-150',
+                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent',
+                active
+                  ? 'bg-surface-muted text-fg'
+                  : 'text-fg-muted hover:text-fg hover:bg-surface-muted'
+              )}
+            >
+              <Icon
+                className={cn(
+                  'h-3.5 w-3.5',
+                  active ? 'text-accent' : 'text-fg-subtle'
+                )}
+                strokeWidth={1.75}
+                aria-hidden
+              />
+              {item.label}
+            </Link>
+          )
+        })}
+      </nav>
 
       {breadcrumb && breadcrumb.length > 0 && (
         <nav
           aria-label="Breadcrumb"
-          className="hidden sm:flex items-center gap-1.5 text-sm text-fg-muted min-w-0"
+          className="hidden lg:flex items-center gap-1.5 text-sm text-fg-muted min-w-0"
         >
           <span className="text-fg-subtle" aria-hidden>
             <ChevronRight className="h-3.5 w-3.5" />
@@ -188,6 +265,13 @@ function UserMenu() {
           <span className="ml-auto text-[10px] text-fg-subtle uppercase">
             Soon
           </span>
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem onSelect={() => navigate('/admin')}>
+          <Shield className="h-4 w-4" /> Admin
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={() => navigate('/admin/uploads')}>
+          <Upload className="h-4 w-4" /> Upload batches
         </DropdownMenuItem>
         <DropdownMenuSeparator />
         <DropdownMenuItem onSelect={() => navigate('/logout')}>

--- a/src/pages/Portfolio.tsx
+++ b/src/pages/Portfolio.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import { useAuth } from '../hooks/useAuth'
-import Navbar from '../components/ui/Navbar'
+import AppShell from '../components/layout/AppShell'
 import Button from '../components/ui/Button'
 import PortfolioStats from '../components/portfolio/PortfolioStats'
 import ShareLinkModal from '../components/portfolio/ShareLinkModal'
@@ -42,27 +42,23 @@ export default function PortfolioPage() {
 
   if (loading) {
     return (
-      <div className="flex flex-col h-full">
-        <Navbar />
-        <div className="flex-1 flex items-center justify-center text-gray-500">Loading...</div>
-      </div>
+      <AppShell>
+        <div className="flex h-full items-center justify-center text-fg-subtle">Loading…</div>
+      </AppShell>
     )
   }
 
   if (!portfolio) {
     return (
-      <div className="flex flex-col h-full">
-        <Navbar />
-        <div className="flex-1 flex items-center justify-center text-gray-500">Portfolio not found.</div>
-      </div>
+      <AppShell>
+        <div className="flex h-full items-center justify-center text-fg-subtle">Portfolio not found.</div>
+      </AppShell>
     )
   }
 
   return (
-    <div className="flex flex-col h-full bg-gray-50">
-      <Navbar />
-      <div className="flex-1 overflow-y-auto">
-        <div className="max-w-5xl mx-auto px-6 py-8 space-y-6">
+    <AppShell breadcrumb={[{ label: 'Portfolios' }, { label: portfolio.name }]}>
+      <div className="mx-auto max-w-5xl px-6 py-10 space-y-6">
           <div className="flex items-start justify-between">
             <div>
               <h1 className="text-2xl font-bold text-gray-900">{portfolio.name}</h1>
@@ -113,7 +109,6 @@ export default function PortfolioPage() {
               )}
             </div>
           </div>
-        </div>
       </div>
 
       <ShareLinkModal
@@ -122,6 +117,6 @@ export default function PortfolioPage() {
         portfolioId={portfolioId!}
         existingToken={portfolio.share_token}
       />
-    </div>
+    </AppShell>
   )
 }

--- a/src/pages/ServiceLocation.tsx
+++ b/src/pages/ServiceLocation.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import { useAuth } from '../hooks/useAuth'
-import Navbar from '../components/ui/Navbar'
+import AppShell from '../components/layout/AppShell'
 import Button from '../components/ui/Button'
 import type { ServiceLocation, Property, PropertyChange } from '../types'
 import { STATUS_LABELS, STATUS_COLORS } from '../lib/constants'
@@ -98,31 +98,23 @@ export default function ServiceLocationPage() {
 
   if (loading) {
     return (
-      <div className="flex flex-col h-full">
-        <Navbar />
-        <div className="flex-1 flex items-center justify-center">
-          <div className="text-gray-500">Loading...</div>
-        </div>
-      </div>
+      <AppShell>
+        <div className="flex h-full items-center justify-center text-fg-subtle">Loading…</div>
+      </AppShell>
     )
   }
 
   if (!location || !property) {
     return (
-      <div className="flex flex-col h-full">
-        <Navbar />
-        <div className="flex-1 flex items-center justify-center">
-          <div className="text-gray-500">Location not found.</div>
-        </div>
-      </div>
+      <AppShell>
+        <div className="flex h-full items-center justify-center text-fg-subtle">Location not found.</div>
+      </AppShell>
     )
   }
 
   return (
-    <div className="flex flex-col h-full bg-gray-50">
-      <Navbar />
-      <div className="flex-1 overflow-y-auto">
-        <div className="max-w-4xl mx-auto px-6 py-8 space-y-6">
+    <AppShell breadcrumb={[{ label: 'Map', to: '/map' }, { label: property?.address_line1 ?? 'Service location' }]}>
+      <div className="mx-auto max-w-4xl px-6 py-10 space-y-6">
           {/* Header */}
           <div className="flex items-center justify-between">
             <div>
@@ -276,9 +268,8 @@ export default function ServiceLocationPage() {
               </div>
             </div>
           )}
-        </div>
       </div>
-    </div>
+    </AppShell>
   )
 }
 

--- a/src/pages/Upload.tsx
+++ b/src/pages/Upload.tsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom'
 import { useAuth } from '../hooks/useAuth'
 import { useClient } from '../context/ClientContext'
 import { apiFetch } from '../lib/api'
-import Navbar from '../components/ui/Navbar'
+import AppShell from '../components/layout/AppShell'
 import UploadDropzone from '../components/upload/UploadDropzone'
 import SheetMappingStep from '../components/upload/SheetMappingStep'
 import ColumnMappingStep from '../components/upload/ColumnMappingStep'
@@ -298,11 +298,11 @@ export default function UploadPage() {
   const stepIndex = STEP_LABELS.indexOf(step)
 
   return (
-    <div className="flex flex-col h-full bg-gray-50">
-      <Navbar />
-      <div className="flex-1 overflow-y-auto">
-        <div className="max-w-4xl mx-auto px-6 py-8">
-          <h1 className="text-2xl font-bold text-gray-900 mb-6">Upload Service Locations</h1>
+    <AppShell breadcrumb={[{ label: 'Upload' }]}>
+      <div className="mx-auto max-w-4xl px-6 py-10">
+        <h1 className="mb-6 text-2xl font-semibold tracking-tight text-fg">
+          Upload service locations
+        </h1>
 
           {/* Step indicator */}
           <div className="flex items-center gap-1 mb-8 overflow-x-auto pb-1">
@@ -525,8 +525,7 @@ export default function UploadPage() {
               getToken={getToken}
             />
           )}
-        </div>
       </div>
-    </div>
+    </AppShell>
   )
 }

--- a/src/pages/UploadReview.tsx
+++ b/src/pages/UploadReview.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import { useAuth } from '../hooks/useAuth'
-import Navbar from '../components/ui/Navbar'
+import AppShell from '../components/layout/AppShell'
 import Button from '../components/ui/Button'
 import type { StagedAddress, ScrubSummary, ValidatedAddress } from '../types'
 
@@ -164,23 +164,21 @@ export default function UploadReview() {
 
   if (loading) {
     return (
-      <div className="flex flex-col h-full bg-gray-50">
-        <Navbar />
-        <div className="flex-1 flex items-center justify-center">
-          <div className="text-gray-500">Loading review data…</div>
+      <AppShell>
+        <div className="flex h-full items-center justify-center text-fg-subtle">
+          Loading review data…
         </div>
-      </div>
+      </AppShell>
     )
   }
 
   if (error && !state) {
     return (
-      <div className="flex flex-col h-full bg-gray-50">
-        <Navbar />
-        <div className="flex-1 flex items-center justify-center">
-          <div className="text-red-600">{error}</div>
+      <AppShell>
+        <div className="flex h-full items-center justify-center text-danger">
+          {error}
         </div>
-      </div>
+      </AppShell>
     )
   }
 
@@ -198,11 +196,9 @@ export default function UploadReview() {
   ]
 
   return (
-    <div className="flex flex-col h-full bg-gray-50">
-      <Navbar />
-      <div className="flex-1 overflow-y-auto">
-        <div className="max-w-5xl mx-auto px-6 py-8">
-          <h1 className="text-2xl font-bold text-gray-900 mb-2">Address Review</h1>
+    <AppShell breadcrumb={[{ label: 'Upload', to: '/upload' }, { label: 'Review' }]}>
+      <div className="mx-auto max-w-5xl px-6 py-10">
+        <h1 className="mb-2 text-2xl font-semibold tracking-tight text-fg">Address review</h1>
           <p className="text-gray-500 mb-6 text-sm">
             Review and approve scrubbed addresses before starting geocoding enrichment.
           </p>
@@ -516,9 +512,8 @@ export default function UploadReview() {
               Proceed to enrichment
             </Button>
           </div>
-        </div>
       </div>
-    </div>
+    </AppShell>
   )
 }
 

--- a/src/pages/UploadSummary.tsx
+++ b/src/pages/UploadSummary.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import { useParams, Link } from 'react-router-dom'
 import { useAuth } from '../hooks/useAuth'
-import Navbar from '../components/ui/Navbar'
+import AppShell from '../components/layout/AppShell'
 import type { UploadSummaryStats } from '../types'
 
 interface SummaryData {
@@ -57,10 +57,8 @@ export default function UploadSummaryPage() {
   }, [batchId, getToken])
 
   return (
-    <div className="flex flex-col h-full bg-gray-50">
-      <Navbar />
-      <div className="flex-1 overflow-y-auto">
-        <div className="max-w-3xl mx-auto px-6 py-8">
+    <AppShell breadcrumb={[{ label: 'Upload', to: '/upload' }, { label: 'Summary' }]}>
+      <div className="mx-auto max-w-3xl px-6 py-10">
           {loading && (
             <div className="flex items-center gap-3 text-gray-500">
               <div className="w-5 h-5 border-2 border-blue-600 border-t-transparent rounded-full animate-spin" />
@@ -196,9 +194,8 @@ export default function UploadSummaryPage() {
               </div>
             </div>
           )}
-        </div>
       </div>
-    </div>
+    </AppShell>
   )
 }
 

--- a/src/pages/accounts/AccountsList.tsx
+++ b/src/pages/accounts/AccountsList.tsx
@@ -1,13 +1,25 @@
 import { useState, useEffect } from 'react'
 import { Link } from 'react-router-dom'
+import { Search, Users } from 'lucide-react'
 import { useAuth } from '../../hooks/useAuth'
-import Navbar from '../../components/ui/Navbar'
+import AppShell from '../../components/layout/AppShell'
+import Button from '../../components/ui/Button'
+import { Badge } from '../../components/ui/Badge'
+import { Card } from '../../components/ui/Card'
+import { EmptyState } from '../../components/ui/EmptyState'
+import { ErrorState } from '../../components/ui/ErrorState'
+import { Input } from '../../components/ui/Input'
+import { Skeleton } from '../../components/ui/Skeleton'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '../../components/ui/Table'
 import type { Account } from '../../types'
 
-const TYPE_BADGE: Record<string, string> = {
-  self_managed: 'bg-blue-100 text-blue-700',
-  property_manager: 'bg-purple-100 text-purple-700',
-}
 const TYPE_LABEL: Record<string, string> = {
   self_managed: 'Self-Managed',
   property_manager: 'Property Manager',
@@ -50,7 +62,9 @@ export default function AccountsListPage() {
           setError(
             isTimeout
               ? 'Request timed out — the server is taking too long to respond.'
-              : err instanceof Error ? err.message : 'Failed to load accounts'
+              : err instanceof Error
+                ? err.message
+                : 'Failed to load accounts'
           )
         }
       } finally {
@@ -69,97 +83,131 @@ export default function AccountsListPage() {
   }, [search, getToken, retryCount])
 
   return (
-    <div className="flex flex-col h-full bg-gray-50">
-      <Navbar />
-      <div className="flex-1 overflow-y-auto">
-        <div className="max-w-6xl mx-auto px-6 py-8">
-          <div className="flex items-center justify-between mb-6">
-            <h1 className="text-2xl font-bold text-gray-900">Accounts</h1>
-            <Link
-              to="/accounts/new"
-              className="px-4 py-2 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 transition-colors"
-            >
-              + New Account
-            </Link>
+    <AppShell breadcrumb={[{ label: 'Accounts' }]}>
+      <div className="mx-auto max-w-6xl px-6 py-10 space-y-8">
+        <header className="flex items-start justify-between gap-6 flex-wrap">
+          <div className="space-y-1">
+            <h1 className="text-2xl font-semibold tracking-tight text-fg">
+              Accounts
+            </h1>
+            <p className="text-sm text-fg-muted">
+              {accounts.length > 0 && (
+                <>
+                  <span className="font-tabular">{accounts.length}</span>{' '}
+                  {accounts.length === 1 ? 'account' : 'accounts'}
+                </>
+              )}
+            </p>
           </div>
+          <Button asChild>
+            <Link to="/accounts/new">+ New account</Link>
+          </Button>
+        </header>
 
-          <div className="flex gap-3 mb-6">
-            <input
-              type="text"
-              placeholder="Search by name…"
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-              className="flex-1 max-w-xs border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-            />
-          </div>
-
-          <div className="bg-white rounded-xl shadow-sm border overflow-hidden">
-            {loading ? (
-              <div className="flex items-center justify-center py-16 text-gray-400 text-sm">Loading…</div>
-            ) : error ? (
-              <div className="flex flex-col items-center justify-center py-16 gap-3">
-                <p className="text-red-600 text-sm">{error}</p>
-                <button
-                  onClick={() => setRetryCount((c) => c + 1)}
-                  className="text-blue-600 text-sm hover:underline"
-                >
-                  Retry
-                </button>
-              </div>
-            ) : accounts.length === 0 ? (
-              <div className="flex flex-col items-center justify-center py-16 gap-3">
-                <p className="text-gray-500">No accounts yet — create your first account</p>
-                <Link to="/accounts/new" className="text-blue-600 text-sm hover:underline">
-                  Create your first account →
-                </Link>
-              </div>
-            ) : (
-              <table className="w-full text-sm">
-                <thead>
-                  <tr className="border-b bg-gray-50">
-                    <th className="text-left px-4 py-3 font-semibold text-gray-600">Name</th>
-                    <th className="text-left px-4 py-3 font-semibold text-gray-600">Type</th>
-                    <th className="text-left px-4 py-3 font-semibold text-gray-600">Status</th>
-                    <th className="text-left px-4 py-3 font-semibold text-gray-600">Contact</th>
-                    <th className="text-left px-4 py-3 font-semibold text-gray-600">Actions</th>
-                  </tr>
-                </thead>
-                <tbody className="divide-y">
-                  {accounts.map((a) => (
-                    <tr key={a.id} className="hover:bg-gray-50 transition-colors">
-                      <td className="px-4 py-3">
-                        <Link to={`/accounts/${a.id}`} className="font-medium text-gray-900 hover:text-blue-600">
-                          {a.display_name ?? a.name}
-                        </Link>
-                        {a.display_name && <p className="text-xs text-gray-400">{a.name}</p>}
-                      </td>
-                      <td className="px-4 py-3">
-                        <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${TYPE_BADGE[a.account_type] ?? 'bg-gray-100 text-gray-500'}`}>
-                          {TYPE_LABEL[a.account_type] ?? a.account_type}
-                        </span>
-                      </td>
-                      <td className="px-4 py-3">
-                        <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${a.status === 'active' ? 'bg-green-100 text-green-700' : 'bg-gray-100 text-gray-500'}`}>
-                          {a.status}
-                        </span>
-                      </td>
-                      <td className="px-4 py-3 text-gray-500 text-xs">
-                        {a.primary_contact_name ?? '—'}
-                        {a.primary_contact_email && <div>{a.primary_contact_email}</div>}
-                      </td>
-                      <td className="px-4 py-3">
-                        <Link to={`/accounts/${a.id}`} className="text-blue-600 hover:underline text-xs">
-                          View
-                        </Link>
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            )}
-          </div>
+        <div className="relative max-w-sm">
+          <Search
+            className="absolute left-3 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-fg-subtle pointer-events-none"
+            aria-hidden
+          />
+          <Input
+            type="search"
+            placeholder="Search accounts…"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="pl-8"
+          />
         </div>
+
+        {loading ? (
+          <Card padding="none">
+            <div className="space-y-2 p-6">
+              <Skeleton className="h-9" />
+              <Skeleton className="h-9" />
+              <Skeleton className="h-9" />
+            </div>
+          </Card>
+        ) : error ? (
+          <ErrorState
+            title="Couldn't load accounts"
+            description={error}
+            onRetry={() => setRetryCount((c) => c + 1)}
+          />
+        ) : accounts.length === 0 ? (
+          <Card padding="none">
+            <EmptyState
+              icon={Users}
+              title={search ? 'No accounts match your search' : 'No accounts yet'}
+              description={
+                search
+                  ? 'Try a different search term, or clear the filter.'
+                  : 'Create your first account to start managing portfolios.'
+              }
+              action={
+                !search && (
+                  <Button asChild>
+                    <Link to="/accounts/new">Create your first account →</Link>
+                  </Button>
+                )
+              }
+            />
+          </Card>
+        ) : (
+          <Card padding="none">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Name</TableHead>
+                  <TableHead>Type</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Contact</TableHead>
+                  <TableHead className="w-16" />
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {accounts.map((a) => (
+                  <TableRow key={a.id}>
+                    <TableCell>
+                      <Link
+                        to={`/accounts/${a.id}`}
+                        className="font-medium text-fg hover:text-accent transition-colors"
+                      >
+                        {a.display_name ?? a.name}
+                      </Link>
+                      {a.display_name && (
+                        <p className="text-xs text-fg-subtle">{a.name}</p>
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant={a.account_type === 'property_manager' ? 'accent' : 'default'}>
+                        {TYPE_LABEL[a.account_type] ?? a.account_type}
+                      </Badge>
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant={a.status === 'active' ? 'success' : 'default'}>
+                        {a.status}
+                      </Badge>
+                    </TableCell>
+                    <TableCell className="text-xs text-fg-muted">
+                      {a.primary_contact_name ?? '—'}
+                      {a.primary_contact_email && (
+                        <div className="text-fg-subtle">{a.primary_contact_email}</div>
+                      )}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <Link
+                        to={`/accounts/${a.id}`}
+                        className="text-xs text-accent hover:underline"
+                      >
+                        View →
+                      </Link>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </Card>
+        )}
       </div>
-    </div>
+    </AppShell>
   )
 }

--- a/src/pages/accounts/NewAccount.tsx
+++ b/src/pages/accounts/NewAccount.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { useNavigate, Link } from 'react-router-dom'
 import { useAuth } from '../../hooks/useAuth'
-import Navbar from '../../components/ui/Navbar'
+import AppShell from '../../components/layout/AppShell'
 import Button from '../../components/ui/Button'
 
 type AccountType = 'self_managed' | 'property_manager'
@@ -62,10 +62,8 @@ export default function NewAccountPage() {
   }
 
   return (
-    <div className="flex flex-col h-full bg-gray-50">
-      <Navbar />
-      <div className="flex-1 overflow-y-auto">
-        <div className="max-w-2xl mx-auto px-6 py-8">
+    <AppShell breadcrumb={[{ label: 'Accounts', to: '/accounts' }, { label: 'New' }]}>
+      <div className="mx-auto max-w-2xl px-6 py-10">
           <div className="flex items-center gap-3 mb-6">
             <Link to="/accounts" className="text-gray-400 hover:text-gray-600 text-sm">← Accounts</Link>
             <h1 className="text-2xl font-bold text-gray-900">New Account</h1>
@@ -210,8 +208,7 @@ export default function NewAccountPage() {
               </div>
             </form>
           )}
-        </div>
       </div>
-    </div>
+    </AppShell>
   )
 }

--- a/src/pages/accounts/NewAccountClient.tsx
+++ b/src/pages/accounts/NewAccountClient.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react'
 import { useParams, useNavigate, Link } from 'react-router-dom'
 import { useAuth } from '../../hooks/useAuth'
-import Navbar from '../../components/ui/Navbar'
+import AppShell from '../../components/layout/AppShell'
 import Button from '../../components/ui/Button'
 import type { Account } from '../../types'
 
@@ -75,23 +75,23 @@ export default function NewAccountClientPage() {
   }
 
   if (loadingAccount) return (
-    <div className="flex flex-col h-full bg-gray-50"><Navbar />
-      <div className="flex-1 flex items-center justify-center text-gray-400">Loading…</div>
-    </div>
+    <AppShell>
+      <div className="flex h-full items-center justify-center text-fg-subtle">Loading…</div>
+    </AppShell>
   )
 
   return (
-    <div className="flex flex-col h-full bg-gray-50">
-      <Navbar />
-      <div className="flex-1 overflow-y-auto">
-        <div className="max-w-2xl mx-auto px-6 py-8">
-          <div className="flex items-center gap-2 mb-6 text-sm">
-            <Link to="/accounts" className="text-gray-400 hover:text-gray-600">Accounts</Link>
-            <span className="text-gray-300">›</span>
-            <Link to={`/accounts/${id}`} className="text-gray-400 hover:text-gray-600">{account?.display_name ?? account?.name ?? id}</Link>
-            <span className="text-gray-300">›</span>
-            <h1 className="text-2xl font-bold text-gray-900">New Client</h1>
-          </div>
+    <AppShell
+      breadcrumb={[
+        { label: 'Accounts', to: '/accounts' },
+        { label: account?.display_name ?? account?.name ?? id, to: `/accounts/${id}` },
+        { label: 'New client' },
+      ]}
+    >
+      <div className="mx-auto max-w-2xl px-6 py-10">
+        <h1 className="mb-6 text-2xl font-semibold tracking-tight text-fg">
+          New client
+        </h1>
 
           <form onSubmit={handleSubmit} className="bg-white rounded-xl shadow-sm border p-6 space-y-5">
             {error && <div className="p-3 bg-red-50 border border-red-200 rounded-lg text-red-700 text-sm">{error}</div>}
@@ -137,8 +137,7 @@ export default function NewAccountClientPage() {
               <Button type="submit" loading={saving}>Create Client</Button>
             </div>
           </form>
-        </div>
       </div>
-    </div>
+    </AppShell>
   )
 }

--- a/src/pages/admin/AdminHub.tsx
+++ b/src/pages/admin/AdminHub.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef } from 'react'
 import { Link } from 'react-router-dom'
 import { useAuth } from '../../hooks/useAuth'
-import Navbar from '../../components/ui/Navbar'
+import AppShell from '../../components/layout/AppShell'
 import Button from '../../components/ui/Button'
 
 interface EnrichmentStats {
@@ -97,10 +97,8 @@ export default function AdminHubPage() {
   const isRunning = enrichState.status === 'running'
 
   return (
-    <div className="flex flex-col h-full bg-gray-50">
-      <Navbar />
-      <div className="flex-1 overflow-y-auto">
-        <div className="max-w-4xl mx-auto px-6 py-8 space-y-6">
+    <AppShell breadcrumb={[{ label: 'Admin' }]}>
+      <div className="mx-auto max-w-4xl px-6 py-10 space-y-6">
           <div className="flex items-center gap-3 mb-2">
             <Link to="/map" className="text-gray-400 hover:text-gray-600 text-sm">← Map</Link>
             <h1 className="text-2xl font-bold text-gray-900">Admin</h1>
@@ -213,8 +211,7 @@ export default function AdminHubPage() {
               <li><Link to="/admin/parcels/fallbacks" className="text-blue-600 hover:underline">Parcel Fallbacks</Link></li>
             </ul>
           </div>
-        </div>
       </div>
-    </div>
+    </AppShell>
   )
 }

--- a/src/pages/admin/Dangerous.tsx
+++ b/src/pages/admin/Dangerous.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { Link } from 'react-router-dom'
 import { useAuth } from '../../hooks/useAuth'
-import Navbar from '../../components/ui/Navbar'
+import AppShell from '../../components/layout/AppShell'
 import Button from '../../components/ui/Button'
 
 const RESET_PHRASE = 'delete all data'
@@ -40,10 +40,8 @@ export default function DangerousAdminPage() {
   }
 
   return (
-    <div className="flex flex-col h-full bg-gray-50">
-      <Navbar />
-      <div className="flex-1 overflow-y-auto">
-        <div className="max-w-2xl mx-auto px-6 py-8 space-y-6">
+    <AppShell breadcrumb={[{ label: 'Admin', to: '/admin' }, { label: 'Dangerous' }]}>
+      <div className="mx-auto max-w-2xl px-6 py-10 space-y-6">
           <div className="flex items-center gap-3 mb-2">
             <Link to="/admin" className="text-gray-400 hover:text-gray-600 text-sm">← Admin</Link>
             <h1 className="text-2xl font-bold text-gray-900">Admin — Dangerous Actions</h1>
@@ -103,8 +101,7 @@ export default function DangerousAdminPage() {
               <li><Link to="/admin/parcels/fallbacks" className="text-blue-600 hover:underline">Parcel Fallbacks</Link></li>
             </ul>
           </div>
-        </div>
       </div>
-    </div>
+    </AppShell>
   )
 }

--- a/src/pages/admin/Uploads.tsx
+++ b/src/pages/admin/Uploads.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { useAuth } from '../../hooks/useAuth'
-import Navbar from '../../components/ui/Navbar'
+import AppShell from '../../components/layout/AppShell'
 import Button from '../../components/ui/Button'
 import Modal from '../../components/ui/Modal'
 
@@ -233,10 +233,8 @@ export default function AdminUploadsPage() {
   }
 
   return (
-    <div className="flex flex-col h-full bg-gray-50">
-      <Navbar />
-      <div className="flex-1 overflow-y-auto">
-        <div className="max-w-7xl mx-auto px-6 py-8 space-y-6">
+    <AppShell breadcrumb={[{ label: 'Admin', to: '/admin' }, { label: 'Upload batches' }]}>
+      <div className="mx-auto max-w-7xl px-6 py-10 space-y-6">
           <div className="flex items-center gap-3 mb-2">
             <Link to="/admin" className="text-gray-400 hover:text-gray-600 text-sm">← Admin</Link>
             <h1 className="text-2xl font-bold text-gray-900">Admin — Upload Batches</h1>
@@ -307,7 +305,6 @@ export default function AdminUploadsPage() {
               </div>
             </div>
           )}
-        </div>
       </div>
 
       <Modal
@@ -336,6 +333,6 @@ export default function AdminUploadsPage() {
           </div>
         )}
       </Modal>
-    </div>
+    </AppShell>
   )
 }

--- a/src/pages/clients/ClientDetail.tsx
+++ b/src/pages/clients/ClientDetail.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react'
 import { useParams, Link, useNavigate } from 'react-router-dom'
 import { useAuth } from '../../hooks/useAuth'
-import Navbar from '../../components/ui/Navbar'
+import AppShell from '../../components/layout/AppShell'
 import Button from '../../components/ui/Button'
 import { useClient } from '../../context/ClientContext'
 import type { Client } from '../../types'
@@ -120,34 +120,30 @@ export default function ClientDetailPage() {
 
   if (loading) {
     return (
-      <div className="flex flex-col h-full bg-gray-50">
-        <Navbar />
-        <div className="flex-1 flex items-center justify-center text-gray-400">Loading…</div>
-      </div>
+      <AppShell>
+        <div className="flex h-full items-center justify-center text-fg-subtle">Loading…</div>
+      </AppShell>
     )
   }
 
   if (!client) {
     return (
-      <div className="flex flex-col h-full bg-gray-50">
-        <Navbar />
-        <div className="flex-1 flex items-center justify-center">
-          <div className="text-center space-y-3">
-            <p className="text-gray-500">Client not found.</p>
-            <Link to="/clients" className="text-blue-600 text-sm hover:underline">← Back to clients</Link>
+      <AppShell>
+        <div className="flex h-full items-center justify-center">
+          <div className="space-y-3 text-center">
+            <p className="text-fg-muted">Client not found.</p>
+            <Link to="/clients" className="text-sm text-accent hover:underline">← Back to clients</Link>
           </div>
         </div>
-      </div>
+      </AppShell>
     )
   }
 
   const clientColor = client.brand_color ?? hashColor(client.id)
 
   return (
-    <div className="flex flex-col h-full bg-gray-50">
-      <Navbar />
-      <div className="flex-1 overflow-y-auto">
-        <div className="max-w-4xl mx-auto px-6 py-8 space-y-6">
+    <AppShell breadcrumb={[{ label: 'Clients', to: '/clients' }, { label: client.display_name ?? client.name }]}>
+      <div className="mx-auto max-w-4xl px-6 py-10 space-y-6">
           {error && (
             <div className="p-3 bg-red-50 border border-red-200 rounded-lg text-red-700 text-sm">{error}</div>
           )}
@@ -319,7 +315,6 @@ export default function ClientDetailPage() {
             )}
           </div>
         </div>
-      </div>
 
       {/* Edit modal */}
       {editing && (
@@ -380,7 +375,7 @@ export default function ClientDetailPage() {
           </div>
         </div>
       )}
-    </div>
+    </AppShell>
   )
 }
 

--- a/src/pages/clients/ClientSetup.tsx
+++ b/src/pages/clients/ClientSetup.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef } from 'react'
 import { useParams, useNavigate, Link } from 'react-router-dom'
 import { useAuth } from '../../hooks/useAuth'
-import Navbar from '../../components/ui/Navbar'
+import AppShell from '../../components/layout/AppShell'
 import Button from '../../components/ui/Button'
 import Papa from 'papaparse'
 import * as XLSX from 'xlsx'
@@ -272,18 +272,16 @@ export default function ClientSetupPage() {
   const STEP_LABELS = ['Service Offerings', 'Custom Fields', 'Upload Template', 'Validate Template', 'Done']
 
   if (loading) return (
-    <div className="flex flex-col h-full bg-gray-50"><Navbar />
-      <div className="flex-1 flex items-center justify-center text-gray-400">Loading…</div>
-    </div>
+    <AppShell>
+      <div className="flex h-full items-center justify-center text-fg-subtle">Loading…</div>
+    </AppShell>
   )
 
   const clientName = client?.display_name ?? client?.name ?? '…'
 
   return (
-    <div className="flex flex-col h-full bg-gray-50">
-      <Navbar />
-      <div className="flex-1 overflow-y-auto">
-        <div className="max-w-3xl mx-auto px-6 py-8 space-y-6">
+    <AppShell breadcrumb={[{ label: 'Clients', to: '/clients' }, { label: clientName, to: `/clients/${id}` }, { label: 'Setup' }]}>
+      <div className="mx-auto max-w-3xl px-6 py-10 space-y-6">
           {/* Breadcrumb */}
           <div className="flex items-center gap-2 text-sm text-gray-400">
             <Link to="/accounts" className="hover:text-gray-600">Accounts</Link>
@@ -680,8 +678,7 @@ export default function ClientSetupPage() {
               </div>
             </div>
           )}
-        </div>
       </div>
-    </div>
+    </AppShell>
   )
 }

--- a/src/pages/clients/ClientsList.tsx
+++ b/src/pages/clients/ClientsList.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react'
 import { Link } from 'react-router-dom'
 import { useAuth } from '../../hooks/useAuth'
-import Navbar from '../../components/ui/Navbar'
+import AppShell from '../../components/layout/AppShell'
 import type { Client } from '../../types'
 
 const STATUS_BADGE: Record<string, string> = {
@@ -39,10 +39,8 @@ export default function ClientsListPage() {
   }, [statusFilter, search, getToken])
 
   return (
-    <div className="flex flex-col h-full bg-gray-50">
-      <Navbar />
-      <div className="flex-1 overflow-y-auto">
-        <div className="max-w-6xl mx-auto px-6 py-8">
+    <AppShell breadcrumb={[{ label: 'Clients' }]}>
+      <div className="mx-auto max-w-6xl px-6 py-10">
           <div className="flex items-center justify-between mb-6">
             <h1 className="text-2xl font-bold text-gray-900">Clients</h1>
             <Link
@@ -136,9 +134,8 @@ export default function ClientsListPage() {
               </table>
             )}
           </div>
-        </div>
       </div>
-    </div>
+    </AppShell>
   )
 }
 

--- a/src/pages/clients/NewClient.tsx
+++ b/src/pages/clients/NewClient.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { useNavigate, Link } from 'react-router-dom'
 import { useAuth } from '../../hooks/useAuth'
-import Navbar from '../../components/ui/Navbar'
+import AppShell from '../../components/layout/AppShell'
 import Button from '../../components/ui/Button'
 import { useClient } from '../../context/ClientContext'
 
@@ -57,10 +57,8 @@ export default function NewClientPage() {
   }
 
   return (
-    <div className="flex flex-col h-full bg-gray-50">
-      <Navbar />
-      <div className="flex-1 overflow-y-auto">
-        <div className="max-w-2xl mx-auto px-6 py-8">
+    <AppShell breadcrumb={[{ label: 'Clients', to: '/clients' }, { label: 'New' }]}>
+      <div className="mx-auto max-w-2xl px-6 py-10">
           <div className="flex items-center gap-3 mb-6">
             <Link to="/clients" className="text-gray-400 hover:text-gray-600 text-sm">← Clients</Link>
             <h1 className="text-2xl font-bold text-gray-900">New Client</h1>
@@ -176,8 +174,7 @@ export default function NewClientPage() {
               </Button>
             </div>
           </form>
-        </div>
       </div>
-    </div>
+    </AppShell>
   )
 }


### PR DESCRIPTION
## Summary

Two issues called out in review:

1. **Navigation was unreachable from pages without a contextual sidebar** (notably `/map`, where the left sidebar is the FilterSidebar). No way to get back to Accounts or Upload without manually editing the URL.
2. **Upload and Accounts pages still wore the legacy `<Navbar />`** — visual jarring when bouncing between migrated and unmigrated pages.

This PR fixes both.

### Global navigation in the TopBar

Added a primary nav strip between the logo and the breadcrumb:

```
[PortfolioIQ]  [Map]  [Accounts]  [Upload]   ›  Accounts › JLL    [theme] [user]
```

- Three tabs with lucide icons + active state. `match()` predicates handle nested routes — `/properties/abc` still highlights Map; `/clients/foo` still highlights Accounts; `/upload/123/review` still highlights Upload.
- Hidden on small screens (< md). Mobile users on a sidebar page get the hamburger drawer; mobile users without a sidebar fall back to the user-menu admin links (acceptable trade-off for now; a hamburger-on-no-sidebar variant is a future tweak).
- Logo label collapses to icon-only on `< sm` to make room.
- User menu dropdown picks up Admin + "Upload batches" entries so admin surfaces stay reachable.

### Page coverage — every page now uses AppShell

Migrated 15 pages off the legacy `<Navbar />`:

| Visual depth | Pages |
|---|---|
| **Full token + component migration** | `AccountsList` (search Input + Table + Badge + EmptyState + ErrorState + Skeleton) |
| **AppShell wrapper swap** | `Upload`, `UploadReview`, `UploadSummary`, `accounts/NewAccount`, `accounts/NewAccountClient`, `admin/AdminHub`, `admin/Dangerous`, `admin/Uploads`, `clients/ClientsList`, `clients/ClientDetail`, `clients/ClientSetup`, `clients/NewClient`, `Portfolio`, `ServiceLocation` |

The wrapper-swap pages now wear the new TopBar (with nav links + breadcrumb + theme toggle + user menu), but their internal cards/forms keep their legacy `bg-white shadow-sm` styling for now. They all still work — they just don't yet match the design system internally. **A future polish PR** will sweep through the wizard, form, and admin internals.

After this PR, **zero pages import the legacy `<Navbar />`**. The component file itself stays on disk for one more PR; once preview branches all merge, it can be deleted.

### Files changed

16 files, +334 / -252:
- `src/components/layout/TopBar.tsx` — primary nav + admin entries in user menu
- `src/pages/accounts/AccountsList.tsx` — full redesign
- 13 other pages — AppShell wrapper swap

## What I verified

- [x] `npx tsc --noEmit` passes silently
- [x] `vite build` succeeds (CSS bundle 89.48 → 90.21 kB)
- [x] No `<Navbar />` references remain in `src/pages/`

## Test plan — please verify locally

- [ ] `npm run dev` → visit `/map`. The new TopBar shows **Map · Accounts · Upload** with Map highlighted (`bg-surface-muted`, accent icon). Click Accounts → navigates to `/accounts`. Click Upload → `/upload`.
- [ ] Visit `/properties/<id>` → Map tab still highlighted (matches the `/properties/*` rule).
- [ ] Visit `/clients/<id>` → Accounts tab highlighted.
- [ ] Toggle theme via TopBar → both light + dark read polished. Active-tab style remains legible in dark.
- [ ] Open the user-menu (avatar) → Admin + "Upload batches" entries route correctly.
- [ ] `/accounts` → new design: search input with magnifier glass, Table with sticky header, Badge for type/status, EmptyState when search returns nothing, ErrorState if `/v1/accounts` fails (devtools throttling makes this easy).
- [ ] `/upload`, `/clients`, `/admin`, `/admin/uploads`, etc. — they all show the new TopBar but the page bodies look legacy. That's expected; a follow-up PR polishes the internals.
- [ ] Resize to < md → primary nav hides; user menu still works; hamburger appears on pages with a sidebar.

## Related deferred work

- The deferred D2 follow-ups (chart components, ScenarioPanel slider details, CostAssumptionsPanel collapsible body, OperationalConstraintsPanel + BuildSelectionModal → Dialog migration) are still outstanding. Picking those up next.
- Visual deep-redesign of the migrated-but-still-legacy-internal pages (the 13 wrapper-swap entries above). Bundles well with the legacy `<Navbar />` file deletion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)