### PR TITLE
Hotfix: Accounts page crashes — Button asChild + Slot

### DIFF
--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -68,9 +68,30 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
     },
     ref
   ) => {
-    const Comp = asChild ? Slot : 'button'
+    // asChild renders through Radix's Slot, which calls React.Children.only
+    // on its rendered children. The pre-fix Button passed both
+    // `{loading && <Loader2/>}` and `{children}` — when loading is falsy,
+    // React.Children sees an array of [false, child] (length 2) and Slot
+    // throws "expected to receive a single React element child", which
+    // crashes any page that renders <Button asChild> unconditionally on
+    // first paint (e.g. AccountsList's "+ New account" button).
+    //
+    // asChild callers almost always wrap a Link or other non-spinning
+    // navigation element, so the spinner is meaningless on that path.
+    // Skip it entirely.
+    if (asChild) {
+      return (
+        <Slot
+          ref={ref}
+          className={cn(buttonVariants({ variant, size }), className)}
+          {...props}
+        >
+          {children}
+        </Slot>
+      )
+    }
     return (
-      <Comp
+      <button
         ref={ref}
         className={cn(buttonVariants({ variant, size }), className)}
         disabled={disabled || loading}
@@ -79,7 +100,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       >
         {loading && <Loader2 className="h-4 w-4 animate-spin" aria-hidden />}
         {children}
-      </Comp>
+      </button>
     )
   }
 )


### PR DESCRIPTION
## What broke

\`/accounts\` rendered nothing. The page mounts, React tries to render the header's \`<Button asChild>\`, Slot's \`React.Children.only()\` throws, error boundary catches it.

## Root cause

The Phase B \`Button\` always rendered:

\`\`\`tsx
<Comp ...>
  {loading && <Loader2 />}
  {children}
</Comp>
\`\`\`

When \`asChild=true\`, \`Comp\` is Radix's \`Slot\`. Slot calls \`React.Children.only()\` on its rendered children. With \`loading\` falsy, React still sees \`[false, child]\` of length 2 — Slot throws *"expected to receive a single React element child"* on first paint.

## Why it didn't show up earlier

\`AccountDetail\` and \`PropertyDetail\` both use \`<Button asChild>\` too, but inside conditional renders (\`{isPM && …}\` for the Add Client button on Account Detail; the not-found state for Property Detail). \`AccountsList\` renders one unconditionally in the header, so the crash hit immediately.

## Fix

Branch the render path. The \`asChild\` path goes through Slot with just the children — no spinner — since asChild callers almost always wrap a navigation \`<Link>\` and the loading state is meaningless on that path. The plain-button path is unchanged.

\`\`\`tsx
if (asChild) {
  return (
    <Slot ref={ref} className={...} {...props}>
      {children}
    </Slot>
  )
}
return (
  <button ref={ref} ... disabled={disabled || loading} aria-busy={loading || undefined}>
    {loading && <Loader2 .../>}
    {children}
  </button>
)
\`\`\`

## Verified

- \`npx tsc --noEmit\` clean
- \`vite build\` clean

## Test plan

- [ ] Visit \`/accounts\` → page renders. Header shows the \"+ New account\" button.
- [ ] Click \"+ New account\" → routes to \`/accounts/new\`.
- [ ] Visit \`/accounts/[JLL]\` (multi-client account) → \"+ Add client\" button still works in the header.
- [ ] Visit \`/properties/<bogus-id>\` → not-found EmptyState shows \"Back to map\" button that routes correctly.

## Related

The chart-component design migration I'm working on is on a separate branch (\`claude/design-charts-tokens\`). This is a focused hotfix because the user's accounts page is broken on production right now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)