### PR TITLE
Phase 4a PR1: service-location constraints (schedule/access/ops, hard or soft)

### DIFF
--- a/api/_lib/analysis/constraint-validators.ts
+++ b/api/_lib/analysis/constraint-validators.ts
@@ -1,0 +1,259 @@
+// Validators for service-location constraint configs. Each constraint_type
+// has its own expected `config` shape — this module is the single source of
+// truth for those shapes and is called by every API endpoint that writes
+// constraint rows (POST, PUT, bulk-apply, template apply).
+//
+// Hand-rolled rather than Zod: the shapes are simple, the type-set is small,
+// and adding a runtime dep just for this isn't worth it.
+
+export type ConstraintType =
+  | 'day_of_week'
+  | 'blackout_dates'
+  | 'seasonal_window'
+  | 'time_window'
+  | 'access_requirement'
+  | 'contact_requirement'
+
+export type ConstraintEnforcement = 'hard' | 'soft'
+
+export interface ConstraintInput {
+  constraint_type: string
+  enforcement: string
+  config: unknown
+  notes?: string | null
+}
+
+export interface ValidationResult {
+  ok: boolean
+  errors: string[]
+  // Normalized config — caller should persist this rather than the raw input
+  // (e.g. dedups, sorts, lowercases). Only present when ok=true.
+  normalized?: {
+    constraint_type: ConstraintType
+    enforcement: ConstraintEnforcement
+    config: Record<string, unknown>
+  }
+}
+
+const CONSTRAINT_TYPES: ConstraintType[] = [
+  'day_of_week',
+  'blackout_dates',
+  'seasonal_window',
+  'time_window',
+  'access_requirement',
+  'contact_requirement',
+]
+
+// Group labels surfaced in the Add Constraint dialog. Kept here so UI and
+// API agree on what each type is.
+export const CONSTRAINT_GROUPS: Record<'schedule' | 'access' | 'operations', ConstraintType[]> = {
+  schedule: ['day_of_week', 'blackout_dates', 'seasonal_window', 'time_window'],
+  access: ['access_requirement'],
+  operations: ['contact_requirement'],
+}
+
+export const CONSTRAINT_LABELS: Record<ConstraintType, string> = {
+  day_of_week: 'Day-of-week restriction',
+  blackout_dates: 'Blackout dates',
+  seasonal_window: 'Seasonal window',
+  time_window: 'Time-of-day window',
+  access_requirement: 'Access requirement',
+  contact_requirement: 'Contact requirement',
+}
+
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/
+const HHMM_RE = /^\d{2}:\d{2}$/
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v)
+}
+
+export function validateConstraint(input: ConstraintInput): ValidationResult {
+  const errors: string[] = []
+
+  if (!CONSTRAINT_TYPES.includes(input.constraint_type as ConstraintType)) {
+    errors.push(
+      `constraint_type must be one of: ${CONSTRAINT_TYPES.join(', ')} (got: ${input.constraint_type})`
+    )
+    return { ok: false, errors }
+  }
+  const type = input.constraint_type as ConstraintType
+
+  if (input.enforcement !== 'hard' && input.enforcement !== 'soft') {
+    errors.push(`enforcement must be 'hard' or 'soft' (got: ${input.enforcement})`)
+    return { ok: false, errors }
+  }
+  const enforcement = input.enforcement as ConstraintEnforcement
+
+  if (!isPlainObject(input.config)) {
+    errors.push('config must be an object')
+    return { ok: false, errors }
+  }
+
+  const normalizedConfig = validateConfigByType(type, input.config, errors)
+  if (errors.length > 0) return { ok: false, errors }
+
+  return {
+    ok: true,
+    errors: [],
+    normalized: { constraint_type: type, enforcement, config: normalizedConfig },
+  }
+}
+
+function validateConfigByType(
+  type: ConstraintType,
+  config: Record<string, unknown>,
+  errors: string[]
+): Record<string, unknown> {
+  switch (type) {
+    case 'day_of_week':
+      return validateDayOfWeek(config, errors)
+    case 'blackout_dates':
+      return validateBlackoutDates(config, errors)
+    case 'seasonal_window':
+      return validateSeasonalWindow(config, errors)
+    case 'time_window':
+      return validateTimeWindow(config, errors)
+    case 'access_requirement':
+      return validateAccessRequirement(config, errors)
+    case 'contact_requirement':
+      return validateContactRequirement(config, errors)
+  }
+}
+
+// { allowed_days: number[] } — 0=Sunday … 6=Saturday. Must be non-empty,
+// values must be ints 0-6, dedup + sort on normalize.
+function validateDayOfWeek(c: Record<string, unknown>, errors: string[]) {
+  const days = c.allowed_days
+  if (!Array.isArray(days) || days.length === 0) {
+    errors.push('day_of_week.allowed_days must be a non-empty array')
+    return c
+  }
+  const seen = new Set<number>()
+  for (const d of days) {
+    if (typeof d !== 'number' || !Number.isInteger(d) || d < 0 || d > 6) {
+      errors.push(`day_of_week.allowed_days[*] must be integers 0–6 (got: ${JSON.stringify(d)})`)
+      return c
+    }
+    seen.add(d)
+  }
+  return { allowed_days: Array.from(seen).sort((a, b) => a - b) }
+}
+
+// { dates: string[] } — ISO YYYY-MM-DD. Must be non-empty, valid dates.
+function validateBlackoutDates(c: Record<string, unknown>, errors: string[]) {
+  const dates = c.dates
+  if (!Array.isArray(dates) || dates.length === 0) {
+    errors.push('blackout_dates.dates must be a non-empty array')
+    return c
+  }
+  const seen = new Set<string>()
+  for (const d of dates) {
+    if (typeof d !== 'string' || !ISO_DATE_RE.test(d) || Number.isNaN(Date.parse(d))) {
+      errors.push(`blackout_dates.dates[*] must be ISO YYYY-MM-DD (got: ${JSON.stringify(d)})`)
+      return c
+    }
+    seen.add(d)
+  }
+  return { dates: Array.from(seen).sort() }
+}
+
+// { start_month: 1-12, end_month: 1-12 } — inclusive on both ends. If start
+// > end the window wraps the year (e.g. 11→3 = Nov–Mar).
+function validateSeasonalWindow(c: Record<string, unknown>, errors: string[]) {
+  const sm = c.start_month
+  const em = c.end_month
+  for (const [k, v] of [
+    ['start_month', sm],
+    ['end_month', em],
+  ] as const) {
+    if (typeof v !== 'number' || !Number.isInteger(v) || v < 1 || v > 12) {
+      errors.push(`seasonal_window.${k} must be integer 1–12 (got: ${JSON.stringify(v)})`)
+      return c
+    }
+  }
+  return { start_month: sm as number, end_month: em as number }
+}
+
+// { earliest_start: 'HH:MM', latest_end: 'HH:MM' } — service must run
+// inside [earliest_start, latest_end). If end <= start the window wraps
+// midnight (e.g. 22:00→06:00 = overnight).
+function validateTimeWindow(c: Record<string, unknown>, errors: string[]) {
+  const start = c.earliest_start
+  const end = c.latest_end
+  for (const [k, v] of [
+    ['earliest_start', start],
+    ['latest_end', end],
+  ] as const) {
+    if (typeof v !== 'string' || !HHMM_RE.test(v)) {
+      errors.push(`time_window.${k} must be 'HH:MM' (got: ${JSON.stringify(v)})`)
+      return c
+    }
+    const [h, m] = (v as string).split(':').map(Number)
+    if (h < 0 || h > 23 || m < 0 || m > 59) {
+      errors.push(`time_window.${k} hours/minutes out of range (got: ${v})`)
+      return c
+    }
+  }
+  return { earliest_start: start as string, latest_end: end as string }
+}
+
+// { kind: 'badge' | 'escort' | 'key' | 'code' | 'other', details?: string }
+const ACCESS_KINDS = ['badge', 'escort', 'key', 'code', 'other'] as const
+function validateAccessRequirement(c: Record<string, unknown>, errors: string[]) {
+  const kind = c.kind
+  if (typeof kind !== 'string' || !(ACCESS_KINDS as readonly string[]).includes(kind)) {
+    errors.push(
+      `access_requirement.kind must be one of: ${ACCESS_KINDS.join(', ')} (got: ${JSON.stringify(kind)})`
+    )
+    return c
+  }
+  const details = c.details
+  if (details !== undefined && details !== null && typeof details !== 'string') {
+    errors.push('access_requirement.details must be a string when present')
+    return c
+  }
+  const out: Record<string, unknown> = { kind }
+  if (typeof details === 'string' && details.trim().length > 0) out.details = details.trim()
+  return out
+}
+
+// { contact_name?, contact_phone?, advance_notice_hours?: number,
+//   instructions?: string } — at least one field must be set so the
+// constraint actually says something.
+function validateContactRequirement(c: Record<string, unknown>, errors: string[]) {
+  const out: Record<string, unknown> = {}
+  if (c.contact_name !== undefined && c.contact_name !== null) {
+    if (typeof c.contact_name !== 'string') {
+      errors.push('contact_requirement.contact_name must be a string')
+      return c
+    }
+    if (c.contact_name.trim().length > 0) out.contact_name = c.contact_name.trim()
+  }
+  if (c.contact_phone !== undefined && c.contact_phone !== null) {
+    if (typeof c.contact_phone !== 'string') {
+      errors.push('contact_requirement.contact_phone must be a string')
+      return c
+    }
+    if (c.contact_phone.trim().length > 0) out.contact_phone = c.contact_phone.trim()
+  }
+  if (c.advance_notice_hours !== undefined && c.advance_notice_hours !== null) {
+    const h = c.advance_notice_hours
+    if (typeof h !== 'number' || !Number.isFinite(h) || h < 0) {
+      errors.push('contact_requirement.advance_notice_hours must be a non-negative number')
+      return c
+    }
+    out.advance_notice_hours = h
+  }
+  if (c.instructions !== undefined && c.instructions !== null) {
+    if (typeof c.instructions !== 'string') {
+      errors.push('contact_requirement.instructions must be a string')
+      return c
+    }
+    if (c.instructions.trim().length > 0) out.instructions = c.instructions.trim()
+  }
+  if (Object.keys(out).length === 0) {
+    errors.push('contact_requirement requires at least one of: contact_name, contact_phone, advance_notice_hours, instructions')
+  }
+  return out
+}

--- a/api/service-locations/[serviceLocationId]/constraints/[constraintId].ts
+++ b/api/service-locations/[serviceLocationId]/constraints/[constraintId].ts
@@ -1,0 +1,91 @@
+// PUT    /api/service-locations/[serviceLocationId]/constraints/[constraintId]
+//        body: { constraint_type?, enforcement?, config?, notes? }
+//        → partial update. Re-validates if type/enforcement/config touched.
+// DELETE /api/service-locations/[serviceLocationId]/constraints/[constraintId]
+
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { createAdminClient } from '../../../_lib/supabase.js'
+import { authenticateRequest } from '../../../_lib/auth.js'
+import { validateConstraint } from '../../../_lib/analysis/constraint-validators.js'
+
+export const config = { maxDuration: 10 }
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  try {
+    await authenticateRequest(req)
+  } catch (err) {
+    const e = err as { statusCode?: number; message?: string }
+    return res.status(e.statusCode ?? 401).json({ error: e.message ?? 'Unauthorized' })
+  }
+
+  const serviceLocationId = req.query.serviceLocationId as string
+  const constraintId = req.query.constraintId as string
+  if (!serviceLocationId || !constraintId) {
+    return res.status(400).json({ error: 'serviceLocationId and constraintId required' })
+  }
+
+  const db = createAdminClient()
+
+  // Verify the constraint belongs to the service_location in the URL.
+  // Prevents a caller with a known constraintId from mutating a row under a
+  // different SL just by changing the path.
+  const { data: existing, error: fetchErr } = await db
+    .from('service_location_constraints')
+    .select('id, service_location_id, constraint_type, enforcement, config')
+    .eq('id', constraintId)
+    .maybeSingle()
+
+  if (fetchErr) return res.status(500).json({ error: fetchErr.message })
+  if (!existing) return res.status(404).json({ error: 'Constraint not found' })
+  if (existing.service_location_id !== serviceLocationId) {
+    return res.status(404).json({ error: 'Constraint not found on this service location' })
+  }
+
+  if (req.method === 'PUT') {
+    const body = (req.body ?? {}) as Record<string, unknown>
+
+    const merged = {
+      constraint_type: typeof body.constraint_type === 'string' ? body.constraint_type : existing.constraint_type,
+      enforcement: typeof body.enforcement === 'string' ? body.enforcement : existing.enforcement,
+      config: body.config !== undefined ? body.config : existing.config,
+      notes: body.notes as string | null | undefined,
+    }
+
+    const result = validateConstraint(merged)
+    if (!result.ok) {
+      return res.status(400).json({ error: 'Invalid constraint', details: result.errors })
+    }
+
+    const update: Record<string, unknown> = {
+      constraint_type: result.normalized!.constraint_type,
+      enforcement: result.normalized!.enforcement,
+      config: result.normalized!.config,
+      updated_at: new Date().toISOString(),
+    }
+    if (body.notes !== undefined) {
+      update.notes =
+        typeof body.notes === 'string' && body.notes.trim().length > 0 ? body.notes.trim() : null
+    }
+
+    const { data: updated, error: updateErr } = await db
+      .from('service_location_constraints')
+      .update(update)
+      .eq('id', constraintId)
+      .select('*')
+      .single()
+
+    if (updateErr) return res.status(500).json({ error: updateErr.message })
+    return res.status(200).json({ constraint: updated })
+  }
+
+  if (req.method === 'DELETE') {
+    const { error } = await db
+      .from('service_location_constraints')
+      .delete()
+      .eq('id', constraintId)
+    if (error) return res.status(500).json({ error: error.message })
+    return res.status(204).end()
+  }
+
+  return res.status(405).json({ error: 'Method not allowed' })
+}

--- a/api/service-locations/[serviceLocationId]/constraints/index.ts
+++ b/api/service-locations/[serviceLocationId]/constraints/index.ts
@@ -1,0 +1,84 @@
+// GET    /api/service-locations/[serviceLocationId]/constraints
+//        → list all constraints attached to this service location
+// POST   /api/service-locations/[serviceLocationId]/constraints
+//        body: { constraint_type, enforcement, config, notes? }
+//        → create a constraint. account_id/client_id are pulled from the
+//        parent service_location row so the caller can't lie about scope.
+
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { createAdminClient } from '../../../_lib/supabase.js'
+import { authenticateRequest, type AuthContext } from '../../../_lib/auth.js'
+import { validateConstraint } from '../../../_lib/analysis/constraint-validators.js'
+
+export const config = { maxDuration: 10 }
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  let ctx: AuthContext
+  try {
+    ctx = await authenticateRequest(req)
+  } catch (err) {
+    const e = err as { statusCode?: number; message?: string }
+    return res.status(e.statusCode ?? 401).json({ error: e.message ?? 'Unauthorized' })
+  }
+
+  const serviceLocationId = req.query.serviceLocationId as string
+  if (!serviceLocationId) return res.status(400).json({ error: 'serviceLocationId required' })
+
+  const db = createAdminClient()
+
+  if (req.method === 'GET') {
+    const { data, error } = await db
+      .from('service_location_constraints')
+      .select('*')
+      .eq('service_location_id', serviceLocationId)
+      .order('created_at', { ascending: true })
+
+    if (error) return res.status(500).json({ error: error.message })
+    return res.status(200).json({ constraints: data ?? [] })
+  }
+
+  if (req.method === 'POST') {
+    const body = (req.body ?? {}) as Record<string, unknown>
+    const result = validateConstraint({
+      constraint_type: String(body.constraint_type ?? ''),
+      enforcement: String(body.enforcement ?? ''),
+      config: body.config,
+      notes: body.notes as string | null | undefined,
+    })
+    if (!result.ok) {
+      return res.status(400).json({ error: 'Invalid constraint', details: result.errors })
+    }
+
+    const { data: sl, error: slErr } = await db
+      .from('service_locations')
+      .select('id, account_id, client_id')
+      .eq('id', serviceLocationId)
+      .maybeSingle()
+
+    if (slErr) return res.status(500).json({ error: slErr.message })
+    if (!sl) return res.status(404).json({ error: 'Service location not found' })
+    if (!sl.account_id) {
+      return res.status(400).json({ error: 'Service location has no account_id — cannot scope constraint' })
+    }
+
+    const { data: inserted, error: insertErr } = await db
+      .from('service_location_constraints')
+      .insert({
+        service_location_id: serviceLocationId,
+        account_id: sl.account_id,
+        client_id: sl.client_id,
+        constraint_type: result.normalized!.constraint_type,
+        enforcement: result.normalized!.enforcement,
+        config: result.normalized!.config,
+        notes: typeof body.notes === 'string' && body.notes.trim().length > 0 ? body.notes.trim() : null,
+        created_by: ctx.email ?? ctx.userId ?? null,
+      })
+      .select('*')
+      .single()
+
+    if (insertErr) return res.status(500).json({ error: insertErr.message })
+    return res.status(201).json({ constraint: inserted })
+  }
+
+  return res.status(405).json({ error: 'Method not allowed' })
+}

--- a/src/components/property/AddConstraintDialog.tsx
+++ b/src/components/property/AddConstraintDialog.tsx
@@ -1,0 +1,474 @@
+// Add Constraint dialog — service location → type → enforcement → config →
+// optional notes → submit. Type picker is grouped (Schedule / Access /
+// Operations) to make the type-set discoverable. Per-type config form swaps
+// inline — no multi-step wizard since each type's config is small.
+import { useState } from 'react'
+import { useAuth } from '../../hooks/useAuth'
+import Button from '../ui/Button'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '../ui/Dialog'
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectGroup,
+  SelectLabel,
+  SelectItem,
+} from '../ui/Select'
+import { Input, Textarea, FormField } from '../ui/Input'
+import { cn } from '../../lib/cn'
+import {
+  CONSTRAINT_LABELS,
+  CONSTRAINT_DESCRIPTIONS,
+  CONSTRAINT_GROUPS,
+  type ConstraintType,
+} from './constraint-types'
+import type { ServiceLocation } from '../../types'
+
+interface Props {
+  open: boolean
+  onClose: () => void
+  serviceLocations: ServiceLocation[]
+  onCreated: () => void
+}
+
+export default function AddConstraintDialog({
+  open,
+  onClose,
+  serviceLocations,
+  onCreated,
+}: Props) {
+  const { getToken } = useAuth()
+
+  const [serviceLocationId, setServiceLocationId] = useState<string>(
+    serviceLocations[0]?.service_location_id ?? ''
+  )
+  const [type, setType] = useState<ConstraintType>('day_of_week')
+  const [enforcement, setEnforcement] = useState<'hard' | 'soft'>('hard')
+  const [config, setConfig] = useState<Record<string, unknown>>(() => defaultConfig('day_of_week'))
+  const [notes, setNotes] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  // Reset config when type changes
+  function changeType(next: ConstraintType) {
+    setType(next)
+    setConfig(defaultConfig(next))
+  }
+
+  function reset() {
+    setServiceLocationId(serviceLocations[0]?.service_location_id ?? '')
+    setType('day_of_week')
+    setEnforcement('hard')
+    setConfig(defaultConfig('day_of_week'))
+    setNotes('')
+    setError(null)
+  }
+
+  async function handleSubmit() {
+    if (!serviceLocationId) {
+      setError('Pick a service location.')
+      return
+    }
+    setSubmitting(true)
+    setError(null)
+    try {
+      const token = await getToken()
+      const res = await fetch(`/api/service-locations/${serviceLocationId}/constraints`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        body: JSON.stringify({ constraint_type: type, enforcement, config, notes }),
+      })
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}))
+        const detail = Array.isArray(body.details) ? ` — ${body.details.join('; ')}` : ''
+        throw new Error(`${body.error ?? `Save failed (${res.status})`}${detail}`)
+      }
+      reset()
+      onCreated()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(o) => {
+        if (!o) {
+          reset()
+          onClose()
+        }
+      }}
+    >
+      <DialogContent className="max-w-xl">
+        <DialogHeader>
+          <DialogTitle>Add service constraint</DialogTitle>
+          <DialogDescription>
+            Schedule, access, or operational rule for one service location.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          {serviceLocations.length > 1 && (
+            <FormField label="Service location" htmlFor="constraint-sl">
+              <Select value={serviceLocationId} onValueChange={setServiceLocationId}>
+                <SelectTrigger id="constraint-sl">
+                  <SelectValue placeholder="Pick a service location" />
+                </SelectTrigger>
+                <SelectContent>
+                  {serviceLocations.map((sl) => (
+                    <SelectItem key={sl.service_location_id} value={sl.service_location_id}>
+                      {sl.display_name ?? sl.service_location_id}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </FormField>
+          )}
+
+          <FormField label="Constraint type" htmlFor="constraint-type" helper={CONSTRAINT_DESCRIPTIONS[type]}>
+            <Select value={type} onValueChange={(v) => changeType(v as ConstraintType)}>
+              <SelectTrigger id="constraint-type">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {CONSTRAINT_GROUPS.map((g) => (
+                  <SelectGroup key={g.label}>
+                    <SelectLabel>{g.label}</SelectLabel>
+                    {g.types.map((t) => (
+                      <SelectItem key={t} value={t}>
+                        {CONSTRAINT_LABELS[t]}
+                      </SelectItem>
+                    ))}
+                  </SelectGroup>
+                ))}
+              </SelectContent>
+            </Select>
+          </FormField>
+
+          <FormField label="Enforcement">
+            <div className="flex gap-2">
+              {(['hard', 'soft'] as const).map((opt) => (
+                <button
+                  key={opt}
+                  type="button"
+                  onClick={() => setEnforcement(opt)}
+                  className={cn(
+                    'flex-1 rounded-md border px-3 py-2 text-sm transition-colors',
+                    enforcement === opt
+                      ? 'border-accent bg-accent/10 text-fg'
+                      : 'border-border bg-surface text-fg-muted hover:text-fg'
+                  )}
+                >
+                  <span className="font-medium capitalize">{opt}</span>
+                  <span className="block text-[11px] text-fg-subtle mt-0.5">
+                    {opt === 'hard' ? 'Must satisfy' : 'Preference'}
+                  </span>
+                </button>
+              ))}
+            </div>
+          </FormField>
+
+          <ConfigForm type={type} config={config} setConfig={setConfig} />
+
+          <FormField label="Notes (optional)" htmlFor="constraint-notes">
+            <Textarea
+              id="constraint-notes"
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              placeholder="Additional context, exceptions, etc."
+              rows={2}
+            />
+          </FormField>
+
+          {error && <p className="text-xs text-danger">{error}</p>}
+        </div>
+
+        <DialogFooter>
+          <Button variant="ghost" onClick={onClose}>Cancel</Button>
+          <Button onClick={handleSubmit} loading={submitting}>Save constraint</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function defaultConfig(type: ConstraintType): Record<string, unknown> {
+  switch (type) {
+    case 'day_of_week':
+      return { allowed_days: [1, 2, 3, 4, 5] } // Mon–Fri
+    case 'blackout_dates':
+      return { dates: [] }
+    case 'seasonal_window':
+      return { start_month: 1, end_month: 12 }
+    case 'time_window':
+      return { earliest_start: '08:00', latest_end: '17:00' }
+    case 'access_requirement':
+      return { kind: 'badge' }
+    case 'contact_requirement':
+      return {}
+  }
+}
+
+// Per-type config form. Edits flow through setConfig — never uses an
+// internal form lib because (a) the shapes are tiny and (b) the API
+// re-validates everything anyway.
+function ConfigForm({
+  type,
+  config,
+  setConfig,
+}: {
+  type: ConstraintType
+  config: Record<string, unknown>
+  setConfig: (c: Record<string, unknown>) => void
+}) {
+  if (type === 'day_of_week') return <DayOfWeekForm config={config} setConfig={setConfig} />
+  if (type === 'blackout_dates') return <BlackoutDatesForm config={config} setConfig={setConfig} />
+  if (type === 'seasonal_window') return <SeasonalWindowForm config={config} setConfig={setConfig} />
+  if (type === 'time_window') return <TimeWindowForm config={config} setConfig={setConfig} />
+  if (type === 'access_requirement') return <AccessRequirementForm config={config} setConfig={setConfig} />
+  if (type === 'contact_requirement') return <ContactRequirementForm config={config} setConfig={setConfig} />
+  return null
+}
+
+const DAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
+
+function DayOfWeekForm({
+  config,
+  setConfig,
+}: { config: Record<string, unknown>; setConfig: (c: Record<string, unknown>) => void }) {
+  const days = new Set((config.allowed_days as number[] | undefined) ?? [])
+  const toggle = (d: number) => {
+    const next = new Set(days)
+    if (next.has(d)) next.delete(d)
+    else next.add(d)
+    setConfig({ allowed_days: Array.from(next).sort((a, b) => a - b) })
+  }
+  return (
+    <FormField label="Allowed days" helper="Tap to toggle. Service is allowed only on selected days.">
+      <div className="flex gap-1">
+        {DAY_LABELS.map((label, i) => {
+          const on = days.has(i)
+          return (
+            <button
+              key={i}
+              type="button"
+              onClick={() => toggle(i)}
+              className={cn(
+                'flex-1 rounded-md border px-2 py-2 text-xs font-medium transition-colors',
+                on
+                  ? 'border-accent bg-accent/10 text-fg'
+                  : 'border-border bg-surface text-fg-subtle hover:text-fg'
+              )}
+            >
+              {label}
+            </button>
+          )
+        })}
+      </div>
+    </FormField>
+  )
+}
+
+function BlackoutDatesForm({
+  config,
+  setConfig,
+}: { config: Record<string, unknown>; setConfig: (c: Record<string, unknown>) => void }) {
+  const [draft, setDraft] = useState('')
+  const dates = (config.dates as string[] | undefined) ?? []
+  const addDate = () => {
+    if (!draft) return
+    setConfig({ dates: [...dates, draft] })
+    setDraft('')
+  }
+  const remove = (d: string) => setConfig({ dates: dates.filter((x) => x !== d) })
+  return (
+    <FormField label="Blackout dates" helper="Pick a date and click Add. Service will not run on these days.">
+      <div className="flex gap-2">
+        <Input type="date" value={draft} onChange={(e) => setDraft(e.target.value)} />
+        <Button type="button" variant="secondary" size="sm" onClick={addDate}>Add</Button>
+      </div>
+      {dates.length > 0 && (
+        <div className="flex flex-wrap gap-1 mt-2">
+          {dates.map((d) => (
+            <span
+              key={d}
+              className="inline-flex items-center gap-1 rounded-md border border-border bg-surface-subtle px-2 py-1 text-xs"
+            >
+              <span className="font-tabular">{d}</span>
+              <button
+                type="button"
+                onClick={() => remove(d)}
+                className="text-fg-subtle hover:text-danger"
+                aria-label={`Remove ${d}`}
+              >
+                ×
+              </button>
+            </span>
+          ))}
+        </div>
+      )}
+    </FormField>
+  )
+}
+
+const MONTHS = [
+  'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+  'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+]
+
+function SeasonalWindowForm({
+  config,
+  setConfig,
+}: { config: Record<string, unknown>; setConfig: (c: Record<string, unknown>) => void }) {
+  const sm = (config.start_month as number | undefined) ?? 1
+  const em = (config.end_month as number | undefined) ?? 12
+  return (
+    <div className="grid grid-cols-2 gap-3">
+      <FormField label="Start month">
+        <Select
+          value={String(sm)}
+          onValueChange={(v) => setConfig({ ...config, start_month: Number(v) })}
+        >
+          <SelectTrigger><SelectValue /></SelectTrigger>
+          <SelectContent>
+            {MONTHS.map((m, i) => (
+              <SelectItem key={i} value={String(i + 1)}>{m}</SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </FormField>
+      <FormField label="End month" helper={sm > em ? 'Wraps around the year (Nov–Mar = Nov, Dec, Jan, Feb, Mar)' : undefined}>
+        <Select
+          value={String(em)}
+          onValueChange={(v) => setConfig({ ...config, end_month: Number(v) })}
+        >
+          <SelectTrigger><SelectValue /></SelectTrigger>
+          <SelectContent>
+            {MONTHS.map((m, i) => (
+              <SelectItem key={i} value={String(i + 1)}>{m}</SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </FormField>
+    </div>
+  )
+}
+
+function TimeWindowForm({
+  config,
+  setConfig,
+}: { config: Record<string, unknown>; setConfig: (c: Record<string, unknown>) => void }) {
+  return (
+    <div className="grid grid-cols-2 gap-3">
+      <FormField label="Earliest start">
+        <Input
+          type="time"
+          value={(config.earliest_start as string | undefined) ?? ''}
+          onChange={(e) => setConfig({ ...config, earliest_start: e.target.value })}
+        />
+      </FormField>
+      <FormField label="Latest end">
+        <Input
+          type="time"
+          value={(config.latest_end as string | undefined) ?? ''}
+          onChange={(e) => setConfig({ ...config, latest_end: e.target.value })}
+        />
+      </FormField>
+    </div>
+  )
+}
+
+const ACCESS_KINDS = [
+  { value: 'badge', label: 'Badge required' },
+  { value: 'escort', label: 'Escort required' },
+  { value: 'key', label: 'Key required' },
+  { value: 'code', label: 'Access code' },
+  { value: 'other', label: 'Other' },
+]
+
+function AccessRequirementForm({
+  config,
+  setConfig,
+}: { config: Record<string, unknown>; setConfig: (c: Record<string, unknown>) => void }) {
+  return (
+    <>
+      <FormField label="Access kind">
+        <Select
+          value={(config.kind as string | undefined) ?? 'badge'}
+          onValueChange={(v) => setConfig({ ...config, kind: v })}
+        >
+          <SelectTrigger><SelectValue /></SelectTrigger>
+          <SelectContent>
+            {ACCESS_KINDS.map((k) => (
+              <SelectItem key={k.value} value={k.value}>{k.label}</SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </FormField>
+      <FormField label="Details (optional)">
+        <Input
+          value={(config.details as string | undefined) ?? ''}
+          onChange={(e) => setConfig({ ...config, details: e.target.value })}
+          placeholder="e.g. Pick up badge from front desk"
+        />
+      </FormField>
+    </>
+  )
+}
+
+function ContactRequirementForm({
+  config,
+  setConfig,
+}: { config: Record<string, unknown>; setConfig: (c: Record<string, unknown>) => void }) {
+  return (
+    <div className="grid grid-cols-2 gap-3">
+      <FormField label="Contact name">
+        <Input
+          value={(config.contact_name as string | undefined) ?? ''}
+          onChange={(e) => setConfig({ ...config, contact_name: e.target.value })}
+        />
+      </FormField>
+      <FormField label="Contact phone">
+        <Input
+          value={(config.contact_phone as string | undefined) ?? ''}
+          onChange={(e) => setConfig({ ...config, contact_phone: e.target.value })}
+          placeholder="555-555-5555"
+        />
+      </FormField>
+      <FormField label="Advance notice (hours)">
+        <Input
+          type="number"
+          min={0}
+          value={
+            config.advance_notice_hours == null ? '' : String(config.advance_notice_hours)
+          }
+          onChange={(e) =>
+            setConfig({
+              ...config,
+              advance_notice_hours: e.target.value === '' ? undefined : Number(e.target.value),
+            })
+          }
+        />
+      </FormField>
+      <FormField label="Instructions" className="col-span-2">
+        <Textarea
+          value={(config.instructions as string | undefined) ?? ''}
+          onChange={(e) => setConfig({ ...config, instructions: e.target.value })}
+          placeholder="Anything the crew should know before arriving"
+          rows={2}
+        />
+      </FormField>
+    </div>
+  )
+}

--- a/src/components/property/ConstraintsPanel.tsx
+++ b/src/components/property/ConstraintsPanel.tsx
@@ -1,0 +1,241 @@
+// Service-location constraints panel. Sits on PropertyDetail between the
+// Risk Assessment card and Comparable Properties.
+//
+// Shows all constraints for the property, grouped by service location.
+// Edit-in-place isn't supported in PR1 — delete + re-add is the workflow.
+import { useEffect, useState, useCallback } from 'react'
+import { Trash2, Plus } from 'lucide-react'
+import { useAuth } from '../../hooks/useAuth'
+import Button from '../ui/Button'
+import { Badge } from '../ui/Badge'
+import { Card, CardTitle, CardDescription } from '../ui/Card'
+import { EmptyState } from '../ui/EmptyState'
+import { cn } from '../../lib/cn'
+import AddConstraintDialog from './AddConstraintDialog'
+import { CONSTRAINT_LABELS, type ConstraintType } from './constraint-types'
+import type { ServiceLocation } from '../../types'
+
+export interface ConstraintRow {
+  id: string
+  service_location_id: string
+  constraint_type: ConstraintType
+  enforcement: 'hard' | 'soft'
+  config: Record<string, unknown>
+  notes: string | null
+  created_at: string
+  created_by: string | null
+}
+
+interface Props {
+  serviceLocations: ServiceLocation[]
+}
+
+export default function ConstraintsPanel({ serviceLocations }: Props) {
+  const { getToken } = useAuth()
+  const [rowsBySl, setRowsBySl] = useState<Record<string, ConstraintRow[]>>({})
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [dialogOpen, setDialogOpen] = useState(false)
+  const [deletingId, setDeletingId] = useState<string | null>(null)
+
+  const loadAll = useCallback(async () => {
+    if (serviceLocations.length === 0) {
+      setRowsBySl({})
+      setLoading(false)
+      return
+    }
+    setLoading(true)
+    setError(null)
+    try {
+      const token = await getToken()
+      const fetched = await Promise.all(
+        serviceLocations.map(async (sl) => {
+          const res = await fetch(
+            `/api/service-locations/${sl.service_location_id}/constraints`,
+            { headers: { Authorization: `Bearer ${token}` } }
+          )
+          if (!res.ok) throw new Error(`Failed to load constraints (${res.status})`)
+          const json = (await res.json()) as { constraints: ConstraintRow[] }
+          return [sl.service_location_id, json.constraints] as const
+        })
+      )
+      const map: Record<string, ConstraintRow[]> = {}
+      for (const [slId, rows] of fetched) map[slId] = rows
+      setRowsBySl(map)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setLoading(false)
+    }
+  }, [serviceLocations, getToken])
+
+  useEffect(() => {
+    loadAll()
+  }, [loadAll])
+
+  async function handleDelete(slId: string, constraintId: string) {
+    setDeletingId(constraintId)
+    try {
+      const token = await getToken()
+      const res = await fetch(
+        `/api/service-locations/${slId}/constraints/${constraintId}`,
+        { method: 'DELETE', headers: { Authorization: `Bearer ${token}` } }
+      )
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}))
+        throw new Error(body.error ?? `Delete failed (${res.status})`)
+      }
+      await loadAll()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setDeletingId(null)
+    }
+  }
+
+  const totalCount = Object.values(rowsBySl).reduce((n, rows) => n + rows.length, 0)
+
+  return (
+    <Card>
+      <div className="flex items-start justify-between gap-3">
+        <div className="space-y-1">
+          <CardTitle>Service constraints</CardTitle>
+          <CardDescription>
+            Schedule, access, and operational rules attached to each service location.
+          </CardDescription>
+        </div>
+        <Button
+          size="sm"
+          variant="secondary"
+          onClick={() => setDialogOpen(true)}
+          disabled={serviceLocations.length === 0}
+        >
+          <Plus className="h-3.5 w-3.5" />
+          Add constraint
+        </Button>
+      </div>
+
+      <div className="mt-4">
+        {loading ? (
+          <p className="text-sm text-fg-muted">Loading constraints…</p>
+        ) : error ? (
+          <p className="text-sm text-danger">Error: {error}</p>
+        ) : serviceLocations.length === 0 ? (
+          <EmptyState
+            title="No service locations"
+            description="Constraints attach to service locations. Add one to this property first."
+          />
+        ) : totalCount === 0 ? (
+          <p className="text-sm text-fg-muted">
+            No constraints yet. Click <span className="font-medium text-fg">Add constraint</span> to define schedule,
+            access, or operational rules for this property's service locations.
+          </p>
+        ) : (
+          <div className="space-y-4">
+            {serviceLocations.map((sl) => {
+              const rows = rowsBySl[sl.service_location_id] ?? []
+              if (rows.length === 0) return null
+              return (
+                <div key={sl.service_location_id}>
+                  <p className="text-[10px] font-semibold uppercase tracking-wider text-fg-subtle mb-2">
+                    {sl.display_name ?? sl.service_location_id}
+                  </p>
+                  <ul className="space-y-2">
+                    {rows.map((r) => (
+                      <li
+                        key={r.id}
+                        className={cn(
+                          'rounded-md border-l-2 bg-surface-subtle px-3 py-2 text-sm',
+                          r.enforcement === 'hard' ? 'border-accent' : 'border-fg-subtle'
+                        )}
+                      >
+                        <div className="flex items-start justify-between gap-3">
+                          <div className="flex-1 min-w-0">
+                            <div className="flex items-center gap-2 flex-wrap">
+                              <span className="font-medium text-fg">
+                                {CONSTRAINT_LABELS[r.constraint_type] ?? r.constraint_type}
+                              </span>
+                              <Badge variant={r.enforcement === 'hard' ? 'accent' : 'outline'}>
+                                {r.enforcement}
+                              </Badge>
+                            </div>
+                            <p className="mt-0.5 text-xs text-fg-muted">
+                              {summarizeConfig(r.constraint_type, r.config)}
+                            </p>
+                            {r.notes && (
+                              <p className="mt-1 text-xs text-fg-subtle italic">{r.notes}</p>
+                            )}
+                          </div>
+                          <button
+                            type="button"
+                            onClick={() => handleDelete(sl.service_location_id, r.id)}
+                            disabled={deletingId === r.id}
+                            className="text-fg-subtle hover:text-danger transition-colors disabled:opacity-50"
+                            aria-label="Delete constraint"
+                          >
+                            <Trash2 className="h-3.5 w-3.5" />
+                          </button>
+                        </div>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )
+            })}
+          </div>
+        )}
+      </div>
+
+      <AddConstraintDialog
+        open={dialogOpen}
+        onClose={() => setDialogOpen(false)}
+        serviceLocations={serviceLocations}
+        onCreated={() => {
+          setDialogOpen(false)
+          loadAll()
+        }}
+      />
+    </Card>
+  )
+}
+
+const DAY_NAMES = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
+const MONTH_NAMES = [
+  'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+  'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+]
+
+function summarizeConfig(type: ConstraintType, c: Record<string, unknown>): string {
+  switch (type) {
+    case 'day_of_week': {
+      const days = (c.allowed_days as number[] | undefined) ?? []
+      if (days.length === 7) return 'All days allowed'
+      return `Allowed: ${days.map((d) => DAY_NAMES[d]).join(', ')}`
+    }
+    case 'blackout_dates': {
+      const dates = (c.dates as string[] | undefined) ?? []
+      if (dates.length <= 3) return `Blackout: ${dates.join(', ')}`
+      return `Blackout: ${dates.slice(0, 3).join(', ')} +${dates.length - 3} more`
+    }
+    case 'seasonal_window': {
+      const sm = c.start_month as number
+      const em = c.end_month as number
+      return `${MONTH_NAMES[sm - 1]}–${MONTH_NAMES[em - 1]}`
+    }
+    case 'time_window': {
+      return `${c.earliest_start}–${c.latest_end}`
+    }
+    case 'access_requirement': {
+      const details = c.details ? ` (${c.details})` : ''
+      return `${c.kind}${details}`
+    }
+    case 'contact_requirement': {
+      const parts: string[] = []
+      if (c.contact_name) parts.push(`Contact: ${c.contact_name}`)
+      if (c.contact_phone) parts.push(`${c.contact_phone}`)
+      if (c.advance_notice_hours != null) parts.push(`${c.advance_notice_hours}h notice`)
+      if (c.instructions) parts.push(`"${c.instructions}"`)
+      return parts.join(' · ')
+    }
+  }
+}

--- a/src/components/property/constraint-types.ts
+++ b/src/components/property/constraint-types.ts
@@ -1,0 +1,37 @@
+// Shared client-side constants for service-location constraint types.
+// Mirrors api/_lib/analysis/constraint-validators.ts — keep in sync.
+
+export type ConstraintType =
+  | 'day_of_week'
+  | 'blackout_dates'
+  | 'seasonal_window'
+  | 'time_window'
+  | 'access_requirement'
+  | 'contact_requirement'
+
+export const CONSTRAINT_LABELS: Record<ConstraintType, string> = {
+  day_of_week: 'Day-of-week restriction',
+  blackout_dates: 'Blackout dates',
+  seasonal_window: 'Seasonal window',
+  time_window: 'Time-of-day window',
+  access_requirement: 'Access requirement',
+  contact_requirement: 'Contact requirement',
+}
+
+export const CONSTRAINT_DESCRIPTIONS: Record<ConstraintType, string> = {
+  day_of_week: 'Restrict service to specific days of the week.',
+  blackout_dates: 'Specific dates when service is not allowed.',
+  seasonal_window: 'Service only allowed within a month range.',
+  time_window: 'Service must occur within a daily time range.',
+  access_requirement: 'Site access requirements (badge, escort, etc).',
+  contact_requirement: 'On-site contact or advance-notice requirements.',
+}
+
+export const CONSTRAINT_GROUPS: {
+  label: string
+  types: ConstraintType[]
+}[] = [
+  { label: 'Schedule', types: ['day_of_week', 'blackout_dates', 'seasonal_window', 'time_window'] },
+  { label: 'Access', types: ['access_requirement'] },
+  { label: 'Operations', types: ['contact_requirement'] },
+]

--- a/src/pages/PropertyDetail.tsx
+++ b/src/pages/PropertyDetail.tsx
@@ -19,6 +19,7 @@ import {
 import AppShell from '../components/layout/AppShell'
 import ComparablesPanel from '../components/analysis/ComparablesPanel'
 import ServiceMixPanel from '../components/analysis/ServiceMixPanel'
+import ConstraintsPanel from '../components/property/ConstraintsPanel'
 import { CATEGORY_COLORS, STATUS_LABELS } from '../lib/constants'
 import { cn } from '../lib/cn'
 import type { ServiceLocation } from '../types'
@@ -559,6 +560,9 @@ export default function PropertyDetailPage() {
                 )}
               </div>
             </Card>
+
+            {/* Service constraints */}
+            <ConstraintsPanel serviceLocations={property.service_locations} />
 
             {/* Comparable Properties */}
             <ComparablesPanel propertyId={property.property_id} />

--- a/supabase/migrations/20260430033630_phase4a_service_location_constraints.sql
+++ b/supabase/migrations/20260430033630_phase4a_service_location_constraints.sql
@@ -1,0 +1,62 @@
+-- Phase 4a: Service-location constraints.
+--
+-- Each row is one constraint attached to a service_location (e.g. "no service
+-- on Sundays", "blackout dates Dec 24–26", "must coordinate with on-site
+-- contact"). Constraints are typed via constraint_type, with type-specific
+-- config validated in the API layer (api/_lib/analysis/constraint-validators.ts).
+--
+-- Enforcement is either 'hard' (must satisfy or schedule fails) or 'soft'
+-- (preference — penalty in the scheduler's objective).
+--
+-- account_id + client_id are denormalized so tenant scoping doesn't require
+-- a join through service_locations on every read.
+
+CREATE TABLE IF NOT EXISTS public.service_location_constraints (
+  id                   UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  service_location_id  UUID NOT NULL REFERENCES public.service_locations(id) ON DELETE CASCADE,
+  account_id           UUID NOT NULL REFERENCES public.accounts(id) ON DELETE CASCADE,
+  client_id            UUID REFERENCES public.clients(id) ON DELETE CASCADE,
+
+  constraint_type      TEXT NOT NULL,
+  enforcement          TEXT NOT NULL CHECK (enforcement IN ('hard', 'soft')),
+  config               JSONB NOT NULL DEFAULT '{}'::jsonb,
+  notes                TEXT,
+
+  created_at           TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at           TIMESTAMPTZ NOT NULL DEFAULT now(),
+  created_by           TEXT
+);
+
+CREATE INDEX IF NOT EXISTS service_location_constraints_sl_idx
+  ON public.service_location_constraints(service_location_id);
+
+CREATE INDEX IF NOT EXISTS service_location_constraints_tenant_idx
+  ON public.service_location_constraints(account_id, client_id);
+
+CREATE INDEX IF NOT EXISTS service_location_constraints_type_idx
+  ON public.service_location_constraints(constraint_type);
+
+-- Saved bundles of constraints that can be applied to many service locations
+-- in one operation (e.g. "Standard retail M–F 8a–6p"). The constraints[] is
+-- an array of { constraint_type, enforcement, config, notes? } — the same
+-- shape that's persisted in service_location_constraints rows.
+
+CREATE TABLE IF NOT EXISTS public.service_location_constraint_templates (
+  id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  account_id   UUID NOT NULL REFERENCES public.accounts(id) ON DELETE CASCADE,
+  client_id    UUID REFERENCES public.clients(id) ON DELETE CASCADE,
+
+  name         TEXT NOT NULL,
+  description  TEXT,
+  constraints  JSONB NOT NULL DEFAULT '[]'::jsonb,
+
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+  created_by   TEXT
+);
+
+CREATE INDEX IF NOT EXISTS service_location_constraint_templates_tenant_idx
+  ON public.service_location_constraint_templates(account_id, client_id);
+
+CREATE UNIQUE INDEX IF NOT EXISTS service_location_constraint_templates_name_unique
+  ON public.service_location_constraint_templates(account_id, client_id, name);


### PR DESCRIPTION
## Summary
- Foundation for the upcoming scheduler: each `service_location` can now carry typed constraints (schedule, access, operational) with hard or soft enforcement.
- Two new tables: `service_location_constraints` (per-row constraints) and `service_location_constraint_templates` (saved bundles, used in PR3).
- Six initial constraint types with hand-rolled per-type validators that also normalize the incoming config (dedup days, sort ISO dates, trim strings, etc.).
- CRUD API + Property Detail UI panel + Add Constraint dialog with type-grouped picker (Schedule / Access / Operations) and a dynamic config form per type.

## Schema
```sql
service_location_constraints (
  id uuid pk,
  service_location_id uuid -> service_locations(id) cascade,
  account_id uuid -> accounts(id) cascade,           -- denormalized for tenant filtering
  client_id uuid -> clients(id) cascade,             -- denormalized, nullable
  constraint_type text,                              -- not enum so adding types doesn't need a migration
  enforcement text check (hard|soft),
  config jsonb default '{}',                         -- type-specific shape, validated in API layer
  notes text,
  created_at, updated_at, created_by
)

service_location_constraint_templates (
  id uuid pk,
  account_id, client_id,
  name text,
  description text,
  constraints jsonb,                                 -- array of { constraint_type, enforcement, config, notes? }
  audit cols
)
-- unique (account_id, client_id, name)
```

## Constraint types

| Type | Config shape | Group |
|---|---|---|
| `day_of_week` | `{ allowed_days: 0..6[] }` | Schedule |
| `blackout_dates` | `{ dates: 'YYYY-MM-DD'[] }` | Schedule |
| `seasonal_window` | `{ start_month: 1..12, end_month: 1..12 }` (wraps) | Schedule |
| `time_window` | `{ earliest_start: 'HH:MM', latest_end: 'HH:MM' }` | Schedule |
| `access_requirement` | `{ kind: badge\|escort\|key\|code\|other, details? }` | Access |
| `contact_requirement` | `{ contact_name?, contact_phone?, advance_notice_hours?, instructions? }` (≥1 required) | Operations |

## API
- `GET    /api/service-locations/[serviceLocationId]/constraints` — list
- `POST   /api/service-locations/[serviceLocationId]/constraints` — create (account/client_id pulled from parent SL row, not body)
- `PUT    /api/service-locations/[serviceLocationId]/constraints/[constraintId]` — partial update; revalidates merged shape
- `DELETE /api/service-locations/[serviceLocationId]/constraints/[constraintId]` — verifies the constraint actually belongs to the SL in the URL before deleting

## Trade-offs
- **No edit-in-place** — delete + re-add for now. Cuts the dialog complexity in half. Can add later if it's a real pain point.
- **No Zod** — six small shapes, normalization needs custom code anyway. Avoided pulling in a new runtime dep just for this.
- **constraint_type is TEXT, not a DB enum** — so adding a 7th type doesn't need a migration; the API is the source of truth.
- **Templates + bulk-apply** are scoped to PR3.

## Test plan
- [ ] Open a property's detail page → "Service constraints" card shows under Risk Assessment, before Comparables
- [ ] Click "Add constraint" → dialog opens, type picker shows three groups, each type renders its own config form
- [ ] Save a `day_of_week` constraint with M-F → row appears in panel with "Mon, Tue, Wed, Thu, Fri" summary and `hard` badge
- [ ] Save a `seasonal_window` Nov→Mar → summary reads "Nov–Mar"
- [ ] Try a `contact_requirement` with all fields blank → API returns 400 with the "at least one of …" message
- [ ] Delete a constraint → row disappears, others stay
- [ ] Property with zero service_locations → empty state, "Add constraint" disabled
- [ ] DELETE with wrong serviceLocationId in path → 404 (the cross-SL check kicks in)

🤖 Generated with [Claude Code](https://claude.com/claude-code)