### PR TITLE
Fix: Portfolio Map + risk-assessment use selected branches, not recommended

### DIFF
--- a/api/_lib/analysis/risk-flags.ts
+++ b/api/_lib/analysis/risk-flags.ts
@@ -139,13 +139,43 @@ export function computeRiskFlags(
   return { flags, score }
 }
 
-// Pull the most recent branch_optimization output's branches at the recommended_k.
-// Returns null if no completed run exists.
+// Branch set used as input to risk-flag computation (isolation distance
+// from the actual deployed network).
+//
+// Resolution order:
+//   1. User's saved selection in account_operational_constraints.selected_branches.
+//      This is what the user actually plans to deploy and is what risk should
+//      be computed against — even if it differs from the optimization's
+//      recommendation (e.g. user picked K=3 over the recommended K=2).
+//   2. Fallback: the optimization's recommended_k branches from the most
+//      recent completed branch_optimization. Used before the user has
+//      confirmed a selection.
+//   3. null — no selection AND no completed optimization yet.
 export async function fetchLatestBranchSet(
   db: SupabaseClient,
   accountId: string,
   clientId: string
 ): Promise<Array<{ lat: number; lng: number; name: string }> | null> {
+  // 1. User selection wins.
+  const { data: aoc } = await db
+    .from('account_operational_constraints')
+    .select('selected_branches')
+    .eq('account_id', accountId)
+    .eq('client_id', clientId)
+    .maybeSingle()
+
+  const selected = (aoc as any)?.selected_branches as
+    | Array<{ name?: string; city_state?: string; lat: number; lng: number }>
+    | null
+  if (Array.isArray(selected) && selected.length > 0) {
+    return selected.map((b) => ({
+      name: b.city_state || b.name || '',
+      lat: b.lat,
+      lng: b.lng,
+    }))
+  }
+
+  // 2. Fall back to optimization recommendation.
   const { data } = await db
     .from('portfolio_analyses')
     .select('outputs')

--- a/src/pages/accounts/AccountAnalysis.tsx
+++ b/src/pages/accounts/AccountAnalysis.tsx
@@ -287,25 +287,8 @@ export default function AccountAnalysisPage() {
         setRunning((prev) => ({ ...prev, ...resumeRunning }))
       }
 
-      // Hydrate map branches from the latest completed branch_optimization
-      const bo = byModule.branch_optimization
-      if (bo && bo.status === 'completed' && bo.outputs) {
-        const recommended = bo.outputs.k_results?.find(
-          (r: any) => r.k === bo.outputs.recommended_k
-        )
-        if (recommended) {
-          setMapBranches(
-            recommended.branches.map((b: any) => ({
-              name: b.city_state,
-              lat: b.lat,
-              lng: b.lng,
-              population: b.population ?? null,
-              property_count: b.property_count ?? undefined,
-            }))
-          )
-        }
-      }
-
+      // mapBranches is derived in a separate effect that prefers the user's
+      // selected_branches over the optimization's recommended_k.
       setMapPoints(propsRes.points)
     } finally {
       setMapLoading(false)
@@ -316,6 +299,63 @@ export default function AccountAnalysisPage() {
     loadEverything()
     refreshConstraints()
   }, [loadEverything, refreshConstraints])
+
+  // Derive the map's branch markers from whatever the user is *actually*
+  // committed to. Prefers their saved selection (selectedBranches) over the
+  // optimization's recommended_k — those can diverge (e.g. recommended K=2,
+  // user picked K=3) and the map needs to reflect what's deployed, not what
+  // was suggested. Re-runs whenever either source changes (a fresh
+  // optimization run or a save in the Build Selection modal).
+  useEffect(() => {
+    // 1. User selection wins.
+    if (selectedBranches && selectedBranches.length > 0) {
+      // Try to enrich with population/property_count from the matching
+      // recommended row when K matches — falls back to bare selection
+      // otherwise. Coordinate match within ~1km tolerance.
+      const bo = latestByModule.branch_optimization
+      const recRow =
+        bo?.outputs?.k_results?.find((r: any) => r.k === selectedBranches.length) ?? null
+      const recBranches: any[] = recRow?.branches ?? []
+      const findMatch = (lat: number, lng: number) =>
+        recBranches.find(
+          (rb) => Math.abs(rb.lat - lat) < 0.01 && Math.abs(rb.lng - lng) < 0.01
+        )
+      setMapBranches(
+        selectedBranches.map((b) => {
+          const m = findMatch(b.lat, b.lng)
+          return {
+            name: b.city_state || b.name,
+            lat: b.lat,
+            lng: b.lng,
+            population: m?.population ?? null,
+            property_count: m?.property_count ?? undefined,
+          }
+        })
+      )
+      return
+    }
+    // 2. Fallback: optimization's recommended branches.
+    const bo = latestByModule.branch_optimization
+    if (bo && bo.status === 'completed' && bo.outputs) {
+      const recommended = bo.outputs.k_results?.find(
+        (r: any) => r.k === bo.outputs.recommended_k
+      )
+      if (recommended) {
+        setMapBranches(
+          recommended.branches.map((b: any) => ({
+            name: b.city_state,
+            lat: b.lat,
+            lng: b.lng,
+            population: b.population ?? null,
+            property_count: b.property_count ?? undefined,
+          }))
+        )
+        return
+      }
+    }
+    // 3. Nothing to render.
+    setMapBranches([])
+  }, [selectedBranches, latestByModule.branch_optimization])
 
   // ─── Build-selection modal handlers ───
   const openBuildModal = useCallback(
@@ -429,26 +469,9 @@ export default function AccountAnalysisPage() {
             delete next[moduleKey]
             return next
           })
-          if (
-            row.status === 'completed' &&
-            row.module_key === 'branch_optimization' &&
-            row.outputs
-          ) {
-            const recommended = row.outputs.k_results?.find(
-              (r: any) => r.k === row.outputs.recommended_k
-            )
-            if (recommended) {
-              setMapBranches(
-                recommended.branches.map((b: any) => ({
-                  name: b.city_state,
-                  lat: b.lat,
-                  lng: b.lng,
-                  population: b.population ?? null,
-                  property_count: b.property_count ?? undefined,
-                }))
-              )
-            }
-          }
+          // mapBranches updates via the derive-from-state effect above; no
+          // inline setMapBranches needed here. The setLatestByModule call
+          // triggers the dependency.
         }
       } catch (err: any) {
         setLastPollError((prev) => ({
@@ -537,26 +560,7 @@ export default function AccountAnalysisPage() {
           if (rowRes.ok) {
             const row: AnalysisRow = await rowRes.json()
             setLatestByModule((prev) => ({ ...prev, [moduleKey]: row }))
-            if (
-              row.status === 'completed' &&
-              row.module_key === 'branch_optimization' &&
-              row.outputs
-            ) {
-              const recommended = row.outputs.k_results?.find(
-                (r: any) => r.k === row.outputs.recommended_k
-              )
-              if (recommended) {
-                setMapBranches(
-                  recommended.branches.map((b: any) => ({
-                    name: b.city_state,
-                    lat: b.lat,
-                    lng: b.lng,
-                    population: b.population ?? null,
-                    property_count: b.property_count ?? undefined,
-                  }))
-                )
-              }
-            }
+            // mapBranches derives via the effect; no inline update needed.
           }
         }
 


### PR DESCRIPTION
## What's broken

User report: when Branch Optimization recommends K=2 but the user picks K=3 in Build Selection, the dashboard keeps using the K=2 recommended locations for both:

1. The **Portfolio Map** — branch markers render the recommendation, not the selection
2. **Risk re-assessment** — clicking "Re-assess risk" scores properties against the recommended branch set, not the deployed one

Both should reflect what the user is *actually* deploying.

## Root cause

Two independent sites that both reached for \`branch_optimization.outputs.k_results.find(r => r.k === recommended_k)\` instead of consulting \`account_operational_constraints.selected_branches\`:

- **Backend**: \`fetchLatestBranchSet\` (used by \`/risk-flags-bulk\` + \`/properties/:id/risk-flags\`) only queried \`portfolio_analyses\` for the recommended-K row.
- **Frontend**: \`AccountAnalysis.tsx\` had three inline \`setMapBranches\` sites — the initial load and two poll paths — all using the same recommended-K logic.

## Fix

### Backend (\`api/_lib/analysis/risk-flags.ts\`)

\`fetchLatestBranchSet\` resolves in priority order:
1. \`account_operational_constraints.selected_branches\` when non-empty → user's deployment plan
2. \`portfolio_analyses.outputs\` at \`recommended_k\` → fallback before any selection saved
3. \`null\` if neither

### Frontend (\`src/pages/accounts/AccountAnalysis.tsx\`)

Replaced the three inline sites with a single derive-from-state effect:

\`\`\`tsx
useEffect(() => {
  if (selectedBranches?.length) {
    // Use selection. Enrich population/property_count by matching
    // coordinates against the same-K recommended row when available.
    setMapBranches(selectedBranches.map(...))
    return
  }
  // Fall back to recommended_k branches.
  const bo = latestByModule.branch_optimization
  if (bo?.status === 'completed' && bo.outputs) { ... }
  setMapBranches([])
}, [selectedBranches, latestByModule.branch_optimization])
\`\`\`

The poll paths still call \`setLatestByModule(...)\` which trips the effect's dependency. The three legacy inline setters are now redundant comments.

## Files

- \`api/_lib/analysis/risk-flags.ts\` (+34/-9)
- \`src/pages/accounts/AccountAnalysis.tsx\` (+61/-61)

## Verified

- [x] \`npx tsc --noEmit\` clean
- [x] \`vite build\` clean

## Test plan

- [ ] On the dashboard, with branch optimization recommending one K and the user having saved a different K via Build Selection: the Portfolio Map markers show the **selected** locations, not the recommended ones. Branch count matches \`K = N\` from the locked-selection banner.
- [ ] Click **Re-assess risk** → backend uses the selected branches when computing isolation distance. Verify by comparing risk_score on a property close to a selected branch but far from a recommended one (should drop relative to before).
- [ ] Clear the selection (Change selection → Confirm clear) → Portfolio Map falls back to the recommended K branches.
- [ ] On a fresh account with no completed branch_optimization yet → map shows zero markers (was rendering empty before too; behavior preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)