### PR TITLE
Design: chart components on theme tokens

### DIFF
--- a/src/components/analysis/BidPricingChart.tsx
+++ b/src/components/analysis/BidPricingChart.tsx
@@ -1,4 +1,20 @@
-import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Cell } from 'recharts'
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  Cell,
+  CartesianGrid,
+} from 'recharts'
+import { Card } from '../ui/Card'
+import {
+  CHART_CATEGORICAL,
+  tickStyle,
+  tooltipStyle,
+  useChartTheme,
+} from '../../hooks/useChartTheme'
 
 interface BidOutputs {
   property_count: number
@@ -35,18 +51,6 @@ interface BidOutputs {
   }
 }
 
-const BUILDUP_COLOR: Record<string, string> = {
-  direct_labor: '#3b82f6',
-  vehicle_fuel: '#0891b2',
-  vehicle_lease: '#0284c7',
-  hotels: '#14b8a6',
-  supplies: '#84cc16',
-  branch_overhead: '#a855f7',
-  insurance: '#d946ef',
-  corporate_overhead: '#ec4899',
-  margin: '#16a34a',
-}
-
 const ROW_LABELS: Record<string, string> = {
   direct_labor: 'Direct labor',
   vehicle_fuel: 'Vehicle fuel',
@@ -60,6 +64,7 @@ const ROW_LABELS: Record<string, string> = {
 }
 
 export default function BidPricingChart({ data }: { data: BidOutputs }) {
+  const theme = useChartTheme()
   const buildupRows = [
     { key: 'direct_labor', value: data.cost_buildup.direct_labor },
     { key: 'vehicle_fuel', value: data.cost_buildup.vehicle_fuel },
@@ -73,116 +78,155 @@ export default function BidPricingChart({ data }: { data: BidOutputs }) {
   ].filter((r) => r.value > 0)
 
   return (
-    <div className="space-y-5">
-      {/* Headline bid number */}
-      <div className="bg-gradient-to-br from-green-50 via-emerald-50 to-teal-50 border-2 border-green-200 rounded-xl p-5">
-        <div className="text-xs font-semibold text-green-800 uppercase tracking-wide">
+    <div className="space-y-6">
+      {/* Headline bid number — quiet 1px-bordered card per design rules
+          (the legacy version used a green→teal gradient + 2px border which
+          shouted; we let the typography do the work instead). */}
+      <Card padding="md">
+        <p className="text-[10px] font-semibold uppercase tracking-wider text-fg-subtle">
           Recommended bid
+        </p>
+        <p className="mt-1 leading-none">
+          <span className="font-mono text-4xl font-semibold tabular-nums text-fg">
+            ${(data.bid_total / 1_000_000).toFixed(2)}M
+          </span>
+          <span className="ml-2 text-base text-fg-muted">/year</span>
+        </p>
+        <div className="mt-4 grid grid-cols-3 gap-4 text-sm">
+          <BidStat
+            label="Per property"
+            value={`$${data.bid_per_property.toLocaleString()}`}
+          />
+          <BidStat label="Per sqft" value={`$${data.bid_per_sqft.toFixed(2)}`} />
+          <BidStat
+            label="Monthly invoice"
+            value={`$${data.monthly_invoice_estimate.toLocaleString()}`}
+          />
         </div>
-        <div className="text-4xl font-bold text-gray-900 mt-1">
-          ${(data.bid_total / 1_000_000).toFixed(2)}M
-          <span className="text-base font-medium text-gray-500 ml-1">/year</span>
-        </div>
-        <div className="grid grid-cols-3 gap-3 mt-3 text-sm">
-          <div>
-            <div className="text-xs text-gray-500 uppercase tracking-wide">Per property</div>
-            <div className="font-semibold text-gray-900">
-              ${data.bid_per_property.toLocaleString()}
-            </div>
-          </div>
-          <div>
-            <div className="text-xs text-gray-500 uppercase tracking-wide">Per sqft</div>
-            <div className="font-semibold text-gray-900">
-              ${data.bid_per_sqft.toFixed(2)}
-            </div>
-          </div>
-          <div>
-            <div className="text-xs text-gray-500 uppercase tracking-wide">Monthly invoice</div>
-            <div className="font-semibold text-gray-900">
-              ${data.monthly_invoice_estimate.toLocaleString()}
-            </div>
-          </div>
-        </div>
-      </div>
+      </Card>
 
       {/* Cost buildup bars */}
-      <div>
-        <h4 className="text-sm font-semibold text-gray-700 mb-2">Cost buildup</h4>
+      <section className="space-y-2">
+        <h4 className="text-[10px] font-semibold uppercase tracking-wider text-fg-subtle">
+          Cost buildup
+        </h4>
         <div className="h-72 w-full">
           <ResponsiveContainer>
-            <BarChart data={buildupRows.map((r) => ({ ...r, name: ROW_LABELS[r.key] }))} layout="vertical" margin={{ left: 100 }}>
+            <BarChart
+              data={buildupRows.map((r) => ({ ...r, name: ROW_LABELS[r.key] }))}
+              layout="vertical"
+              margin={{ top: 4, right: 8, left: 100, bottom: 0 }}
+            >
+              <CartesianGrid stroke={theme.grid} strokeDasharray="3 3" horizontal={false} />
               <XAxis
                 type="number"
-                tick={{ fontSize: 11 }}
+                tick={tickStyle(theme)}
+                axisLine={{ stroke: theme.grid }}
+                tickLine={false}
                 tickFormatter={(v: number) => `$${(v / 1000).toFixed(0)}k`}
               />
-              <YAxis type="category" dataKey="name" tick={{ fontSize: 11 }} width={140} />
-              <Tooltip
-                formatter={(v: number) => [`$${v.toLocaleString()}`, 'Amount']}
-                contentStyle={{ fontSize: 12 }}
+              <YAxis
+                type="category"
+                dataKey="name"
+                tick={tickStyle(theme)}
+                axisLine={false}
+                tickLine={false}
+                width={140}
               />
-              <Bar dataKey="value">
-                {buildupRows.map((r, i) => (
-                  <Cell key={i} fill={BUILDUP_COLOR[r.key] ?? '#6b7280'} />
+              <Tooltip
+                cursor={{ fill: theme.grid, opacity: 0.4 }}
+                contentStyle={tooltipStyle(theme)}
+                formatter={(v: number) => [`$${v.toLocaleString()}`, 'Amount']}
+              />
+              <Bar dataKey="value" radius={[0, 2, 2, 0]}>
+                {buildupRows.map((_, i) => (
+                  <Cell key={i} fill={CHART_CATEGORICAL[i % CHART_CATEGORICAL.length]} />
                 ))}
               </Bar>
             </BarChart>
           </ResponsiveContainer>
         </div>
-      </div>
+      </section>
 
-      {/* Breakdown table */}
-      <div>
-        <h4 className="text-sm font-semibold text-gray-700 mb-2">Detailed breakdown</h4>
-        <table className="w-full text-sm">
-          <tbody>
-            {buildupRows.map((r) => (
-              <tr key={r.key} className="border-b last:border-0">
-                <td className="py-1.5 pr-4 text-gray-700">{ROW_LABELS[r.key]}</td>
-                <td className="py-1.5 text-right font-mono text-gray-900">
-                  ${r.value.toLocaleString()}
-                </td>
-              </tr>
-            ))}
-            <tr className="border-t-2">
-              <td className="py-2 pr-4 font-semibold text-gray-900">Total bid</td>
-              <td className="py-2 text-right font-mono font-bold text-gray-900">
-                ${data.bid_total.toLocaleString()}
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
+      {/* Detailed breakdown */}
+      <section className="space-y-2">
+        <h4 className="text-[10px] font-semibold uppercase tracking-wider text-fg-subtle">
+          Detailed breakdown
+        </h4>
+        <ul className="divide-y divide-border rounded-md border border-border bg-surface">
+          {buildupRows.map((r) => (
+            <li key={r.key} className="flex items-center justify-between px-4 py-2 text-sm">
+              <span className="text-fg-muted">{ROW_LABELS[r.key]}</span>
+              <span className="font-mono tabular-nums text-fg">
+                ${r.value.toLocaleString()}
+              </span>
+            </li>
+          ))}
+          <li className="flex items-center justify-between border-t-2 border-border-strong px-4 py-2.5 text-sm">
+            <span className="font-semibold text-fg">Total bid</span>
+            <span className="font-mono text-base font-semibold tabular-nums text-fg">
+              ${data.bid_total.toLocaleString()}
+            </span>
+          </li>
+        </ul>
+      </section>
 
       {/* Composition pct */}
-      <div>
-        <h4 className="text-sm font-semibold text-gray-700 mb-2">Bid composition</h4>
+      <section className="space-y-2">
+        <h4 className="text-[10px] font-semibold uppercase tracking-wider text-fg-subtle">
+          Bid composition
+        </h4>
         <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 text-sm">
-          <CompCard label="Labor" pct={data.cost_breakdown_pct.labor} color="#3b82f6" />
-          <CompCard label="Vehicle/fuel" pct={data.cost_breakdown_pct.vehicle} color="#0891b2" />
+          <CompCard label="Labor" pct={data.cost_breakdown_pct.labor} color={theme.accent} />
+          <CompCard
+            label="Vehicle / fuel"
+            pct={data.cost_breakdown_pct.vehicle}
+            color="#0891b2"
+          />
           <CompCard label="Overhead" pct={data.cost_breakdown_pct.overhead} color="#a855f7" />
-          <CompCard label="Margin" pct={data.cost_breakdown_pct.margin} color="#16a34a" />
+          <CompCard label="Margin" pct={data.cost_breakdown_pct.margin} color={theme.success} />
         </div>
-      </div>
+      </section>
 
       {data.sourced_from.crew_strategy_option && (
-        <div className="text-xs text-gray-500 italic border-t pt-2">
-          Labor sourced from Crew Strategy Option {data.sourced_from.crew_strategy_option} ·{' '}
-          {data.sourced_from.crew_count} crews ·{' '}
-          {data.sourced_from.branch_count} branches
-        </div>
+        <p className="border-t border-border pt-3 text-xs italic text-fg-subtle">
+          Labor sourced from Crew Strategy Option{' '}
+          <span className="font-mono not-italic">{data.sourced_from.crew_strategy_option}</span>{' '}
+          · <span className="font-tabular not-italic">{data.sourced_from.crew_count}</span> crews
+          · <span className="font-tabular not-italic">{data.sourced_from.branch_count}</span> branches
+        </p>
       )}
+    </div>
+  )
+}
+
+function BidStat({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <p className="text-[10px] font-semibold uppercase tracking-wider text-fg-subtle">
+        {label}
+      </p>
+      <p className="mt-0.5 font-mono text-base font-semibold tabular-nums text-fg">
+        {value}
+      </p>
     </div>
   )
 }
 
 function CompCard({ label, pct, color }: { label: string; pct: number; color: string }) {
   return (
-    <div className="border rounded-lg p-2.5">
-      <div className="text-xs text-gray-500 uppercase tracking-wide">{label}</div>
-      <div className="font-semibold text-gray-900 mt-0.5">{pct}%</div>
-      <div className="h-1.5 mt-1 rounded bg-gray-100 overflow-hidden">
-        <div className="h-full" style={{ width: `${Math.min(100, pct)}%`, background: color }} />
+    <div className="rounded-md border border-border bg-surface p-2.5">
+      <p className="text-[10px] font-semibold uppercase tracking-wider text-fg-subtle">
+        {label}
+      </p>
+      <p className="mt-0.5 font-mono text-base font-semibold tabular-nums text-fg">
+        {pct}%
+      </p>
+      <div className="mt-1.5 h-1 overflow-hidden rounded bg-surface-muted">
+        <div
+          className="h-full"
+          style={{ width: `${Math.min(100, pct)}%`, background: color }}
+        />
       </div>
     </div>
   )

--- a/src/components/analysis/BranchOptimizationChart.tsx
+++ b/src/components/analysis/BranchOptimizationChart.tsx
@@ -9,7 +9,21 @@ import {
   ResponsiveContainer,
   Cell,
   ReferenceLine,
+  CartesianGrid,
 } from 'recharts'
+import { ChevronDown } from 'lucide-react'
+import { Badge } from '../ui/Badge'
+import Button from '../ui/Button'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '../ui/Table'
+import { tickStyle, tooltipStyle, useChartTheme } from '../../hooks/useChartTheme'
+import { cn } from '../../lib/cn'
 
 interface KResult {
   k: number
@@ -59,13 +73,8 @@ interface BranchOptOutputs {
 }
 
 interface SelectionTableProps {
-  // Render the per-K selection table that lets the user pick which K to
-  // build a manual selection for. Optional — when omitted, the chart skips
-  // the table (e.g. when a selection is already locked in).
   onBuild?: (k: number) => void
   showTable?: boolean
-  // Phase 3.5 — show a banner with both the optimization's recommended K
-  // and the user's confirmed selection so it's obvious when they diverge.
   selectedK?: number | null
   selectedBranchNames?: string[] | null
 }
@@ -77,116 +86,162 @@ export default function BranchOptimizationChart({
   selectedK,
   selectedBranchNames,
 }: { data: BranchOptOutputs } & SelectionTableProps) {
+  const theme = useChartTheme()
   const recommended = data.k_results.find((r) => r.k === data.recommended_k)
 
-  // Phase 3.5 — surface optimization-recommended K vs user-selected K when
-  // they differ so the card stops looking "frozen" on the original
-  // recommendation after a manual selection.
   const recommendedBranchNames = recommended
-    ? recommended.branches.slice().sort((a, b) => b.property_count - a.property_count).map((b) => b.city_state)
+    ? recommended.branches
+        .slice()
+        .sort((a, b) => b.property_count - a.property_count)
+        .map((b) => b.city_state)
     : []
   const selectionDiffers =
     selectedK != null &&
     (selectedK !== data.recommended_k ||
-      (selectedBranchNames && selectedBranchNames.join('|') !== recommendedBranchNames.join('|')))
+      (selectedBranchNames &&
+        selectedBranchNames.join('|') !== recommendedBranchNames.join('|')))
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-6">
       {/* Recommended-vs-selected status banner */}
       {(selectedK != null || data.recommended_k > 0) && (
         <div
-          className={`rounded-lg border p-3 text-sm ${
+          className={cn(
+            'rounded-md border px-4 py-3 text-sm',
             selectionDiffers
-              ? 'bg-amber-50 border-amber-200'
-              : 'bg-blue-50 border-blue-200'
-          }`}
+              ? 'border-warning/20 bg-warning-subtle'
+              : 'border-accent/20 bg-accent-subtle'
+          )}
         >
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
             <div>
-              <div className="text-xs font-semibold text-gray-500 uppercase tracking-wide">
-                🟢 Optimization recommends
-              </div>
-              <div className="font-semibold text-gray-900">
-                K = {data.recommended_k}
-              </div>
+              <p className="text-[10px] font-semibold uppercase tracking-wider text-fg-subtle">
+                Optimization recommends
+              </p>
+              <p className="mt-0.5 font-semibold text-fg">
+                K = <span className="font-tabular">{data.recommended_k}</span>
+              </p>
               {recommendedBranchNames.length > 0 && (
-                <div className="text-xs text-gray-600 mt-0.5">
+                <p className="mt-0.5 text-xs text-fg-muted">
                   {recommendedBranchNames.join(' · ')}
-                </div>
+                </p>
               )}
             </div>
             {selectedK != null && (
               <div>
-                <div className="text-xs font-semibold text-gray-500 uppercase tracking-wide">
-                  🔵 You selected
-                </div>
-                <div className="font-semibold text-gray-900">K = {selectedK}</div>
+                <p className="text-[10px] font-semibold uppercase tracking-wider text-fg-subtle">
+                  You selected
+                </p>
+                <p className="mt-0.5 font-semibold text-fg">
+                  K = <span className="font-tabular">{selectedK}</span>
+                </p>
                 {selectedBranchNames?.length ? (
-                  <div className="text-xs text-gray-600 mt-0.5">
+                  <p className="mt-0.5 text-xs text-fg-muted">
                     {selectedBranchNames.join(' · ')}
-                  </div>
+                  </p>
                 ) : null}
               </div>
             )}
           </div>
           {selectionDiffers && (
-            <div className="mt-2 pt-2 border-t border-amber-200 text-xs text-amber-900">
-              Selection differs from current optimization recommendation. Re-run optimization
-              to refresh the recommendation, or update your selection if the new analysis
-              suggests a better fit.
-            </div>
+            <p className="mt-3 border-t border-warning/20 pt-2 text-xs text-warning">
+              Selection differs from current optimization recommendation. Re-run
+              optimization to refresh, or update your selection if the new
+              analysis suggests a better fit.
+            </p>
           )}
         </div>
       )}
 
-      <div>
-        <h4 className="text-sm font-semibold text-gray-700 mb-2">
-          Annual cost by branch count (k) · recommended k = {data.recommended_k}
+      <section className="space-y-2">
+        <h4 className="text-[10px] font-semibold uppercase tracking-wider text-fg-subtle">
+          Annual cost by branch count (k) · recommended k ={' '}
+          <span className="font-tabular">{data.recommended_k}</span>
         </h4>
         <div className="h-64 w-full">
           <ResponsiveContainer>
-            <ComposedChart data={data.k_results}>
-              <XAxis dataKey="k" tick={{ fontSize: 11 }} label={{ value: 'k (# branches)', position: 'insideBottom', offset: -2, fontSize: 11 }} />
+            <ComposedChart data={data.k_results} margin={{ top: 8, right: 8, left: -8, bottom: 8 }}>
+              <CartesianGrid stroke={theme.grid} strokeDasharray="3 3" vertical={false} />
+              <XAxis
+                dataKey="k"
+                tick={tickStyle(theme)}
+                axisLine={{ stroke: theme.grid }}
+                tickLine={false}
+                label={{
+                  value: 'k (# branches)',
+                  position: 'insideBottom',
+                  offset: -2,
+                  fontSize: 11,
+                  fill: theme.tick,
+                }}
+              />
               <YAxis
                 yAxisId="cost"
-                tick={{ fontSize: 11 }}
+                tick={tickStyle(theme)}
+                axisLine={false}
+                tickLine={false}
                 tickFormatter={(v: number) => `$${(v / 1000).toFixed(0)}k`}
               />
               <YAxis
                 yAxisId="drive"
                 orientation="right"
-                tick={{ fontSize: 11 }}
+                tick={tickStyle(theme)}
+                axisLine={false}
+                tickLine={false}
                 tickFormatter={(v: number) => `${v}mi`}
               />
               <Tooltip
+                cursor={{ fill: theme.grid, opacity: 0.4 }}
+                contentStyle={tooltipStyle(theme)}
                 formatter={(value: number, name: string) => {
-                  if (name === 'avg_drive_per_property') return [`${value.toFixed(1)} mi`, 'Avg drive/property']
+                  if (name === 'avg_drive_per_property')
+                    return [`${value.toFixed(1)} mi`, 'Avg drive/property']
                   return [`$${value.toLocaleString()}`, name]
                 }}
-                contentStyle={{ fontSize: 12 }}
               />
-              <Legend wrapperStyle={{ fontSize: 12 }} />
-              <ReferenceLine x={data.recommended_k} stroke="#16a34a" strokeDasharray="3 3" yAxisId="cost" />
+              <Legend wrapperStyle={{ fontSize: 12, color: theme.tick }} />
+              <ReferenceLine
+                x={data.recommended_k}
+                stroke={theme.success}
+                strokeDasharray="3 3"
+                yAxisId="cost"
+              />
               {data.floor_k && data.floor_k > 0 && (
                 <ReferenceLine
                   x={data.floor_k}
-                  stroke="#dc2626"
+                  stroke={theme.danger}
                   strokeDasharray="2 4"
                   yAxisId="cost"
-                  label={{ value: 'Floor (locked)', fontSize: 10, fill: '#dc2626' }}
+                  label={{
+                    value: 'Floor (locked)',
+                    fontSize: 10,
+                    fill: theme.danger,
+                  }}
                 />
               )}
-              <Bar yAxisId="cost" dataKey="drive_cost" stackId="a" fill="#3b82f6" name="Drive cost" />
-              <Bar yAxisId="cost" dataKey="branch_cost" stackId="a" fill="#a855f7" name="Branch cost">
+              <Bar
+                yAxisId="cost"
+                dataKey="drive_cost"
+                stackId="a"
+                fill={theme.accent}
+                name="Drive cost"
+              />
+              <Bar
+                yAxisId="cost"
+                dataKey="branch_cost"
+                stackId="a"
+                fill="#a855f7"
+                name="Branch cost"
+              >
                 {data.k_results.map((r, i) => (
-                  <Cell key={i} fill={r.is_elbow ? '#16a34a' : '#a855f7'} />
+                  <Cell key={i} fill={r.is_elbow ? theme.success : '#a855f7'} />
                 ))}
               </Bar>
               <Line
                 yAxisId="drive"
                 type="monotone"
                 dataKey="avg_drive_per_property"
-                stroke="#f97316"
+                stroke={theme.warning}
                 strokeWidth={2}
                 dot={{ r: 3 }}
                 name="Avg drive/property (mi)"
@@ -194,176 +249,187 @@ export default function BranchOptimizationChart({
             </ComposedChart>
           </ResponsiveContainer>
         </div>
-      </div>
+      </section>
 
       {recommended && (
-        <div>
-          <h4 className="text-sm font-semibold text-gray-700 mb-2">
+        <section className="space-y-2">
+          <h4 className="text-[10px] font-semibold uppercase tracking-wider text-fg-subtle">
             Recommended branches (k = {recommended.k})
           </h4>
-          <div className="overflow-x-auto">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="border-b text-left text-xs uppercase tracking-wide text-gray-500">
-                  <th className="py-2 pr-4">Location</th>
-                  <th className="py-2 pr-4 text-right">Population</th>
-                  <th className="py-2 pr-4 text-right">Properties</th>
-                  <th className="py-2 pr-4 text-right">Total sqft</th>
-                  <th className="py-2 pr-4 text-right">Avg drive (mi)</th>
-                  <th className="py-2 text-right">Max drive (mi)</th>
-                </tr>
-              </thead>
-              <tbody>
+          <div className="rounded-md border border-border bg-surface overflow-hidden">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Location</TableHead>
+                  <TableHead className="text-right">Population</TableHead>
+                  <TableHead className="text-right">Properties</TableHead>
+                  <TableHead className="text-right">Total sqft</TableHead>
+                  <TableHead className="text-right">Avg drive (mi)</TableHead>
+                  <TableHead className="text-right">Max drive (mi)</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
                 {recommended.branches
                   .slice()
                   .sort((a, b) => b.property_count - a.property_count)
                   .map((b, i) => (
-                    <tr key={i} className="border-b last:border-0">
-                      <td className="py-2 pr-4 font-medium text-gray-900">
-                        {b.city_state}
-                        {b.locked && (
-                          <span className="ml-2 text-xs px-1.5 py-0.5 rounded bg-blue-100 text-blue-700 align-middle">
-                            locked
-                          </span>
-                        )}
-                      </td>
-                      <td className="py-2 pr-4 text-right text-gray-600">
+                    <TableRow key={i}>
+                      <TableCell className="font-medium text-fg">
+                        <span className="inline-flex items-center gap-2">
+                          {b.city_state}
+                          {b.locked && <Badge variant="accent">locked</Badge>}
+                        </span>
+                      </TableCell>
+                      <TableCell numeric className="text-fg-muted">
                         {formatPop(b.population)}
-                      </td>
-                      <td className="py-2 pr-4 text-right">{b.property_count}</td>
-                      <td className="py-2 pr-4 text-right">{b.total_sqft.toLocaleString()}</td>
-                      <td className="py-2 pr-4 text-right">{b.avg_drive_distance_miles}</td>
-                      <td className="py-2 text-right">{b.max_drive_distance_miles}</td>
-                    </tr>
+                      </TableCell>
+                      <TableCell numeric>{b.property_count}</TableCell>
+                      <TableCell numeric>{b.total_sqft.toLocaleString()}</TableCell>
+                      <TableCell numeric>{b.avg_drive_distance_miles}</TableCell>
+                      <TableCell numeric>{b.max_drive_distance_miles}</TableCell>
+                    </TableRow>
                   ))}
-              </tbody>
-            </table>
+              </TableBody>
+            </Table>
           </div>
-        </div>
+        </section>
       )}
 
-      {/* Per-K selection table — drives the Branch Selection workflow */}
+      {/* Per-K selection table */}
       {showTable && onBuild && (
-        <div>
-          <h4 className="text-sm font-semibold text-gray-700 mb-1">
-            Pick a branch count to build your selection
-          </h4>
-          <p className="text-xs text-gray-500 mb-2">
-            Each row shows the modeled cost at K branches. Click a row's button to start
-            building your selection — you'll specify the actual locations manually.
-          </p>
-          <div className="overflow-x-auto">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="border-b text-left text-xs uppercase tracking-wide text-gray-500">
-                  <th className="py-2 pr-3">K</th>
-                  <th className="py-2 pr-3 text-right">Total $/yr</th>
-                  <th className="py-2 pr-3 text-right">Drive</th>
-                  <th className="py-2 pr-3 text-right">Branch</th>
-                  <th className="py-2 pr-3 text-right">Avg drive (mi)</th>
-                  <th className="py-2 pr-3">Optimization-suggested centroids</th>
-                  <th className="py-2 text-right"></th>
-                </tr>
-              </thead>
-              <tbody>
+        <section className="space-y-2">
+          <div>
+            <h4 className="text-[10px] font-semibold uppercase tracking-wider text-fg-subtle">
+              Pick a branch count to build your selection
+            </h4>
+            <p className="mt-1 text-xs text-fg-muted">
+              Each row shows the modeled cost at K branches. Click a row's button to
+              start building your selection — you'll specify the actual locations
+              manually.
+            </p>
+          </div>
+          <div className="rounded-md border border-border bg-surface overflow-hidden">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>K</TableHead>
+                  <TableHead className="text-right">Total $/yr</TableHead>
+                  <TableHead className="text-right">Drive</TableHead>
+                  <TableHead className="text-right">Branch</TableHead>
+                  <TableHead className="text-right">Avg drive (mi)</TableHead>
+                  <TableHead>Optimization-suggested centroids</TableHead>
+                  <TableHead className="text-right" />
+                </TableRow>
+              </TableHeader>
+              <TableBody>
                 {data.k_results.map((r) => {
                   const isRec = r.k === data.recommended_k
                   return (
-                    <tr
+                    <TableRow
                       key={r.k}
-                      className={`border-b last:border-0 ${
-                        isRec ? 'bg-green-50' : ''
-                      }`}
+                      className={isRec ? 'bg-success-subtle/40' : undefined}
                     >
-                      <td className="py-2 pr-3 font-mono font-semibold text-gray-900">
-                        {r.k}
-                        {isRec && (
-                          <span className="ml-1.5 text-xs px-1.5 py-0.5 rounded bg-green-100 text-green-700 align-middle">
-                            Recommended
-                          </span>
-                        )}
-                      </td>
-                      <td className="py-2 pr-3 text-right font-mono">
+                      <TableCell className="font-mono font-semibold text-fg">
+                        <span className="inline-flex items-center gap-1.5">
+                          {r.k}
+                          {isRec && <Badge variant="success">Recommended</Badge>}
+                        </span>
+                      </TableCell>
+                      <TableCell numeric className="text-fg">
                         ${r.total_annual_cost.toLocaleString()}
-                      </td>
-                      <td className="py-2 pr-3 text-right text-gray-500">
+                      </TableCell>
+                      <TableCell numeric className="text-fg-muted">
                         ${r.drive_cost.toLocaleString()}
-                      </td>
-                      <td className="py-2 pr-3 text-right text-gray-500">
+                      </TableCell>
+                      <TableCell numeric className="text-fg-muted">
                         ${r.branch_cost.toLocaleString()}
-                      </td>
-                      <td className="py-2 pr-3 text-right text-gray-500">
+                      </TableCell>
+                      <TableCell numeric className="text-fg-muted">
                         {r.avg_drive_per_property}
-                      </td>
-                      <td className="py-2 pr-3 text-xs text-gray-600">
+                      </TableCell>
+                      <TableCell className="text-xs text-fg-muted">
                         {r.branches.map((b) => b.city_state).join(' · ')}
-                      </td>
-                      <td className="py-2 text-right whitespace-nowrap">
-                        <button
-                          type="button"
-                          onClick={() => onBuild(r.k)}
-                          className="px-2.5 py-1 rounded-md text-xs font-medium bg-blue-600 text-white hover:bg-blue-700"
-                        >
-                          Build my K={r.k} selection →
-                        </button>
-                      </td>
-                    </tr>
+                      </TableCell>
+                      <TableCell className="text-right">
+                        <Button size="sm" onClick={() => onBuild(r.k)}>
+                          Build K={r.k} →
+                        </Button>
+                      </TableCell>
+                    </TableRow>
                   )
                 })}
-              </tbody>
-            </table>
+              </TableBody>
+            </Table>
           </div>
-        </div>
+        </section>
       )}
 
       {/* Population constraint info + unconstrained reference */}
       {data.population_constraint && (
-        <div className="border-t pt-3">
-          <div className="text-xs text-gray-600">
+        <section className="border-t border-border pt-4 space-y-2">
+          <p className="text-xs text-fg-muted">
             {data.population_constraint.enabled ? (
               <>
                 Population constraint:{' '}
-                <strong>min {data.population_constraint.min_population.toLocaleString()}</strong>
+                <span className="font-semibold text-fg">
+                  min{' '}
+                  <span className="font-tabular">
+                    {data.population_constraint.min_population.toLocaleString()}
+                  </span>
+                </span>
                 {data.population_constraint.state_filter?.length ? (
                   <> · states: {data.population_constraint.state_filter.join(', ')}</>
                 ) : null}
                 {' · '}
-                {data.population_constraint.eligible_city_count.toLocaleString()} eligible cities
-                in range
+                <span className="font-tabular">
+                  {data.population_constraint.eligible_city_count.toLocaleString()}
+                </span>{' '}
+                eligible cities in range
               </>
             ) : (
               <>Population constraint disabled — using unconstrained k-means.</>
             )}
-          </div>
+          </p>
 
           {data.unconstrained_reference && data.unconstrained_reference.length > 0 && (
-            <details className="mt-2 text-xs">
-              <summary className="cursor-pointer font-medium text-gray-700">
+            <details className="group">
+              <summary
+                className={cn(
+                  'flex cursor-pointer items-center gap-1.5 text-xs font-medium text-fg-muted',
+                  'hover:text-fg list-none [&::-webkit-details-marker]:hidden'
+                )}
+              >
+                <ChevronDown className="h-3.5 w-3.5 transition-transform group-open:rotate-0 -rotate-90" />
                 View unconstrained reference (what pure k-means would have suggested)
               </summary>
-              <div className="mt-2 space-y-2">
+              <ul className="mt-2 space-y-2">
                 {data.unconstrained_reference.map((u) => (
-                  <div key={u.k} className="border rounded p-2 bg-gray-50">
-                    <div className="font-mono text-gray-700">
-                      k={u.k} — drive cost ${u.total_drive_cost.toLocaleString()}
-                    </div>
-                    <div className="text-gray-600 mt-0.5">
+                  <li
+                    key={u.k}
+                    className="rounded-md border border-border bg-surface-subtle px-3 py-2"
+                  >
+                    <p className="font-mono text-xs text-fg">
+                      k=<span className="font-tabular">{u.k}</span> — drive cost
+                      ${u.total_drive_cost.toLocaleString()}
+                    </p>
+                    <p className="mt-0.5 text-xs text-fg-muted">
                       Centroids near:{' '}
                       {u.centroids
                         .map(
                           (c) =>
-                            `${c.nearest_city_unconstrained ?? `${c.lat.toFixed(2)},${c.lng.toFixed(2)}`}${
-                              c.population != null ? ` (${formatPop(c.population)})` : ''
-                            }`
+                            `${
+                              c.nearest_city_unconstrained ??
+                              `${c.lat.toFixed(2)},${c.lng.toFixed(2)}`
+                            }${c.population != null ? ` (${formatPop(c.population)})` : ''}`
                         )
                         .join(' · ')}
-                    </div>
-                  </div>
+                    </p>
+                  </li>
                 ))}
-              </div>
+              </ul>
             </details>
           )}
-        </div>
+        </section>
       )}
     </div>
   )

--- a/src/components/analysis/CrewStrategyChart.tsx
+++ b/src/components/analysis/CrewStrategyChart.tsx
@@ -1,4 +1,27 @@
-import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Cell, Legend } from 'recharts'
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  Cell,
+  Legend,
+  CartesianGrid,
+} from 'recharts'
+import { TriangleAlert } from 'lucide-react'
+import { Badge } from '../ui/Badge'
+import { Card } from '../ui/Card'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '../ui/Table'
+import { tickStyle, tooltipStyle, useChartTheme } from '../../hooks/useChartTheme'
+import { cn } from '../../lib/cn'
 
 type UtilStatus = 'ideal' | 'acceptable' | 'underutilized' | 'overcapacity'
 
@@ -76,17 +99,17 @@ interface CrewStrategyOutputs {
   }>
 }
 
-const STATUS_BADGE: Record<UtilStatus, string> = {
-  ideal: 'bg-green-100 text-green-700 border-green-200',
-  acceptable: 'bg-yellow-100 text-yellow-700 border-yellow-200',
-  underutilized: 'bg-red-100 text-red-700 border-red-200',
-  overcapacity: 'bg-red-100 text-red-700 border-red-200',
+const STATUS_VARIANT: Record<UtilStatus, 'success' | 'warning' | 'danger'> = {
+  ideal: 'success',
+  acceptable: 'warning',
+  underutilized: 'danger',
+  overcapacity: 'danger',
 }
 const STATUS_LABEL: Record<UtilStatus, string> = {
-  ideal: '🟢 Ideal',
-  acceptable: '🟡 Acceptable',
-  underutilized: '🔴 Underutilized',
-  overcapacity: '🔴 Overcapacity',
+  ideal: 'Ideal',
+  acceptable: 'Acceptable',
+  underutilized: 'Underutilized',
+  overcapacity: 'Overcapacity',
 }
 
 function formatPop(p: number | null | undefined): string {
@@ -96,13 +119,8 @@ function formatPop(p: number | null | undefined): string {
   return p.toString()
 }
 
-const RECOMMENDED_BG: Record<string, string> = {
-  A: 'border-blue-500 ring-1 ring-blue-200',
-  B: 'border-green-500 ring-1 ring-green-200',
-  C: 'border-purple-500 ring-1 ring-purple-200',
-}
-
 export default function CrewStrategyChart({ data }: { data: CrewStrategyOutputs }) {
+  const theme = useChartTheme()
   const opts = [
     { key: 'A' as const, ...data.options.A },
     { key: 'B' as const, ...data.options.B },
@@ -118,116 +136,110 @@ export default function CrewStrategyChart({ data }: { data: CrewStrategyOutputs 
   }))
 
   return (
-    <div className="space-y-5">
-      {/* Recommendation banner */}
-      <div className="bg-gradient-to-r from-blue-50 to-indigo-50 border border-blue-200 rounded-lg px-4 py-3">
-        <div className="text-sm text-gray-500 font-semibold uppercase tracking-wide">
+    <div className="space-y-6">
+      {/* Recommendation banner — quiet accent-subtle, no gradient. */}
+      <div className="rounded-md border border-accent/20 bg-accent-subtle px-4 py-3">
+        <p className="text-[10px] font-semibold uppercase tracking-wider text-fg-subtle">
           Recommended
-        </div>
-        <div className="text-lg font-bold text-gray-900 mt-0.5">
+        </p>
+        <p className="mt-0.5 text-base font-semibold text-fg">
           Option {data.recommended_option}: {data.options[data.recommended_option].label}
-        </div>
-        <div className="text-sm text-gray-700 mt-1">{data.recommended_rationale}</div>
+        </p>
+        <p className="mt-1 text-sm text-fg-muted">{data.recommended_rationale}</p>
       </div>
 
       {/* Cost comparison bar chart */}
-      <div>
-        <h4 className="text-sm font-semibold text-gray-700 mb-2">Annual cost comparison</h4>
+      <section className="space-y-2">
+        <h4 className="text-[10px] font-semibold uppercase tracking-wider text-fg-subtle">
+          Annual cost comparison
+        </h4>
         <div className="h-56 w-full">
           <ResponsiveContainer>
-            <BarChart data={chartData}>
-              <XAxis dataKey="name" tick={{ fontSize: 11 }} />
+            <BarChart data={chartData} margin={{ top: 8, right: 8, left: -8, bottom: 0 }}>
+              <CartesianGrid stroke={theme.grid} strokeDasharray="3 3" vertical={false} />
+              <XAxis
+                dataKey="name"
+                tick={tickStyle(theme)}
+                axisLine={{ stroke: theme.grid }}
+                tickLine={false}
+              />
               <YAxis
-                tick={{ fontSize: 11 }}
+                tick={tickStyle(theme)}
+                axisLine={false}
+                tickLine={false}
                 tickFormatter={(v: number) => `$${(v / 1000).toFixed(0)}k`}
               />
               <Tooltip
+                cursor={{ fill: theme.grid, opacity: 0.4 }}
+                contentStyle={tooltipStyle(theme)}
                 formatter={(v: number, name: string) => [`$${v.toLocaleString()}`, name]}
-                contentStyle={{ fontSize: 12 }}
               />
-              <Legend wrapperStyle={{ fontSize: 12 }} />
-              <Bar dataKey="labor" stackId="a" fill="#3b82f6" name="Labor" />
-              <Bar dataKey="vehicle" stackId="a" fill="#a855f7" name="Vehicle/fuel">
+              <Legend wrapperStyle={{ fontSize: 12, color: theme.tick }} />
+              <Bar dataKey="labor" stackId="a" fill={theme.accent} name="Labor" />
+              <Bar dataKey="vehicle" stackId="a" fill="#a855f7" name="Vehicle / fuel">
                 {chartData.map((d, i) => (
-                  <Cell key={i} fill={d.isRecommended ? '#16a34a' : '#a855f7'} />
+                  <Cell key={i} fill={d.isRecommended ? theme.success : '#a855f7'} />
                 ))}
               </Bar>
             </BarChart>
           </ResponsiveContainer>
         </div>
-      </div>
+      </section>
 
       {/* 3-card option comparison */}
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-3">
         {opts.map((o) => (
-          <div
+          <Card
             key={o.key}
-            className={`bg-white rounded-lg border-2 p-4 ${
-              o.key === data.recommended_option
-                ? RECOMMENDED_BG[o.key]
-                : 'border-gray-200'
-            }`}
+            padding="md"
+            className={
+              o.key === data.recommended_option ? 'ring-1 ring-accent' : undefined
+            }
           >
-            <div className="flex items-center justify-between mb-2">
+            <div className="flex items-start justify-between gap-2">
               <div>
-                <div className="text-xs font-semibold text-gray-500 uppercase tracking-wide">
+                <p className="text-[10px] font-semibold uppercase tracking-wider text-fg-subtle">
                   Option {o.key}
-                </div>
-                <div className="font-semibold text-gray-900">{o.label}</div>
+                </p>
+                <p className="mt-0.5 font-semibold text-fg">{o.label}</p>
               </div>
               {o.key === data.recommended_option && (
-                <span className="text-xs px-2 py-0.5 rounded bg-green-100 text-green-700">
-                  Recommended
-                </span>
+                <Badge variant="success">Recommended</Badge>
               )}
             </div>
 
-            <div className="grid grid-cols-2 gap-2 text-sm border-t border-b py-2 my-2">
-              <div>
-                <div className="text-xs text-gray-500">Crews</div>
-                <div className="font-semibold">
-                  {o.crew_count}
-                  {o.surge_crew_count ? ` + ${o.surge_crew_count} surge` : ''}
-                </div>
-              </div>
-              <div>
-                <div className="text-xs text-gray-500">Utilization</div>
-                <div className="font-semibold">{o.utilization_pct}%</div>
-              </div>
-              <div>
-                <div className="text-xs text-gray-500">Labor</div>
-                <div className="font-semibold">
+            <dl className="my-3 grid grid-cols-2 gap-3 border-y border-border py-3 text-sm">
+              <Stat label="Crews">
+                <span className="font-tabular">{o.crew_count}</span>
+                {o.surge_crew_count ? (
+                  <span className="text-fg-muted">
+                    {' + '}
+                    <span className="font-tabular">{o.surge_crew_count}</span> surge
+                  </span>
+                ) : null}
+              </Stat>
+              <Stat label="Utilization">
+                <span className="font-tabular">{o.utilization_pct}%</span>
+              </Stat>
+              <Stat label="Labor">
+                <span className="font-tabular">
                   ${(o.annual_labor_cost / 1000).toFixed(0)}k
-                </div>
-              </div>
-              <div>
-                <div className="text-xs text-gray-500">Total</div>
-                <div className="font-semibold">
+                </span>
+              </Stat>
+              <Stat label="Total">
+                <span className="font-tabular">
                   ${(o.total_annual_cost / 1000).toFixed(0)}k
-                </div>
-              </div>
-            </div>
+                </span>
+              </Stat>
+            </dl>
 
-            <div className="mt-2">
-              <div className="text-xs font-semibold text-gray-500 mb-1">Pros</div>
-              <ul className="text-xs space-y-0.5 text-gray-700 list-disc pl-4">
-                {o.pros.map((p, i) => (
-                  <li key={i}>{p}</li>
-                ))}
-              </ul>
-            </div>
-            <div className="mt-2">
-              <div className="text-xs font-semibold text-gray-500 mb-1">Cons</div>
-              <ul className="text-xs space-y-0.5 text-gray-700 list-disc pl-4">
-                {o.cons.map((p, i) => (
-                  <li key={i}>{p}</li>
-                ))}
-              </ul>
-            </div>
-            <div className="mt-2 pt-2 border-t text-xs italic text-gray-500">
+            <ProsCons label="Pros" items={o.pros} />
+            <ProsCons label="Cons" items={o.cons} className="mt-2" />
+
+            <p className="mt-3 border-t border-border pt-2 text-xs italic text-fg-subtle">
               Best for: {o.recommended_use_case}
-            </div>
-          </div>
+            </p>
+          </Card>
         ))}
       </div>
 
@@ -241,32 +253,83 @@ export default function CrewStrategyChart({ data }: { data: CrewStrategyOutputs 
 
       {/* Constraint violations */}
       {data.constraint_violations && data.constraint_violations.length > 0 && (
-        <div>
-          <h4 className="text-sm font-semibold text-gray-700 mb-2">⚠ Constraint violations</h4>
+        <section className="space-y-2">
+          <h4 className="flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-wider text-fg-subtle">
+            <TriangleAlert className="h-3.5 w-3.5 text-warning" aria-hidden />
+            Constraint violations
+          </h4>
           <ul className="space-y-2">
             {data.constraint_violations.map((v, i) => (
               <li
                 key={i}
-                className={`border-l-4 px-3 py-2 text-sm rounded-r ${
+                className={cn(
+                  'rounded-md border-l-2 px-3 py-2 text-sm',
                   v.severity === 'flag'
-                    ? 'border-red-400 bg-red-50'
-                    : 'border-orange-400 bg-orange-50'
-                }`}
+                    ? 'border-danger bg-danger-subtle'
+                    : 'border-warning bg-warning-subtle'
+                )}
               >
-                <div className="font-medium text-gray-900">
+                <p className="font-medium text-fg">
                   {v.scope === 'branch' ? '' : `${v.scope.toUpperCase()} `}
                   {v.name}
-                </div>
-                <div className="text-xs text-gray-700">
-                  {v.metric === 'utilization_pct' ? `${v.actual}% utilization` : v.actual} —{' '}
+                </p>
+                <p className="text-xs text-fg-muted">
+                  {v.metric === 'utilization_pct' ? (
+                    <>
+                      <span className="font-tabular">{v.actual}%</span> utilization
+                    </>
+                  ) : (
+                    <span className="font-tabular">{v.actual}</span>
+                  )}
+                  {' — '}
                   {v.threshold_violated.replace('_', ' ')}
-                </div>
-                <div className="text-xs text-gray-600 mt-0.5 italic">{v.suggestion}</div>
+                </p>
+                <p className="mt-0.5 text-xs italic text-fg-subtle">{v.suggestion}</p>
               </li>
             ))}
           </ul>
-        </div>
+        </section>
       )}
+    </div>
+  )
+}
+
+function Stat({
+  label,
+  children,
+}: {
+  label: string
+  children: React.ReactNode
+}) {
+  return (
+    <div>
+      <dt className="text-[10px] font-semibold uppercase tracking-wider text-fg-subtle">
+        {label}
+      </dt>
+      <dd className="mt-0.5 font-semibold text-fg">{children}</dd>
+    </div>
+  )
+}
+
+function ProsCons({
+  label,
+  items,
+  className,
+}: {
+  label: string
+  items: string[]
+  className?: string
+}) {
+  return (
+    <div className={className}>
+      <p className="mb-1 text-[10px] font-semibold uppercase tracking-wider text-fg-subtle">
+        {label}
+      </p>
+      <ul className="list-disc space-y-0.5 pl-4 text-xs text-fg">
+        {items.map((p, i) => (
+          <li key={i}>{p}</li>
+        ))}
+      </ul>
     </div>
   )
 }
@@ -283,123 +346,132 @@ function UtilizationSection({
 
   if (scope === 'portfolio' && ub.portfolio) {
     return (
-      <div>
-        <h4 className="text-sm font-semibold text-gray-700 mb-2">
+      <section className="space-y-2">
+        <h4 className="text-[10px] font-semibold uppercase tracking-wider text-fg-subtle">
           Portfolio utilization (Option B)
         </h4>
-        <div className="border rounded-lg p-3 flex items-center justify-between gap-4">
+        <Card padding="md" className="flex items-center justify-between gap-4">
           <div>
-            <div className="text-2xl font-bold text-gray-900">
+            <p className="font-mono text-2xl font-semibold tabular-nums text-fg leading-none">
               {ub.portfolio.utilization_pct}%
-            </div>
-            <div className="text-xs text-gray-500">
-              {ub.portfolio.work_hours.toLocaleString()} work hrs ÷{' '}
-              {ub.portfolio.available_hours.toLocaleString()} available · {ub.portfolio.crew_count} crews
-            </div>
+            </p>
+            <p className="mt-1 text-xs text-fg-muted">
+              <span className="font-tabular">
+                {ub.portfolio.work_hours.toLocaleString()}
+              </span>{' '}
+              work hrs ÷{' '}
+              <span className="font-tabular">
+                {ub.portfolio.available_hours.toLocaleString()}
+              </span>{' '}
+              available ·{' '}
+              <span className="font-tabular">{ub.portfolio.crew_count}</span> crews
+            </p>
           </div>
-          <span
-            className={`text-xs px-2.5 py-1 rounded border font-medium ${STATUS_BADGE[ub.portfolio.status]}`}
-          >
+          <Badge variant={STATUS_VARIANT[ub.portfolio.status]}>
             {STATUS_LABEL[ub.portfolio.status]}
-          </span>
-        </div>
-      </div>
+          </Badge>
+        </Card>
+      </section>
     )
   }
 
   if (scope === 'per_region' && ub.per_region && ub.per_region.length > 0) {
     return (
-      <div>
-        <h4 className="text-sm font-semibold text-gray-700 mb-2">
+      <section className="space-y-2">
+        <h4 className="text-[10px] font-semibold uppercase tracking-wider text-fg-subtle">
           Per-region utilization (Option B)
         </h4>
-        <table className="w-full text-sm">
-          <thead>
-            <tr className="border-b text-left text-xs uppercase tracking-wide text-gray-500">
-              <th className="py-2 pr-4">Region</th>
-              <th className="py-2 pr-4">Branches</th>
-              <th className="py-2 pr-4 text-right">Work hrs</th>
-              <th className="py-2 pr-4 text-right">Available</th>
-              <th className="py-2 pr-4 text-right">Util</th>
-              <th className="py-2 text-right">Status</th>
-            </tr>
-          </thead>
-          <tbody>
-            {ub.per_region.map((r) => (
-              <tr key={r.region} className="border-b last:border-0">
-                <td className="py-2 pr-4 font-medium text-gray-900">{r.region}</td>
-                <td className="py-2 pr-4 text-xs text-gray-600">
-                  {r.branches_in_region.join(', ')}
-                </td>
-                <td className="py-2 pr-4 text-right">{r.work_hours.toLocaleString()}</td>
-                <td className="py-2 pr-4 text-right">{r.available_hours.toLocaleString()}</td>
-                <td className="py-2 pr-4 text-right">{r.aggregate_utilization_pct}%</td>
-                <td className="py-2 text-right">
-                  <span
-                    className={`text-xs px-2 py-0.5 rounded border ${STATUS_BADGE[r.status]}`}
-                  >
-                    {STATUS_LABEL[r.status]}
-                  </span>
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
+        <div className="rounded-md border border-border bg-surface overflow-hidden">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Region</TableHead>
+                <TableHead>Branches</TableHead>
+                <TableHead className="text-right">Work hrs</TableHead>
+                <TableHead className="text-right">Available</TableHead>
+                <TableHead className="text-right">Util</TableHead>
+                <TableHead>Status</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {ub.per_region.map((r) => (
+                <TableRow key={r.region}>
+                  <TableCell className="font-medium text-fg">{r.region}</TableCell>
+                  <TableCell className="text-xs text-fg-muted">
+                    {r.branches_in_region.join(', ')}
+                  </TableCell>
+                  <TableCell numeric>{r.work_hours.toLocaleString()}</TableCell>
+                  <TableCell numeric>{r.available_hours.toLocaleString()}</TableCell>
+                  <TableCell numeric>{r.aggregate_utilization_pct}%</TableCell>
+                  <TableCell>
+                    <Badge variant={STATUS_VARIANT[r.status]}>{STATUS_LABEL[r.status]}</Badge>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      </section>
     )
   }
 
   // per_branch (default)
   if (!ub.per_branch || ub.per_branch.length === 0) return null
   return (
-    <div>
-      <h4 className="text-sm font-semibold text-gray-700 mb-2">
+    <section className="space-y-2">
+      <h4 className="text-[10px] font-semibold uppercase tracking-wider text-fg-subtle">
         Per-branch utilization (Option B)
       </h4>
-      <div className="overflow-x-auto">
-        <table className="w-full text-sm">
-          <thead>
-            <tr className="border-b text-left text-xs uppercase tracking-wide text-gray-500">
-              <th className="py-2 pr-3">Branch</th>
-              <th className="py-2 pr-3 text-right">Pop</th>
-              <th className="py-2 pr-3 text-right">Crews</th>
-              <th className="py-2 pr-3 text-right">Work hrs</th>
-              <th className="py-2 pr-3 text-right">Available</th>
-              <th className="py-2 pr-3 text-right">Util</th>
-              <th className="py-2 text-right">Status</th>
-            </tr>
-          </thead>
-          <tbody>
+      <div className="rounded-md border border-border bg-surface overflow-hidden">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Branch</TableHead>
+              <TableHead className="text-right">Pop</TableHead>
+              <TableHead className="text-right">Crews</TableHead>
+              <TableHead className="text-right">Work hrs</TableHead>
+              <TableHead className="text-right">Available</TableHead>
+              <TableHead className="text-right">Util</TableHead>
+              <TableHead>Status</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
             {ub.per_branch.map((b) => (
-              <tr key={b.branch_name} className="border-b last:border-0 align-top">
-                <td className="py-2 pr-3 font-medium text-gray-900">
+              <TableRow key={b.branch_name} className="align-top">
+                <TableCell className="font-medium text-fg">
                   {b.city_state ?? b.branch_name}
-                  {b.branch_name && b.city_state && b.branch_name !== b.city_state && (
-                    <div className="text-xs text-gray-400 font-normal italic">
-                      {b.branch_name}
-                    </div>
-                  )}
-                </td>
-                <td className="py-2 pr-3 text-right text-gray-600">{formatPop(b.population)}</td>
-                <td className="py-2 pr-3 text-right">{b.crew_count}</td>
-                <td className="py-2 pr-3 text-right">{b.work_hours.toLocaleString()}</td>
-                <td className="py-2 pr-3 text-right text-gray-500">
+                  {b.branch_name &&
+                    b.city_state &&
+                    b.branch_name !== b.city_state && (
+                      <p className="mt-0.5 text-xs italic text-fg-subtle">
+                        {b.branch_name}
+                      </p>
+                    )}
+                </TableCell>
+                <TableCell numeric className="text-fg-muted">
+                  {formatPop(b.population)}
+                </TableCell>
+                <TableCell numeric>{b.crew_count}</TableCell>
+                <TableCell numeric>{b.work_hours.toLocaleString()}</TableCell>
+                <TableCell numeric className="text-fg-muted">
                   {b.available_hours.toLocaleString()}
-                </td>
-                <td className="py-2 pr-3 text-right font-semibold">{b.utilization_pct}%</td>
-                <td className="py-2 text-right">
-                  <span className={`text-xs px-2 py-0.5 rounded border ${STATUS_BADGE[b.status]}`}>
-                    {STATUS_LABEL[b.status]}
-                  </span>
+                </TableCell>
+                <TableCell numeric className="font-semibold">
+                  {b.utilization_pct}%
+                </TableCell>
+                <TableCell>
+                  <Badge variant={STATUS_VARIANT[b.status]}>{STATUS_LABEL[b.status]}</Badge>
                   {b.warning && (
-                    <div className="text-xs text-gray-500 mt-1 italic max-w-xs">{b.warning}</div>
+                    <p className="mt-1 max-w-xs text-xs italic text-fg-subtle">
+                      {b.warning}
+                    </p>
                   )}
-                </td>
-              </tr>
+                </TableCell>
+              </TableRow>
             ))}
-          </tbody>
-        </table>
+          </TableBody>
+        </Table>
       </div>
-    </div>
+    </section>
   )
 }

--- a/src/components/analysis/DriveTimeChart.tsx
+++ b/src/components/analysis/DriveTimeChart.tsx
@@ -1,4 +1,23 @@
-import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Cell } from 'recharts'
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  Cell,
+  CartesianGrid,
+} from 'recharts'
+import { Badge } from '../ui/Badge'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '../ui/Table'
+import { tickStyle, tooltipStyle, useChartTheme } from '../../hooks/useChartTheme'
 
 interface DriveTimeOutputs {
   drive_distribution: Record<string, number>
@@ -21,21 +40,20 @@ const BUCKET_LABELS: Record<string, string> = {
   over_120_min: '>120',
 }
 
+// Drive-time bucket palette — green→red gradient stays semantic so a user
+// can scan the bar chart left-to-right and read time-cost intuitively.
+// These hex values are deliberate (not theme-driven) so the gradient holds
+// in both light and dark.
 const BUCKET_COLORS: Record<string, string> = {
-  under_30_min: '#16a34a',
-  '30_to_60_min': '#65a30d',
-  '60_to_90_min': '#ca8a04',
-  '90_to_120_min': '#ea580c',
-  over_120_min: '#dc2626',
-}
-
-const EFFICIENCY_BADGE: Record<'high' | 'medium' | 'low', string> = {
-  high: 'bg-green-100 text-green-700',
-  medium: 'bg-yellow-100 text-yellow-700',
-  low: 'bg-red-100 text-red-700',
+  under_30_min: '#22c55e',
+  '30_to_60_min': '#84cc16',
+  '60_to_90_min': '#eab308',
+  '90_to_120_min': '#f97316',
+  over_120_min: '#ef4444',
 }
 
 export default function DriveTimeChart({ data }: { data: DriveTimeOutputs }) {
+  const theme = useChartTheme()
   const histogramData = Object.entries(data.drive_distribution).map(([key, count]) => ({
     key,
     label: BUCKET_LABELS[key] ?? key,
@@ -43,77 +61,102 @@ export default function DriveTimeChart({ data }: { data: DriveTimeOutputs }) {
   }))
 
   return (
-    <div className="space-y-4">
-      <div>
-        <h4 className="text-sm font-semibold text-gray-700 mb-2">Drive time distribution</h4>
+    <div className="space-y-6">
+      <section className="space-y-2">
+        <h4 className="text-[10px] font-semibold uppercase tracking-wider text-fg-subtle">
+          Drive time distribution
+        </h4>
         <div className="h-48 w-full">
           <ResponsiveContainer>
-            <BarChart data={histogramData}>
-              <XAxis dataKey="label" tick={{ fontSize: 11 }} />
-              <YAxis tick={{ fontSize: 11 }} />
-              <Tooltip
-                formatter={(v: number) => [`${v} properties`, 'Count']}
-                contentStyle={{ fontSize: 12 }}
+            <BarChart data={histogramData} margin={{ top: 8, right: 8, left: -12, bottom: 0 }}>
+              <CartesianGrid stroke={theme.grid} strokeDasharray="3 3" vertical={false} />
+              <XAxis
+                dataKey="label"
+                tick={tickStyle(theme)}
+                axisLine={{ stroke: theme.grid }}
+                tickLine={false}
               />
-              <Bar dataKey="count">
+              <YAxis tick={tickStyle(theme)} axisLine={false} tickLine={false} />
+              <Tooltip
+                cursor={{ fill: theme.grid, opacity: 0.4 }}
+                contentStyle={tooltipStyle(theme)}
+                formatter={(v: number) => [`${v} properties`, 'Count']}
+              />
+              <Bar dataKey="count" radius={[2, 2, 0, 0]}>
                 {histogramData.map((d, i) => (
-                  <Cell key={i} fill={BUCKET_COLORS[d.key] ?? '#6b7280'} />
+                  <Cell key={i} fill={BUCKET_COLORS[d.key] ?? theme.muted} />
                 ))}
               </Bar>
             </BarChart>
           </ResponsiveContainer>
         </div>
-      </div>
+      </section>
 
-      <div>
-        <h4 className="text-sm font-semibold text-gray-700 mb-2">Cluster efficiency</h4>
-        <div className="overflow-x-auto">
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="border-b text-left text-xs uppercase tracking-wide text-gray-500">
-                <th className="py-2 pr-4">Branch</th>
-                <th className="py-2 pr-4 text-right">Properties</th>
-                <th className="py-2 pr-4 text-right">Avg drive (min)</th>
-                <th className="py-2 pr-4 text-right">Within 60 min</th>
-                <th className="py-2">Efficiency</th>
-              </tr>
-            </thead>
-            <tbody>
+      <section className="space-y-2">
+        <h4 className="text-[10px] font-semibold uppercase tracking-wider text-fg-subtle">
+          Cluster efficiency
+        </h4>
+        <div className="rounded-md border border-border bg-surface overflow-hidden">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Branch</TableHead>
+                <TableHead className="text-right">Properties</TableHead>
+                <TableHead className="text-right">Avg drive (min)</TableHead>
+                <TableHead className="text-right">Within 60 min</TableHead>
+                <TableHead>Efficiency</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
               {data.cluster_efficiency.map((c) => (
-                <tr key={c.branch} className="border-b last:border-0">
-                  <td className="py-2 pr-4 font-medium text-gray-900">
+                <TableRow key={c.branch}>
+                  <TableCell className="font-medium text-fg">
                     {c.city_state ?? c.branch}
-                  </td>
-                  <td className="py-2 pr-4 text-right">{c.property_count}</td>
-                  <td className="py-2 pr-4 text-right">{c.avg_drive_minutes}</td>
-                  <td className="py-2 pr-4 text-right">{c.properties_within_60min_pct}%</td>
-                  <td className="py-2">
-                    <span className={`text-xs px-2 py-0.5 rounded ${EFFICIENCY_BADGE[c.efficiency_score]}`}>
+                  </TableCell>
+                  <TableCell numeric>{c.property_count}</TableCell>
+                  <TableCell numeric>{c.avg_drive_minutes}</TableCell>
+                  <TableCell numeric>{c.properties_within_60min_pct}%</TableCell>
+                  <TableCell>
+                    <Badge variant={efficiencyVariant(c.efficiency_score)}>
                       {c.efficiency_score}
-                    </span>
-                  </td>
-                </tr>
+                    </Badge>
+                  </TableCell>
+                </TableRow>
               ))}
-            </tbody>
-          </table>
+            </TableBody>
+          </Table>
         </div>
-      </div>
+      </section>
 
       {data.long_drive_properties.length > 0 && (
-        <div>
-          <h4 className="text-sm font-semibold text-gray-700 mb-2">
+        <section className="space-y-2">
+          <h4 className="text-[10px] font-semibold uppercase tracking-wider text-fg-subtle">
             Long-drive properties ({data.long_drive_properties.length})
           </h4>
-          <div className="space-y-1.5 max-h-48 overflow-y-auto">
+          <ul className="max-h-48 space-y-1.5 overflow-y-auto">
             {data.long_drive_properties.map((p) => (
-              <div key={p.property_id} className="border-l-4 border-red-400 bg-red-50 px-3 py-2 text-sm">
-                <div className="font-medium text-gray-900">{p.address}</div>
-                <div className="text-xs text-gray-600">{p.drive_minutes}-min one-way drive</div>
-              </div>
+              <li
+                key={p.property_id}
+                className="rounded-md border-l-2 border-danger bg-danger-subtle px-3 py-2 text-sm"
+              >
+                <p className="font-medium text-fg">{p.address}</p>
+                <p className="text-xs text-fg-muted">
+                  <span className="font-tabular">{p.drive_minutes}</span>
+                  -min one-way drive
+                </p>
+              </li>
             ))}
-          </div>
-        </div>
+          </ul>
+        </section>
       )}
     </div>
   )
+}
+
+function efficiencyVariant(
+  score: 'high' | 'medium' | 'low'
+): 'success' | 'warning' | 'danger' {
+  if (score === 'high') return 'success'
+  if (score === 'medium') return 'warning'
+  return 'danger'
 }

--- a/src/components/analysis/GeographicChart.tsx
+++ b/src/components/analysis/GeographicChart.tsx
@@ -1,4 +1,20 @@
-import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Cell } from 'recharts'
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  Cell,
+  CartesianGrid,
+} from 'recharts'
+import { TriangleAlert } from 'lucide-react'
+import {
+  CHART_CATEGORICAL,
+  tickStyle,
+  tooltipStyle,
+  useChartTheme,
+} from '../../hooks/useChartTheme'
 
 interface StateRow {
   state: string
@@ -31,67 +47,85 @@ interface GeographicOutputs {
   outliers: Outlier[]
 }
 
-const COLORS = ['#2563eb', '#7c3aed', '#0891b2', '#059669', '#d97706', '#dc2626', '#9333ea', '#0284c7']
-
 export default function GeographicChart({ data }: { data: GeographicOutputs }) {
-  const stateData = data.states.slice(0, 12) // top N states
+  const theme = useChartTheme()
+  const stateData = data.states.slice(0, 12)
 
   return (
-    <div className="space-y-4">
-      <div>
-        <h4 className="text-sm font-semibold text-gray-700 mb-2">Properties by state (top 12)</h4>
+    <div className="space-y-6">
+      <section className="space-y-2">
+        <h4 className="text-[10px] font-semibold uppercase tracking-wider text-fg-subtle">
+          Properties by state (top 12)
+        </h4>
         <div className="h-56 w-full">
           <ResponsiveContainer>
-            <BarChart data={stateData}>
-              <XAxis dataKey="state" tick={{ fontSize: 11 }} />
-              <YAxis tick={{ fontSize: 11 }} />
-              <Tooltip
-                formatter={(v: number) => [`${v} properties`, 'Count']}
-                contentStyle={{ fontSize: 12 }}
+            <BarChart data={stateData} margin={{ top: 8, right: 8, left: -12, bottom: 0 }}>
+              <CartesianGrid stroke={theme.grid} strokeDasharray="3 3" vertical={false} />
+              <XAxis
+                dataKey="state"
+                tick={tickStyle(theme)}
+                axisLine={{ stroke: theme.grid }}
+                tickLine={false}
               />
-              <Bar dataKey="property_count">
+              <YAxis tick={tickStyle(theme)} axisLine={false} tickLine={false} />
+              <Tooltip
+                cursor={{ fill: theme.grid, opacity: 0.4 }}
+                contentStyle={tooltipStyle(theme)}
+                formatter={(v: number) => [`${v} properties`, 'Count']}
+              />
+              <Bar dataKey="property_count" radius={[2, 2, 0, 0]}>
                 {stateData.map((_, i) => (
-                  <Cell key={i} fill={COLORS[i % COLORS.length]} />
+                  <Cell key={i} fill={CHART_CATEGORICAL[i % CHART_CATEGORICAL.length]} />
                 ))}
               </Bar>
             </BarChart>
           </ResponsiveContainer>
         </div>
-      </div>
+      </section>
 
-      <div>
-        <h4 className="text-sm font-semibold text-gray-700 mb-2">Regions</h4>
+      <section className="space-y-2">
+        <h4 className="text-[10px] font-semibold uppercase tracking-wider text-fg-subtle">
+          Regions
+        </h4>
         <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
           {data.regions.map((r) => (
-            <div key={r.region_name} className="border rounded-lg px-3 py-2 text-sm">
-              <div className="font-medium text-gray-900">{r.region_name}</div>
-              <div className="text-xs text-gray-500">
-                {r.property_count} properties · {r.states.join(', ')}
-              </div>
+            <div
+              key={r.region_name}
+              className="rounded-md border border-border bg-surface px-3 py-2 text-sm"
+            >
+              <p className="font-medium text-fg">{r.region_name}</p>
+              <p className="text-xs text-fg-muted">
+                <span className="font-tabular">{r.property_count}</span>{' '}
+                {r.property_count === 1 ? 'property' : 'properties'}
+                {r.states.length > 0 && ` · ${r.states.join(', ')}`}
+              </p>
             </div>
           ))}
         </div>
-      </div>
+      </section>
 
       {data.outliers.length > 0 && (
-        <div>
-          <h4 className="text-sm font-semibold text-gray-700 mb-2">
+        <section className="space-y-2">
+          <h4 className="text-[10px] font-semibold uppercase tracking-wider text-fg-subtle">
             Outliers ({data.outliers.length})
           </h4>
-          <div className="space-y-1.5 max-h-64 overflow-y-auto">
+          <ul className="max-h-64 space-y-1.5 overflow-y-auto">
             {data.outliers.map((o) => (
-              <div
+              <li
                 key={o.property_id}
-                className="border-l-4 border-amber-400 bg-amber-50 px-3 py-2 text-sm"
+                className="flex items-start gap-2 rounded-md border-l-2 border-warning bg-warning-subtle px-3 py-2 text-sm"
               >
-                <div className="font-medium text-gray-900">
-                  {o.address}, {o.city}, {o.state}
+                <TriangleAlert className="mt-0.5 h-3.5 w-3.5 shrink-0 text-warning" aria-hidden />
+                <div className="min-w-0">
+                  <p className="font-medium text-fg">
+                    {o.address}, {o.city}, {o.state}
+                  </p>
+                  <p className="text-xs text-fg-muted">{o.note}</p>
                 </div>
-                <div className="text-xs text-gray-600">{o.note}</div>
-              </div>
+              </li>
             ))}
-          </div>
-        </div>
+          </ul>
+        </section>
       )}
     </div>
   )

--- a/src/components/analysis/SeasonalityChart.tsx
+++ b/src/components/analysis/SeasonalityChart.tsx
@@ -1,4 +1,18 @@
-import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, ReferenceLine, Legend } from 'recharts'
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  ReferenceLine,
+  Legend,
+  CartesianGrid,
+} from 'recharts'
+import { Badge } from '../ui/Badge'
+import { Card } from '../ui/Card'
+import { tickStyle, tooltipStyle, useChartTheme } from '../../hooks/useChartTheme'
+import { cn } from '../../lib/cn'
 
 interface WindowResult {
   window_name: string
@@ -40,6 +54,7 @@ const WINDOW_LABEL: Record<string, string> = {
 }
 
 export default function SeasonalityChart({ data }: { data: SeasonalityOutputs }) {
+  const theme = useChartTheme()
   const chartData = data.windows.map((w) => ({
     name: WINDOW_LABEL[w.window_name] ?? w.window_name,
     crews_needed: w.demand.simultaneous_crews_needed,
@@ -50,85 +65,125 @@ export default function SeasonalityChart({ data }: { data: SeasonalityOutputs })
   const baseline = data.baseline_crew_count_used
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-6">
       <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
-        <div className="bg-blue-50 border border-blue-200 rounded-lg p-3">
-          <div className="text-xs font-semibold text-blue-700 uppercase tracking-wide">Baseline</div>
-          <div className="text-2xl font-bold text-gray-900 mt-1">
+        <MetricCard label="Baseline">
+          <span className="font-mono text-2xl font-semibold tabular-nums text-fg">
             {baseline}
-            <span className="text-sm font-medium text-gray-500 ml-1">crews</span>
-          </div>
-          <div className="text-xs text-gray-600 mt-1">
-            {data.year_round_baseline.crews_required.toFixed(1)} crews avg-week demand
-          </div>
-        </div>
-        <div className="bg-amber-50 border border-amber-200 rounded-lg p-3">
-          <div className="text-xs font-semibold text-amber-700 uppercase tracking-wide">Peak ratio</div>
-          <div className="text-2xl font-bold text-gray-900 mt-1">
+          </span>
+          <span className="ml-1 text-sm text-fg-muted">crews</span>
+          <p className="mt-1 text-xs text-fg-muted">
+            <span className="font-tabular">
+              {data.year_round_baseline.crews_required.toFixed(1)}
+            </span>{' '}
+            crews avg-week demand
+          </p>
+        </MetricCard>
+        <MetricCard label="Peak ratio">
+          <span className="font-mono text-2xl font-semibold tabular-nums text-fg">
             {data.peak_to_baseline_ratio}x
-          </div>
-          <div className="text-xs text-gray-600 mt-1">peak-week vs avg-week demand</div>
-        </div>
-        <div className="bg-gray-50 border border-gray-200 rounded-lg p-3">
-          <div className="text-xs font-semibold text-gray-600 uppercase tracking-wide">Year-round</div>
-          <div className="text-2xl font-bold text-gray-900 mt-1">
+          </span>
+          <p className="mt-1 text-xs text-fg-muted">
+            peak-week vs avg-week demand
+          </p>
+        </MetricCard>
+        <MetricCard label="Year-round">
+          <span className="font-mono text-2xl font-semibold tabular-nums text-fg">
             {data.year_round_baseline.service_location_count}
-            <span className="text-sm font-medium text-gray-500 ml-1">SLs</span>
-          </div>
-          <div className="text-xs text-gray-600 mt-1">
-            {data.year_round_baseline.avg_weekly_hours.toLocaleString()} hrs/week
-          </div>
-        </div>
+          </span>
+          <span className="ml-1 text-sm text-fg-muted">SLs</span>
+          <p className="mt-1 text-xs text-fg-muted">
+            <span className="font-tabular">
+              {data.year_round_baseline.avg_weekly_hours.toLocaleString()}
+            </span>{' '}
+            hrs/week
+          </p>
+        </MetricCard>
       </div>
 
-      <div>
-        <h4 className="text-sm font-semibold text-gray-700 mb-2">
+      <section className="space-y-2">
+        <h4 className="text-[10px] font-semibold uppercase tracking-wider text-fg-subtle">
           Simultaneous crews required by window (vs baseline of {baseline})
         </h4>
         <div className="h-48 w-full">
           <ResponsiveContainer>
-            <BarChart data={chartData}>
-              <XAxis dataKey="name" tick={{ fontSize: 11 }} />
-              <YAxis tick={{ fontSize: 11 }} />
-              <Tooltip contentStyle={{ fontSize: 12 }} />
-              <Legend wrapperStyle={{ fontSize: 12 }} />
-              <ReferenceLine y={baseline} stroke="#16a34a" strokeDasharray="3 3" label={{ value: 'Baseline', fontSize: 11, fill: '#16a34a' }} />
-              <Bar dataKey="crews_needed" fill="#3b82f6" name="Crews needed" />
-              <Bar dataKey="surge_crews" fill="#f97316" name="Surge crews" />
+            <BarChart data={chartData} margin={{ top: 8, right: 8, left: -12, bottom: 0 }}>
+              <CartesianGrid stroke={theme.grid} strokeDasharray="3 3" vertical={false} />
+              <XAxis
+                dataKey="name"
+                tick={tickStyle(theme)}
+                axisLine={{ stroke: theme.grid }}
+                tickLine={false}
+              />
+              <YAxis tick={tickStyle(theme)} axisLine={false} tickLine={false} />
+              <Tooltip
+                cursor={{ fill: theme.grid, opacity: 0.4 }}
+                contentStyle={tooltipStyle(theme)}
+              />
+              <Legend wrapperStyle={{ fontSize: 12, color: theme.tick }} />
+              <ReferenceLine
+                y={baseline}
+                stroke={theme.success}
+                strokeDasharray="3 3"
+                label={{ value: 'Baseline', fontSize: 11, fill: theme.success }}
+              />
+              <Bar dataKey="crews_needed" fill={theme.accent} name="Crews needed" radius={[2, 2, 0, 0]} />
+              <Bar dataKey="surge_crews" fill={theme.warning} name="Surge crews" radius={[2, 2, 0, 0]} />
             </BarChart>
           </ResponsiveContainer>
         </div>
-      </div>
+      </section>
 
-      <div className="space-y-2">
+      <ul className="space-y-2">
         {data.windows.map((w) => (
-          <div
+          <li
             key={w.window_name}
-            className={`border-l-4 px-4 py-2 rounded-r ${
-              w.surge_required ? 'border-orange-400 bg-orange-50' : 'border-gray-300 bg-gray-50'
-            }`}
+            className={cn(
+              'rounded-md border-l-2 px-4 py-2',
+              w.surge_required
+                ? 'border-warning bg-warning-subtle'
+                : 'border-border-strong bg-surface-subtle'
+            )}
           >
-            <div className="flex items-baseline justify-between">
-              <div className="font-semibold text-gray-900">
+            <div className="flex items-baseline justify-between gap-3 flex-wrap">
+              <p className="font-semibold text-fg">
                 {WINDOW_LABEL[w.window_name] ?? w.window_name}
-                <span className="text-xs text-gray-500 font-normal ml-2">
-                  {w.start_date} – {w.end_date} · {w.duration_days} days
+                <span className="ml-2 text-xs font-normal text-fg-muted">
+                  <span className="font-tabular">{w.start_date}</span> –{' '}
+                  <span className="font-tabular">{w.end_date}</span> ·{' '}
+                  <span className="font-tabular">{w.duration_days}</span> days
                 </span>
-              </div>
+              </p>
               {w.surge_required && (
-                <span className="text-xs px-2 py-0.5 rounded bg-orange-100 text-orange-700">
-                  Surge required: +{w.surge_crews_needed} crews
-                </span>
+                <Badge variant="warning">
+                  Surge required: +<span className="font-tabular">{w.surge_crews_needed}</span> crews
+                </Badge>
               )}
             </div>
-            <div className="text-sm text-gray-700 mt-0.5">
-              {w.demand.service_location_count} SLs · {w.demand.total_hours_required.toLocaleString()} hrs ·{' '}
-              {w.demand.simultaneous_crews_needed} simultaneous crews
-            </div>
-            <div className="text-xs text-gray-600 mt-1">{w.notes}</div>
-          </div>
+            <p className="mt-0.5 text-sm text-fg">
+              <span className="font-tabular">{w.demand.service_location_count}</span> SLs ·{' '}
+              <span className="font-tabular">
+                {w.demand.total_hours_required.toLocaleString()}
+              </span>{' '}
+              hrs ·{' '}
+              <span className="font-tabular">{w.demand.simultaneous_crews_needed}</span>{' '}
+              simultaneous crews
+            </p>
+            <p className="mt-1 text-xs text-fg-muted">{w.notes}</p>
+          </li>
         ))}
-      </div>
+      </ul>
     </div>
+  )
+}
+
+function MetricCard({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <Card padding="sm">
+      <p className="text-[10px] font-semibold uppercase tracking-wider text-fg-subtle">
+        {label}
+      </p>
+      <div className="mt-1">{children}</div>
+    </Card>
   )
 }

--- a/src/components/analysis/WorkforceSizingChart.tsx
+++ b/src/components/analysis/WorkforceSizingChart.tsx
@@ -1,4 +1,22 @@
-import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'recharts'
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  CartesianGrid,
+} from 'recharts'
+import { Card } from '../ui/Card'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '../ui/Table'
+import { tickStyle, tooltipStyle, useChartTheme } from '../../hooks/useChartTheme'
 
 interface WorkforceOutputs {
   property_count: number
@@ -29,100 +47,135 @@ interface WorkforceOutputs {
 }
 
 export default function WorkforceSizingChart({ data }: { data: WorkforceOutputs }) {
+  const theme = useChartTheme()
   const a = data.workforce_a
   const b = data.workforce_b
   const t = data.total_workforce_size
 
   return (
-    <div className="space-y-5">
+    <div className="space-y-6">
       <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
-        <div className="bg-blue-50 border border-blue-200 rounded-lg p-3">
-          <div className="text-xs font-semibold text-blue-700 uppercase tracking-wide">Workforce A</div>
-          <div className="font-semibold text-gray-900 mt-0.5">{a.label}</div>
-          <div className="mt-2 text-2xl font-bold text-gray-900">
-            {a.fte_equivalent?.toFixed(0) ?? '—'}
-            <span className="text-sm font-medium text-gray-500 ml-1">FTE</span>
-          </div>
-          <div className="text-xs text-gray-600 mt-2">{a.note}</div>
-        </div>
+        <WorkforceCard label="Workforce A" subtitle={a.label}>
+          <FteValue value={a.fte_equivalent} />
+          <p className="mt-2 text-xs text-fg-muted">{a.note}</p>
+        </WorkforceCard>
 
-        <div className="bg-purple-50 border border-purple-200 rounded-lg p-3">
-          <div className="text-xs font-semibold text-purple-700 uppercase tracking-wide">Workforce B</div>
-          <div className="font-semibold text-gray-900 mt-0.5">{b.label}</div>
-          <div className="mt-2 text-2xl font-bold text-gray-900">
-            {b.fte_count.toFixed(1)}
-            <span className="text-sm font-medium text-gray-500 ml-1">FTE</span>
-          </div>
-          <div className="text-xs text-gray-600 mt-1">
-            {b.total_annual_hours.toLocaleString()} hrs/year · {b.properties_served} properties
-          </div>
-          <div className="text-xs text-gray-600 mt-1">
-            ~{b.part_time_position_count_estimate} part-time positions
-          </div>
-        </div>
+        <WorkforceCard label="Workforce B" subtitle={b.label}>
+          <FteValue value={b.fte_count} />
+          <p className="mt-1 text-xs text-fg-muted">
+            <span className="font-tabular">
+              {b.total_annual_hours.toLocaleString()}
+            </span>{' '}
+            hrs/year ·{' '}
+            <span className="font-tabular">{b.properties_served}</span> properties
+          </p>
+          <p className="mt-1 text-xs text-fg-muted">
+            ~<span className="font-tabular">{b.part_time_position_count_estimate}</span>{' '}
+            part-time positions
+          </p>
+        </WorkforceCard>
 
-        <div className="bg-gray-50 border border-gray-200 rounded-lg p-3">
-          <div className="text-xs font-semibold text-gray-600 uppercase tracking-wide">Total</div>
-          <div className="font-semibold text-gray-900 mt-0.5">Combined workforce</div>
-          <div className="mt-2 text-2xl font-bold text-gray-900">
-            {t.fte_equivalent.toFixed(1)}
-            <span className="text-sm font-medium text-gray-500 ml-1">FTE</span>
-          </div>
-          <div className="text-xs text-gray-600 mt-1">
-            ~{t.distinct_positions_estimate} distinct positions (incl. part-time)
-          </div>
-        </div>
+        <WorkforceCard label="Total" subtitle="Combined workforce">
+          <FteValue value={t.fte_equivalent} />
+          <p className="mt-1 text-xs text-fg-muted">
+            ~<span className="font-tabular">{t.distinct_positions_estimate}</span>{' '}
+            distinct positions (incl. part-time)
+          </p>
+        </WorkforceCard>
       </div>
 
       {b.by_offering.length > 0 && (
-        <div>
-          <h4 className="text-sm font-semibold text-gray-700 mb-2">
+        <section className="space-y-3">
+          <h4 className="text-[10px] font-semibold uppercase tracking-wider text-fg-subtle">
             Workforce B by service offering
           </h4>
           <div className="h-44 w-full">
             <ResponsiveContainer>
-              <BarChart data={b.by_offering} layout="vertical" margin={{ left: 80 }}>
+              <BarChart
+                data={b.by_offering}
+                layout="vertical"
+                margin={{ top: 4, right: 8, left: 80, bottom: 0 }}
+              >
+                <CartesianGrid stroke={theme.grid} strokeDasharray="3 3" horizontal={false} />
                 <XAxis
                   type="number"
-                  tick={{ fontSize: 11 }}
+                  tick={tickStyle(theme)}
+                  axisLine={{ stroke: theme.grid }}
+                  tickLine={false}
                   tickFormatter={(v: number) => v.toLocaleString()}
                 />
                 <YAxis
                   type="category"
                   dataKey="offering_name"
-                  tick={{ fontSize: 11 }}
+                  tick={tickStyle(theme)}
+                  axisLine={false}
+                  tickLine={false}
                   width={120}
                 />
                 <Tooltip
+                  cursor={{ fill: theme.grid, opacity: 0.4 }}
+                  contentStyle={tooltipStyle(theme)}
                   formatter={(v: number) => [`${v.toLocaleString()} hrs`, 'Annual hours']}
-                  contentStyle={{ fontSize: 12 }}
                 />
-                <Bar dataKey="total_hours" fill="#a855f7" />
+                <Bar dataKey="total_hours" fill={theme.accent} radius={[0, 2, 2, 0]} />
               </BarChart>
             </ResponsiveContainer>
           </div>
-          <table className="w-full text-sm mt-2">
-            <thead>
-              <tr className="border-b text-left text-xs uppercase tracking-wide text-gray-500">
-                <th className="py-2 pr-4">Offering</th>
-                <th className="py-2 pr-4 text-right">Locations</th>
-                <th className="py-2 pr-4 text-right">Annual hrs</th>
-                <th className="py-2 text-right">FTE</th>
-              </tr>
-            </thead>
-            <tbody>
-              {b.by_offering.map((o, i) => (
-                <tr key={i} className="border-b last:border-0">
-                  <td className="py-2 pr-4 font-medium text-gray-900">{o.offering_name}</td>
-                  <td className="py-2 pr-4 text-right">{o.location_count}</td>
-                  <td className="py-2 pr-4 text-right">{o.total_hours.toLocaleString()}</td>
-                  <td className="py-2 text-right">{o.fte_equivalent.toFixed(1)}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+          <div className="rounded-md border border-border bg-surface overflow-hidden">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Offering</TableHead>
+                  <TableHead className="text-right">Locations</TableHead>
+                  <TableHead className="text-right">Annual hrs</TableHead>
+                  <TableHead className="text-right">FTE</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {b.by_offering.map((o, i) => (
+                  <TableRow key={i}>
+                    <TableCell className="font-medium text-fg">{o.offering_name}</TableCell>
+                    <TableCell numeric>{o.location_count}</TableCell>
+                    <TableCell numeric>{o.total_hours.toLocaleString()}</TableCell>
+                    <TableCell numeric>{o.fte_equivalent.toFixed(1)}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        </section>
       )}
     </div>
+  )
+}
+
+function WorkforceCard({
+  label,
+  subtitle,
+  children,
+}: {
+  label: string
+  subtitle: string
+  children: React.ReactNode
+}) {
+  return (
+    <Card padding="sm">
+      <p className="text-[10px] font-semibold uppercase tracking-wider text-fg-subtle">
+        {label}
+      </p>
+      <p className="mt-0.5 text-sm font-semibold text-fg">{subtitle}</p>
+      {children}
+    </Card>
+  )
+}
+
+function FteValue({ value }: { value: number | undefined }) {
+  return (
+    <p className="mt-2 leading-none">
+      <span className="font-mono text-2xl font-semibold tabular-nums text-fg">
+        {value != null ? value.toFixed(1) : '—'}
+      </span>
+      <span className="ml-1 text-sm text-fg-muted">FTE</span>
+    </p>
   )
 }

--- a/src/hooks/useChartTheme.ts
+++ b/src/hooks/useChartTheme.ts
@@ -1,0 +1,104 @@
+// useChartTheme — resolves the design tokens that recharts needs into
+// concrete color strings.
+//
+// Why a hook: recharts components accept color props as strings (e.g. the
+// `stroke` on <CartesianGrid>) and pass them straight to SVG attributes.
+// SVG doesn't resolve CSS custom properties in attribute values, so we have
+// to read the computed styles off <html> ourselves and pass concrete colors.
+//
+// The hook re-reads when the data-theme attribute on <html> changes, so
+// charts re-render when the user toggles light/dark.
+import { useEffect, useState } from 'react'
+
+export interface ChartTheme {
+  /** Axis lines + gridlines — the quiet structural lines. */
+  grid: string
+  /** Axis tick labels. */
+  tick: string
+  /** Tooltip background. */
+  tooltipBg: string
+  /** Tooltip border. */
+  tooltipBorder: string
+  /** Tooltip text. */
+  tooltipText: string
+  /** Primary series color (accent) for highlighted data. */
+  accent: string
+  /** Muted series color for secondary / reference series. */
+  muted: string
+  /** Semantic palette — use sparingly. */
+  success: string
+  warning: string
+  danger: string
+}
+
+function resolve(varName: string, fallback: string): string {
+  if (typeof window === 'undefined') return fallback
+  const root = document.documentElement
+  const v = getComputedStyle(root).getPropertyValue(varName).trim()
+  return v || fallback
+}
+
+function read(): ChartTheme {
+  return {
+    grid: resolve('--color-border', '#e4e4e7'),
+    tick: resolve('--color-fg-muted', '#52525b'),
+    tooltipBg: resolve('--color-bg-elevated', '#ffffff'),
+    tooltipBorder: resolve('--color-border-strong', '#d4d4d8'),
+    tooltipText: resolve('--color-fg', '#09090b'),
+    accent: resolve('--color-accent', '#4f46e5'),
+    muted: resolve('--color-fg-subtle', '#71717a'),
+    success: resolve('--color-success', '#16a34a'),
+    warning: resolve('--color-warning', '#d97706'),
+    danger: resolve('--color-danger', '#dc2626'),
+  }
+}
+
+export function useChartTheme(): ChartTheme {
+  const [theme, setTheme] = useState<ChartTheme>(() => read())
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    const observer = new MutationObserver(() => setTheme(read()))
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['data-theme'],
+    })
+    return () => observer.disconnect()
+  }, [])
+
+  return theme
+}
+
+// Categorical palette for bar charts where each bar is a different bucket
+// (states, regions, branches when not coloring by client). Token-derived
+// where possible, with extra hues blended in for variety. Sticking to a
+// muted, desaturated palette so the chart reads as data-tool, not marketing.
+export const CHART_CATEGORICAL = [
+  '#4f46e5', // indigo (accent)
+  '#0891b2', // cyan-600
+  '#16a34a', // green-600
+  '#d97706', // amber-600
+  '#7c3aed', // violet-600
+  '#dc2626', // red-600
+  '#0284c7', // sky-600
+  '#9333ea', // purple-600
+] as const
+
+// Standard recharts <Tooltip> styling using theme tokens. Pass via
+// `contentStyle={tooltipStyle(theme)}` on every chart.
+export function tooltipStyle(theme: ChartTheme): React.CSSProperties {
+  return {
+    backgroundColor: theme.tooltipBg,
+    border: `1px solid ${theme.tooltipBorder}`,
+    borderRadius: 6,
+    padding: '8px 10px',
+    fontSize: 12,
+    color: theme.tooltipText,
+    boxShadow: '0 1px 3px rgba(0,0,0,0.06)',
+  }
+}
+
+// Standard tick style — small, muted text.
+export function tickStyle(theme: ChartTheme) {
+  return { fontSize: 11, fill: theme.tick }
+}


### PR DESCRIPTION
## Summary

Migrates all 7 dashboard charts off hand-rolled Tailwind utilities + hard-coded recharts colors onto the design tokens. Charts now **respond to the theme toggle** — axes, gridlines, tooltips, and chrome all swap when the user flips light↔dark.

This is the first of three deferred D2 follow-ups (charts → scenario/constraints panels → modal-to-Dialog).

### Key infrastructure

`src/hooks/useChartTheme.ts` — recharts SVG props don't resolve CSS custom properties (passing `var(--color-border)` to a `stroke` attribute renders literally). The hook reads `getComputedStyle` from `<html>` on mount, re-reads via `MutationObserver` on `data-theme` changes, and returns concrete color strings. Exports: `useChartTheme()`, `tooltipStyle(theme)`, `tickStyle(theme)`, plus a `CHART_CATEGORICAL` palette for bar charts that need per-bucket color variation.

### Per-chart highlights

| Chart | What changed |
|---|---|
| **GeographicChart** | State bars use CHART_CATEGORICAL; outliers use warning-subtle + TriangleAlert icon |
| **DriveTimeChart** | Green→red gradient kept (deliberately semantic for drive-time buckets); cluster table uses Phase B Table + Badge |
| **SeasonalityChart** | 3 metric cards (baseline / peak ratio / year-round) in monospace; theme.accent + theme.warning bars; theme.success reference line; window list uses warning-subtle when surge required |
| **WorkforceSizingChart** | 3 workforce cards; horizontal bar chart for by-offering breakdown; design Table for per-offering rows |
| **BidPricingChart** | Replaced green→teal gradient bid card with quiet bg-surface card — typography (4xl monospace) does the work. Cost-buildup horizontal bars use CHART_CATEGORICAL. |
| **BranchOptimizationChart** | Composed line+bar chart respects theme axes/grid; recommended-vs-selected banner uses accent-subtle (or warning-subtle when they diverge); per-K selection table uses design Button. Unconstrained-reference collapses with chevron-rotation summary. |
| **CrewStrategyChart** | Dropped indigo→blue gradient on recommendation banner; A/B/C option cards use ring-1 ring-accent for recommended; per-branch/region/portfolio tables use design Table + Badge |

### Files

- `src/hooks/useChartTheme.ts` (new)
- `src/components/analysis/{Geographic,DriveTime,Seasonality,WorkforceSizing,BidPricing,BranchOptimization,CrewStrategy}Chart.tsx`

8 files, +1133 / -662.

## What I verified

- [x] `npx tsc --noEmit` passes silently
- [x] `vite build` succeeds

## Test plan

- [ ] `/accounts/[JLL]/clients/[Property-Reserve]/analysis` — every analysis module renders correctly. Run each one if you haven't recently.
- [ ] Toggle theme via TopBar → chart axes/grids/tooltips swap. **Specifically watch:** the recharts tooltip background flips from white to bg-surface-elevated dark; axis tick labels darken from text-fg-muted to its dark equivalent.
- [ ] BranchOptimization: composed bar+line chart legible in both themes; recommended-vs-selected banner accent-subtle (or warning-subtle when divergent); per-K table "Build K=N" buttons work.
- [ ] CrewStrategy: A/B/C cards visually distinct (recommended has accent ring); per-branch utilization table; constraint violations list uses semantic stripes.
- [ ] BidPricing: $X.XXM headline reads in monospace 4xl; cost-buildup horizontal bars; composition cards have inline progress bars.
- [ ] Seasonality / WorkforceSizing / DriveTime / Geographic — each chart legible in both themes, no leftover hard-coded gray-* / blue-* utility soup.

## Out of scope (next PRs in this series)

- **ScenarioPanel** slider details + **CostAssumptionsPanel** collapsible body
- **OperationalConstraintsPanel** modal + **BuildSelectionModal** → migrate to design `<Dialog>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)