### PR TITLE
Phase 4a PR2: property editing + audit trail

### DIFF
--- a/api/_lib/property-audit.ts
+++ b/api/_lib/property-audit.ts
@@ -1,0 +1,105 @@
+// Audit helper for property + service_location edits. Diffs the old row
+// against the patched fields and writes one property_edit_history row per
+// changed field.
+//
+// Used by both PATCH /properties/[id] and PATCH /service-locations/[id]
+// so the audit log reads as a single timeline of edits per property.
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+export interface AuditScope {
+  propertyId: string
+  serviceLocationId?: string | null
+  accountId?: string | null
+  clientId?: string | null
+}
+
+export interface AuditOptions {
+  changedBy?: string | null
+}
+
+// Returns the list of field names that actually changed (after deep equality
+// for arrays). Empty array means nothing was logged.
+export async function recordEdits(
+  db: SupabaseClient,
+  scope: AuditScope,
+  oldRow: Record<string, unknown>,
+  newRow: Record<string, unknown>,
+  fieldKeys: string[],
+  opts: AuditOptions = {}
+): Promise<string[]> {
+  const rows: Array<Record<string, unknown>> = []
+  const changedKeys: string[] = []
+
+  for (const key of fieldKeys) {
+    if (!(key in newRow)) continue
+    const oldVal = oldRow[key]
+    const newVal = newRow[key]
+    if (deepEqual(oldVal, newVal)) continue
+
+    changedKeys.push(key)
+    rows.push({
+      property_id: scope.propertyId,
+      service_location_id: scope.serviceLocationId ?? null,
+      account_id: scope.accountId ?? null,
+      client_id: scope.clientId ?? null,
+      field_name: key,
+      old_value: oldVal === undefined ? null : oldVal,
+      new_value: newVal === undefined ? null : newVal,
+      changed_by: opts.changedBy ?? null,
+    })
+  }
+
+  if (rows.length === 0) return []
+
+  const { error } = await db.from('property_edit_history').insert(rows)
+  if (error) {
+    // Audit failures shouldn't break the user's edit — log and move on.
+    console.error('property_edit_history insert failed:', error.message)
+  }
+  return changedKeys
+}
+
+function deepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true
+  if (a == null || b == null) return a == null && b == null
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) return false
+    for (let i = 0; i < a.length; i++) if (!deepEqual(a[i], b[i])) return false
+    return true
+  }
+  if (typeof a === 'object' && typeof b === 'object') {
+    const ak = Object.keys(a as object)
+    const bk = Object.keys(b as object)
+    if (ak.length !== bk.length) return false
+    for (const k of ak) {
+      if (!deepEqual((a as Record<string, unknown>)[k], (b as Record<string, unknown>)[k])) return false
+    }
+    return true
+  }
+  return false
+}
+
+// Mark the most recent completed crew_strategy analysis as 'stale' so the
+// dashboard prompts a re-run. Called when serviceable_sqft moves >10%.
+export async function markCrewStrategyStale(
+  db: SupabaseClient,
+  accountId: string,
+  clientId: string
+): Promise<void> {
+  const { data: latest } = await db
+    .from('portfolio_analyses')
+    .select('id')
+    .eq('account_id', accountId)
+    .eq('client_id', clientId)
+    .eq('module_key', 'crew_strategy')
+    .eq('status', 'completed')
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .maybeSingle()
+
+  if (!latest) return
+  await db
+    .from('portfolio_analyses')
+    .update({ status: 'stale' })
+    .eq('id', (latest as { id: string }).id)
+}

--- a/api/v1/properties/[id].ts
+++ b/api/v1/properties/[id].ts
@@ -2,6 +2,15 @@ import type { VercelRequest, VercelResponse } from '@vercel/node'
 import { createAdminClient } from '../../_lib/supabase.js'
 import { authenticateRequest } from '../../_lib/auth.js'
 import { fireWebhook } from '../../_lib/webhooks.js'
+import { validateAddress, geocodeAddress } from '../../_lib/google-address.js'
+import { recordEdits } from '../../_lib/property-audit.js'
+import {
+  PROPERTY_FIELDS,
+  ADDRESS_FIELD_KEYS,
+  isEditablePropertyField,
+} from '../../../src/lib/editable-fields.js'
+
+export const config = { maxDuration: 30 }
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method === 'OPTIONS') return res.status(200).end()
@@ -14,25 +23,20 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   }
 
   const { id } = req.query
+  const propertyId = id as string
   const db = createAdminClient()
 
   if (req.method === 'GET') {
-    // Embed service_locations only — enrichment_jobs has property_ids as a
-    // UUID[] array (no FK to properties), so PostgREST can't resolve it as
-    // an embedded relationship and the whole query fails. The property
-    // detail page only declares enrichment_jobs in its TS type and doesn't
-    // render it, so dropping it here loses nothing.
     const { data, error } = await db
       .from('properties')
       .select('*, service_locations(*)')
-      .eq('id', id)
+      .eq('id', propertyId)
       .single()
 
     if (error || !data) {
       return res.status(404).json({ error: error?.message ?? 'Not found' })
     }
 
-    // Alias real PKs (properties.id, service_locations.id) for frontend compatibility.
     const aliased = {
       ...data,
       property_id: (data as any).id,
@@ -45,42 +49,126 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   }
 
   if (req.method === 'PATCH') {
-    const updates = req.body ?? {}
-    const changedFields = Object.keys(updates)
+    const body = (req.body ?? {}) as Record<string, unknown>
 
-    if (changedFields.includes('rbm_category')) {
-      const { data: current } = await db
-        .from('properties')
-        .select('rbm_category')
-        .eq('id', id)
-        .single()
+    // Whitelist — silently drop anything not in PROPERTY_FIELDS so callers
+    // can't update system-managed columns (lat/lng, address_hash,
+    // geocode_*, enrichment_*, validated_*) by stuffing them into PATCH.
+    const updates: Record<string, unknown> = {}
+    const rejected: string[] = []
+    for (const [k, v] of Object.entries(body)) {
+      if (isEditablePropertyField(k)) updates[k] = v
+      else rejected.push(k)
+    }
 
-      await db.from('property_changes').insert({
-        property_id: id,
-        field_name: 'rbm_category',
-        old_value: current?.rbm_category,
-        new_value: updates.rbm_category,
-        changed_by: ctx.userId,
-        changed_at: new Date().toISOString(),
+    if (Object.keys(updates).length === 0) {
+      return res.status(400).json({
+        error: 'No editable fields in body',
+        editable: PROPERTY_FIELDS.map((f) => f.key),
+        rejected,
       })
     }
 
-    const { data, error } = await db
+    // Snapshot the current row so we can diff for audit + detect address change.
+    const { data: current, error: fetchErr } = await db
       .from('properties')
-      .update({ ...updates, updated_at: new Date().toISOString() })
-      .eq('id', id)
-      .select()
+      .select('*')
+      .eq('id', propertyId)
       .single()
 
-    if (error) return res.status(500).json({ error: error.message })
+    if (fetchErr || !current) {
+      return res.status(404).json({ error: fetchErr?.message ?? 'Not found' })
+    }
+
+    const { data: updated, error: updateErr } = await db
+      .from('properties')
+      .update({ ...updates, updated_at: new Date().toISOString() })
+      .eq('id', propertyId)
+      .select('*')
+      .single()
+
+    if (updateErr) return res.status(500).json({ error: updateErr.message })
+
+    const accountId = (current as any).account_id ?? null
+    const clientId = (current as any).client_id ?? null
+    const changed = await recordEdits(
+      db,
+      { propertyId, accountId, clientId },
+      current as Record<string, unknown>,
+      updated as Record<string, unknown>,
+      Object.keys(updates),
+      { changedBy: ctx.email ?? ctx.userId ?? null }
+    )
+
+    // Side effect: address change → re-validate + re-geocode + persist
+    // lat/lng. Done synchronously so the user sees the corrected map pin
+    // without a follow-up refresh.
+    let geocodeResult: { lat: number | null; lng: number | null; verdict: string | null } | null = null
+    const addressChanged = changed.some((k) => ADDRESS_FIELD_KEYS.includes(k))
+    if (addressChanged) {
+      try {
+        const addr = {
+          address_line1: String((updated as any).address_line1 ?? ''),
+          address_line2: ((updated as any).address_line2 as string | null) ?? null,
+          city: String((updated as any).city ?? ''),
+          state: String((updated as any).state ?? ''),
+          postal_code: String((updated as any).postal_code ?? ''),
+          country: String((updated as any).country ?? 'US'),
+        }
+        const validation = await validateAddress(addr)
+        const geo = await geocodeAddress(validation?.validated ?? addr)
+
+        const patch: Record<string, unknown> = {}
+        if (validation) {
+          patch.address_validation_result = validation.raw_response
+          patch.address_validation_verdict = validation.verdict
+          patch.address_validated_at = new Date().toISOString()
+          patch.validated_address_line1 = validation.validated.address_line1
+          patch.validated_city = validation.validated.city
+          patch.validated_state = validation.validated.state
+          patch.validated_postal_code = validation.validated.postal_code
+          patch.validated_country = validation.validated.country
+        }
+        if (geo) {
+          patch.latitude = geo.latitude
+          patch.longitude = geo.longitude
+          patch.geocode_source = geo.source
+          patch.geocode_confidence = geo.confidence
+          patch.geocoded_at = new Date().toISOString()
+          patch.google_place_id = geo.place_id
+        }
+        if (Object.keys(patch).length > 0) {
+          await db.from('properties').update(patch).eq('id', propertyId)
+        }
+        geocodeResult = {
+          lat: geo?.latitude ?? null,
+          lng: geo?.longitude ?? null,
+          verdict: validation?.verdict ?? null,
+        }
+      } catch (err) {
+        console.error('re-geocode after address edit failed:', err)
+      }
+    }
 
     await fireWebhook('property.updated', {
-      property_id: id,
-      changed_fields: changedFields,
+      property_id: propertyId,
+      changed_fields: changed,
       changed_by: ctx.userId ?? 'service',
     })
 
-    return res.status(200).json({ property: data })
+    // Return the freshest row including any geocode patch.
+    const { data: finalRow } = await db
+      .from('properties')
+      .select('*')
+      .eq('id', propertyId)
+      .single()
+
+    return res.status(200).json({
+      property: finalRow,
+      changed_fields: changed,
+      rejected_fields: rejected,
+      geocode: geocodeResult,
+    })
   }
 
   return res.status(405).json({ error: 'Method not allowed' })

--- a/api/v1/properties/[id]/edit-history.ts
+++ b/api/v1/properties/[id]/edit-history.ts
@@ -1,6 +1,6 @@
-// Returns the edit history for the parent property of this service_location
-// (covers both property-level and SL-level edits). Reads from the Phase 4a
-// PR2 property_edit_history table.
+// GET /api/v1/properties/[id]/edit-history
+// Full edit log for a property — both property-level edits and SL-level
+// edits show up here, ordered newest first.
 import type { VercelRequest, VercelResponse } from '@vercel/node'
 import { createAdminClient } from '../../../_lib/supabase.js'
 import { authenticateRequest } from '../../../_lib/auth.js'
@@ -18,21 +18,13 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   const { id } = req.query
   const db = createAdminClient()
 
-  const { data: loc } = await db
-    .from('service_locations')
-    .select('property_id')
-    .eq('id', id)
-    .single()
-
-  if (!loc) return res.status(404).json({ error: 'Not found' })
-
   const { data, error } = await db
     .from('property_edit_history')
     .select('*')
-    .eq('property_id', (loc as { property_id: string }).property_id)
+    .eq('property_id', id)
     .order('changed_at', { ascending: false })
-    .limit(50)
+    .limit(100)
 
   if (error) return res.status(500).json({ error: error.message })
-  return res.status(200).json(data ?? [])
+  return res.status(200).json({ history: data ?? [] })
 }

--- a/api/v1/service-locations/[id].ts
+++ b/api/v1/service-locations/[id].ts
@@ -2,29 +2,37 @@ import type { VercelRequest, VercelResponse } from '@vercel/node'
 import { createAdminClient } from '../../_lib/supabase.js'
 import { authenticateRequest } from '../../_lib/auth.js'
 import { fireWebhook } from '../../_lib/webhooks.js'
+import { recordEdits, markCrewStrategyStale } from '../../_lib/property-audit.js'
+import {
+  SERVICE_LOCATION_FIELDS,
+  isEditableServiceLocationField,
+} from '../../../src/lib/editable-fields.js'
+
+const SQFT_STALE_THRESHOLD = 0.1 // 10%
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method === 'OPTIONS') return res.status(200).end()
 
+  let ctx: Awaited<ReturnType<typeof authenticateRequest>>
   try {
-    await authenticateRequest(req)
+    ctx = await authenticateRequest(req)
   } catch (err: any) {
     return res.status(err.statusCode ?? 401).json({ error: err.message ?? 'Unauthorized' })
   }
 
   const { id } = req.query
+  const slId = id as string
   const db = createAdminClient()
 
   if (req.method === 'GET') {
     const { data, error } = await db
       .from('service_locations')
       .select('*, property:properties(*)')
-      .eq('id', id)
+      .eq('id', slId)
       .single()
 
     if (error || !data) return res.status(404).json({ error: 'Not found' })
 
-    // Alias real PKs (id) to legacy field names for frontend compatibility.
     const sl: any = data
     const aliasedSl = { ...sl, service_location_id: sl.id }
     const aliasedProperty = sl.property
@@ -34,36 +42,88 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   }
 
   if (req.method === 'PATCH') {
-    const updates = req.body ?? {}
-    const oldStatus = updates.status
-      ? (
-          await db
-            .from('service_locations')
-            .select('status')
-            .eq('id', id)
-            .single()
-        ).data?.status
-      : undefined
+    const body = (req.body ?? {}) as Record<string, unknown>
 
-    const { data, error } = await db
-      .from('service_locations')
-      .update({ ...updates, updated_at: new Date().toISOString() })
-      .eq('id', id)
-      .select()
-      .single()
+    const updates: Record<string, unknown> = {}
+    const rejected: string[] = []
+    for (const [k, v] of Object.entries(body)) {
+      if (isEditableServiceLocationField(k)) updates[k] = v
+      else rejected.push(k)
+    }
 
-    if (error) return res.status(500).json({ error: error.message })
-
-    if (updates.status && oldStatus && updates.status !== oldStatus) {
-      await fireWebhook('service_location.status_changed', {
-        service_location_id: id,
-        old_status: oldStatus,
-        new_status: updates.status,
+    if (Object.keys(updates).length === 0) {
+      return res.status(400).json({
+        error: 'No editable fields in body',
+        editable: SERVICE_LOCATION_FIELDS.map((f) => f.key),
+        rejected,
       })
     }
 
-    const aliasedSl = data ? { ...(data as any), service_location_id: (data as any).id } : data
-    return res.status(200).json({ service_location: aliasedSl })
+    const { data: current, error: fetchErr } = await db
+      .from('service_locations')
+      .select('*')
+      .eq('id', slId)
+      .single()
+
+    if (fetchErr || !current) return res.status(404).json({ error: 'Not found' })
+
+    const { data: updated, error: updateErr } = await db
+      .from('service_locations')
+      .update({ ...updates, updated_at: new Date().toISOString() })
+      .eq('id', slId)
+      .select('*')
+      .single()
+
+    if (updateErr) return res.status(500).json({ error: updateErr.message })
+
+    const cur = current as any
+    const upd = updated as any
+    const changed = await recordEdits(
+      db,
+      {
+        propertyId: cur.property_id,
+        serviceLocationId: slId,
+        accountId: cur.account_id ?? null,
+        clientId: cur.client_id ?? null,
+      },
+      cur,
+      upd,
+      Object.keys(updates),
+      { changedBy: ctx.email ?? ctx.userId ?? null }
+    )
+
+    // Side effect 1: status change webhook (existing behavior)
+    if (changed.includes('status')) {
+      await fireWebhook('service_location.status_changed', {
+        service_location_id: slId,
+        old_status: cur.status,
+        new_status: upd.status,
+      })
+    }
+
+    // Side effect 2: serviceable_sqft change >10% → mark Crew Strategy
+    // stale so the dashboard prompts a re-run. Skip if there's no prior
+    // sqft to compare against (first-time set is fine).
+    let crewStrategyMarkedStale = false
+    if (changed.includes('serviceable_sqft') && cur.account_id && cur.client_id) {
+      const oldSqft = Number(cur.serviceable_sqft) || 0
+      const newSqft = Number(upd.serviceable_sqft) || 0
+      if (oldSqft > 0) {
+        const delta = Math.abs(newSqft - oldSqft) / oldSqft
+        if (delta >= SQFT_STALE_THRESHOLD) {
+          await markCrewStrategyStale(db, cur.account_id, cur.client_id)
+          crewStrategyMarkedStale = true
+        }
+      }
+    }
+
+    const aliasedSl = { ...upd, service_location_id: upd.id }
+    return res.status(200).json({
+      service_location: aliasedSl,
+      changed_fields: changed,
+      rejected_fields: rejected,
+      crew_strategy_marked_stale: crewStrategyMarkedStale,
+    })
   }
 
   return res.status(405).json({ error: 'Method not allowed' })

--- a/src/components/property/AddressEditDialog.tsx
+++ b/src/components/property/AddressEditDialog.tsx
@@ -1,0 +1,118 @@
+// Edit-address dialog. The 6 address fields are bundled because changing
+// any of them re-validates and re-geocodes the property — doing one at a
+// time would mean hitting the geocoder up to 6 times per address fix.
+import { useState, useEffect } from 'react'
+import { useAuth } from '../../hooks/useAuth'
+import Button from '../ui/Button'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '../ui/Dialog'
+import { Input, FormField } from '../ui/Input'
+
+const ADDRESS_FIELDS = [
+  { key: 'address_line1', label: 'Address line 1' },
+  { key: 'address_line2', label: 'Address line 2' },
+  { key: 'city', label: 'City' },
+  { key: 'state', label: 'State' },
+  { key: 'postal_code', label: 'Postal code' },
+  { key: 'country', label: 'Country' },
+] as const
+
+type AddressKey = typeof ADDRESS_FIELDS[number]['key']
+
+interface Props {
+  open: boolean
+  onClose: () => void
+  propertyId: string
+  current: Partial<Record<AddressKey, string | null | undefined>>
+  onSaved: () => void
+}
+
+export default function AddressEditDialog({
+  open,
+  onClose,
+  propertyId,
+  current,
+  onSaved,
+}: Props) {
+  const { getToken } = useAuth()
+  const [draft, setDraft] = useState<Record<AddressKey, string>>(() => emptyDraft())
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (open) {
+      setDraft({
+        address_line1: current.address_line1 ?? '',
+        address_line2: current.address_line2 ?? '',
+        city: current.city ?? '',
+        state: current.state ?? '',
+        postal_code: current.postal_code ?? '',
+        country: current.country ?? 'US',
+      })
+      setError(null)
+    }
+  }, [open, current])
+
+  async function handleSave() {
+    setSaving(true)
+    setError(null)
+    try {
+      const token = await getToken()
+      const res = await fetch(`/api/v1/properties/${propertyId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        body: JSON.stringify(draft),
+      })
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}))
+        throw new Error(body.error ?? `Save failed (${res.status})`)
+      }
+      onSaved()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => { if (!o) onClose() }}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Edit address</DialogTitle>
+          <DialogDescription>
+            Saving will re-validate the address against Google and update the map pin.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3">
+          {ADDRESS_FIELDS.map((f) => (
+            <FormField key={f.key} label={f.label} htmlFor={`addr-${f.key}`}>
+              <Input
+                id={`addr-${f.key}`}
+                value={draft[f.key]}
+                onChange={(e) => setDraft({ ...draft, [f.key]: e.target.value })}
+              />
+            </FormField>
+          ))}
+          {error && <p className="text-xs text-danger">{error}</p>}
+        </div>
+
+        <DialogFooter>
+          <Button variant="ghost" onClick={onClose}>Cancel</Button>
+          <Button onClick={handleSave} loading={saving}>Save & re-geocode</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function emptyDraft(): Record<AddressKey, string> {
+  return { address_line1: '', address_line2: '', city: '', state: '', postal_code: '', country: 'US' }
+}

--- a/src/components/property/EditHistoryPanel.tsx
+++ b/src/components/property/EditHistoryPanel.tsx
@@ -1,0 +1,157 @@
+// Collapsible audit-log panel for a property. Default closed — many
+// properties will have lots of edits and we don't want to push the rest
+// of the page down on every load.
+import { useState, useCallback } from 'react'
+import { ChevronDown } from 'lucide-react'
+import { useAuth } from '../../hooks/useAuth'
+import { Card, CardTitle, CardDescription } from '../ui/Card'
+import { cn } from '../../lib/cn'
+import {
+  PROPERTY_FIELDS,
+  SERVICE_LOCATION_FIELDS,
+} from '../../lib/editable-fields'
+
+interface HistoryRow {
+  id: string
+  property_id: string
+  service_location_id: string | null
+  field_name: string
+  old_value: unknown
+  new_value: unknown
+  changed_by: string | null
+  changed_at: string
+}
+
+const FIELD_LABELS: Record<string, string> = Object.fromEntries(
+  [...PROPERTY_FIELDS, ...SERVICE_LOCATION_FIELDS].map((f) => [f.key, f.label])
+)
+
+interface Props {
+  propertyId: string
+}
+
+export default function EditHistoryPanel({ propertyId }: Props) {
+  const { getToken } = useAuth()
+  const [open, setOpen] = useState(false)
+  const [rows, setRows] = useState<HistoryRow[] | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const token = await getToken()
+      const res = await fetch(`/api/v1/properties/${propertyId}/edit-history`, {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      if (!res.ok) throw new Error(`Load failed (${res.status})`)
+      const json = (await res.json()) as { history: HistoryRow[] }
+      setRows(json.history)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setLoading(false)
+    }
+  }, [propertyId, getToken])
+
+  function toggle() {
+    if (!open && rows == null) load()
+    setOpen(!open)
+  }
+
+  return (
+    <Card>
+      <button
+        type="button"
+        onClick={toggle}
+        className="flex items-start justify-between gap-3 w-full text-left"
+      >
+        <div className="space-y-1">
+          <CardTitle>Edit history</CardTitle>
+          <CardDescription>
+            Audit log of property and service-location edits.
+          </CardDescription>
+        </div>
+        <ChevronDown
+          className={cn(
+            'h-4 w-4 text-fg-muted shrink-0 mt-1 transition-transform',
+            open && 'rotate-180'
+          )}
+        />
+      </button>
+
+      {open && (
+        <div className="mt-4">
+          {loading ? (
+            <p className="text-sm text-fg-muted">Loading history…</p>
+          ) : error ? (
+            <p className="text-sm text-danger">{error}</p>
+          ) : rows == null || rows.length === 0 ? (
+            <p className="text-sm text-fg-muted">No edits recorded yet.</p>
+          ) : (
+            <ul className="space-y-2">
+              {rows.map((r) => (
+                <li
+                  key={r.id}
+                  className="rounded-md border border-border bg-surface-subtle px-3 py-2 text-sm"
+                >
+                  <div className="flex items-center justify-between gap-2 flex-wrap">
+                    <div className="flex items-center gap-2">
+                      <span className="font-medium text-fg">
+                        {FIELD_LABELS[r.field_name] ?? r.field_name}
+                      </span>
+                      {r.service_location_id && (
+                        <span className="text-[10px] uppercase tracking-wider text-fg-subtle bg-surface-elevated border border-border rounded px-1.5 py-0.5">
+                          Service location
+                        </span>
+                      )}
+                    </div>
+                    <span className="text-xs text-fg-subtle font-tabular">
+                      {new Date(r.changed_at).toLocaleString()}
+                    </span>
+                  </div>
+                  <div className="mt-1 text-xs flex items-baseline gap-2 flex-wrap">
+                    <ValueChip value={r.old_value} variant="old" />
+                    <span className="text-fg-subtle">→</span>
+                    <ValueChip value={r.new_value} variant="new" />
+                  </div>
+                  {r.changed_by && (
+                    <p className="mt-1 text-[11px] text-fg-subtle">By {r.changed_by}</p>
+                  )}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    </Card>
+  )
+}
+
+function ValueChip({ value, variant }: { value: unknown; variant: 'old' | 'new' }) {
+  const display = formatValue(value)
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center rounded px-1.5 py-0.5 font-tabular text-xs max-w-full truncate',
+        variant === 'old'
+          ? 'bg-surface-elevated text-fg-muted line-through decoration-fg-subtle'
+          : 'bg-accent/10 text-fg'
+      )}
+    >
+      {display}
+    </span>
+  )
+}
+
+function formatValue(v: unknown): string {
+  if (v == null) return '—'
+  if (Array.isArray(v)) {
+    if (v.length === 0) return '[]'
+    return `[${v.join(', ')}]`
+  }
+  if (typeof v === 'object') return JSON.stringify(v)
+  if (typeof v === 'number') return v.toLocaleString()
+  return String(v)
+}

--- a/src/components/property/EditableField.tsx
+++ b/src/components/property/EditableField.tsx
@@ -1,0 +1,263 @@
+// Inline-edit primitive. Click the value → input → save (PATCH) or cancel.
+//
+// One field at a time, single PATCH per save. The owner page is responsible
+// for refreshing the property after onSaved fires (we don't try to merge
+// the response in here because side effects like re-geocode write more
+// than just the patched field).
+//
+// Variants: text, textarea, number, select, tags. Tags is a chip list with
+// inline add/remove.
+import { useState, useRef, useEffect } from 'react'
+import { Pencil, Check, X, Plus } from 'lucide-react'
+import { useAuth } from '../../hooks/useAuth'
+import Button from '../ui/Button'
+import { Input, Textarea } from '../ui/Input'
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '../ui/Select'
+import { cn } from '../../lib/cn'
+import type { FieldSpec } from '../../lib/editable-fields'
+
+interface Props {
+  spec: FieldSpec
+  value: unknown
+  endpoint: string // e.g. /api/v1/properties/abc-123 — receives PATCH
+  onSaved: () => void
+  className?: string
+  // Visual override — by default we render the field's `label` above the
+  // value. Set this to false when the parent supplies its own label.
+  showLabel?: boolean
+}
+
+export default function EditableField({
+  spec,
+  value,
+  endpoint,
+  onSaved,
+  className,
+  showLabel = true,
+}: Props) {
+  const { getToken } = useAuth()
+  const [editing, setEditing] = useState(false)
+  const [draft, setDraft] = useState<unknown>(value)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (editing) setDraft(value)
+  }, [editing, value])
+
+  async function save(nextValue: unknown) {
+    setSaving(true)
+    setError(null)
+    try {
+      const token = await getToken()
+      const res = await fetch(endpoint, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        body: JSON.stringify({ [spec.key]: nextValue }),
+      })
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}))
+        throw new Error(body.error ?? `Save failed (${res.status})`)
+      }
+      setEditing(false)
+      onSaved()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  function cancel() {
+    setEditing(false)
+    setDraft(value)
+    setError(null)
+  }
+
+  if (!editing) {
+    return (
+      <div className={cn('group', className)}>
+        {showLabel && (
+          <p className="text-[10px] font-semibold uppercase tracking-wider text-fg-subtle mb-1">
+            {spec.label}
+          </p>
+        )}
+        <div className="flex items-start gap-2">
+          <div className="flex-1 min-w-0 text-sm text-fg">
+            <DisplayValue spec={spec} value={value} />
+          </div>
+          <button
+            type="button"
+            onClick={() => setEditing(true)}
+            className="text-fg-subtle hover:text-accent transition-colors opacity-0 group-hover:opacity-100 focus:opacity-100"
+            aria-label={`Edit ${spec.label}`}
+          >
+            <Pencil className="h-3.5 w-3.5" />
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className={className}>
+      {showLabel && (
+        <p className="text-[10px] font-semibold uppercase tracking-wider text-fg-subtle mb-1">
+          {spec.label}
+        </p>
+      )}
+      <EditControl spec={spec} value={draft} onChange={setDraft} />
+      {spec.helper && <p className="text-[11px] text-fg-subtle mt-1">{spec.helper}</p>}
+      {error && <p className="text-xs text-danger mt-1">{error}</p>}
+      <div className="flex items-center gap-2 mt-2">
+        <Button size="sm" onClick={() => save(draft)} loading={saving}>
+          <Check className="h-3.5 w-3.5" />
+          Save
+        </Button>
+        <Button size="sm" variant="ghost" onClick={cancel} disabled={saving}>
+          <X className="h-3.5 w-3.5" />
+          Cancel
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+function DisplayValue({ spec, value }: { spec: FieldSpec; value: unknown }) {
+  if (value == null || value === '') {
+    return <span className="text-fg-subtle italic">Not set</span>
+  }
+  if (spec.kind === 'tags') {
+    const tags = Array.isArray(value) ? (value as string[]) : []
+    if (tags.length === 0) return <span className="text-fg-subtle italic">No tags</span>
+    return (
+      <div className="flex flex-wrap gap-1">
+        {tags.map((t) => (
+          <span
+            key={t}
+            className="inline-flex items-center rounded-md border border-border bg-surface-subtle px-2 py-0.5 text-xs"
+          >
+            {t}
+          </span>
+        ))}
+      </div>
+    )
+  }
+  if (spec.kind === 'number') {
+    return <span className="font-tabular">{Number(value).toLocaleString()}</span>
+  }
+  if (spec.kind === 'select') {
+    const opt = spec.options?.find((o) => o.value === value)
+    return <span>{opt?.label ?? String(value)}</span>
+  }
+  if (spec.kind === 'textarea') {
+    return <span className="whitespace-pre-wrap">{String(value)}</span>
+  }
+  return <span>{String(value)}</span>
+}
+
+function EditControl({
+  spec,
+  value,
+  onChange,
+}: { spec: FieldSpec; value: unknown; onChange: (v: unknown) => void }) {
+  if (spec.kind === 'textarea') {
+    return (
+      <Textarea
+        value={(value as string | null | undefined) ?? ''}
+        onChange={(e) => onChange(e.target.value)}
+        rows={4}
+      />
+    )
+  }
+  if (spec.kind === 'number') {
+    return (
+      <Input
+        type="number"
+        value={value == null ? '' : String(value)}
+        onChange={(e) => onChange(e.target.value === '' ? null : Number(e.target.value))}
+      />
+    )
+  }
+  if (spec.kind === 'select') {
+    return (
+      <Select
+        value={(value as string | undefined) ?? ''}
+        onValueChange={(v) => onChange(v)}
+      >
+        <SelectTrigger><SelectValue /></SelectTrigger>
+        <SelectContent>
+          {spec.options?.map((o) => (
+            <SelectItem key={o.value} value={o.value}>{o.label}</SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    )
+  }
+  if (spec.kind === 'tags') {
+    return <TagsEditor value={(value as string[] | undefined) ?? []} onChange={onChange} />
+  }
+  return (
+    <Input
+      value={(value as string | null | undefined) ?? ''}
+      onChange={(e) => onChange(e.target.value)}
+    />
+  )
+}
+
+function TagsEditor({
+  value,
+  onChange,
+}: { value: string[]; onChange: (next: string[]) => void }) {
+  const [draft, setDraft] = useState('')
+  const inputRef = useRef<HTMLInputElement>(null)
+  function addTag() {
+    const t = draft.trim()
+    if (!t || value.includes(t)) return
+    onChange([...value, t])
+    setDraft('')
+    inputRef.current?.focus()
+  }
+  function remove(t: string) {
+    onChange(value.filter((x) => x !== t))
+  }
+  return (
+    <div>
+      <div className="flex flex-wrap gap-1 mb-2">
+        {value.map((t) => (
+          <span
+            key={t}
+            className="inline-flex items-center gap-1 rounded-md border border-border bg-surface-subtle px-2 py-0.5 text-xs"
+          >
+            {t}
+            <button
+              type="button"
+              onClick={() => remove(t)}
+              className="text-fg-subtle hover:text-danger"
+              aria-label={`Remove ${t}`}
+            >
+              ×
+            </button>
+          </span>
+        ))}
+      </div>
+      <div className="flex gap-2">
+        <Input
+          ref={inputRef}
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault()
+              addTag()
+            }
+          }}
+          placeholder="Add a tag and press Enter"
+        />
+        <Button type="button" variant="secondary" size="sm" onClick={addTag}>
+          <Plus className="h-3.5 w-3.5" />
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/property/ServiceLocationEditDialog.tsx
+++ b/src/components/property/ServiceLocationEditDialog.tsx
@@ -1,0 +1,153 @@
+// Edit a single service_location row. Surfaces the >10% sqft warning so
+// the user knows their edit will mark Crew Strategy stale.
+import { useState, useEffect } from 'react'
+import { AlertTriangle } from 'lucide-react'
+import { useAuth } from '../../hooks/useAuth'
+import Button from '../ui/Button'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '../ui/Dialog'
+import { Input, FormField } from '../ui/Input'
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '../ui/Select'
+import { SERVICE_LOCATION_FIELDS } from '../../lib/editable-fields'
+import type { ServiceLocation } from '../../types'
+
+interface Props {
+  open: boolean
+  onClose: () => void
+  serviceLocation: ServiceLocation | null
+  onSaved: () => void
+}
+
+const STALE_THRESHOLD = 0.1
+
+export default function ServiceLocationEditDialog({
+  open,
+  onClose,
+  serviceLocation,
+  onSaved,
+}: Props) {
+  const { getToken } = useAuth()
+  const [draft, setDraft] = useState<Record<string, unknown>>({})
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (open && serviceLocation) {
+      const next: Record<string, unknown> = {}
+      for (const f of SERVICE_LOCATION_FIELDS) {
+        next[f.key] = (serviceLocation as unknown as Record<string, unknown>)[f.key] ?? ''
+      }
+      setDraft(next)
+      setError(null)
+    }
+  }, [open, serviceLocation])
+
+  if (!serviceLocation) return null
+
+  const oldSqft = Number(serviceLocation.serviceable_sqft ?? 0)
+  const newSqft = Number(draft.serviceable_sqft ?? 0)
+  const sqftWillStale =
+    oldSqft > 0 &&
+    newSqft > 0 &&
+    Math.abs(newSqft - oldSqft) / oldSqft >= STALE_THRESHOLD
+
+  async function handleSave() {
+    setSaving(true)
+    setError(null)
+    try {
+      const token = await getToken()
+      const res = await fetch(
+        `/api/v1/service-locations/${serviceLocation!.service_location_id}`,
+        {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+          body: JSON.stringify(draft),
+        }
+      )
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}))
+        throw new Error(body.error ?? `Save failed (${res.status})`)
+      }
+      onSaved()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => { if (!o) onClose() }}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Edit service location</DialogTitle>
+          <DialogDescription>{serviceLocation.display_name ?? serviceLocation.service_location_id}</DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3">
+          {SERVICE_LOCATION_FIELDS.map((f) => (
+            <FormField key={f.key} label={f.label} helper={f.helper} htmlFor={`sl-${f.key}`}>
+              {f.kind === 'select' ? (
+                <Select
+                  value={String(draft[f.key] ?? '')}
+                  onValueChange={(v) => setDraft({ ...draft, [f.key]: v })}
+                >
+                  <SelectTrigger id={`sl-${f.key}`}><SelectValue /></SelectTrigger>
+                  <SelectContent>
+                    {f.options?.map((o) => (
+                      <SelectItem key={o.value} value={o.value}>{o.label}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              ) : f.kind === 'number' ? (
+                <Input
+                  id={`sl-${f.key}`}
+                  type="number"
+                  value={draft[f.key] == null ? '' : String(draft[f.key])}
+                  onChange={(e) =>
+                    setDraft({
+                      ...draft,
+                      [f.key]: e.target.value === '' ? null : Number(e.target.value),
+                    })
+                  }
+                />
+              ) : (
+                <Input
+                  id={`sl-${f.key}`}
+                  value={(draft[f.key] as string | null | undefined) ?? ''}
+                  onChange={(e) => setDraft({ ...draft, [f.key]: e.target.value })}
+                />
+              )}
+            </FormField>
+          ))}
+
+          {sqftWillStale && (
+            <div className="flex items-start gap-2 rounded-md border border-warning/40 bg-warning/5 px-3 py-2 text-xs text-fg">
+              <AlertTriangle className="h-4 w-4 text-warning shrink-0 mt-0.5" />
+              <span>
+                Sqft change of{' '}
+                <span className="font-tabular">
+                  {Math.round((Math.abs(newSqft - oldSqft) / oldSqft) * 100)}%
+                </span>{' '}
+                will mark Crew Strategy as stale.
+              </span>
+            </div>
+          )}
+
+          {error && <p className="text-xs text-danger">{error}</p>}
+        </div>
+
+        <DialogFooter>
+          <Button variant="ghost" onClick={onClose}>Cancel</Button>
+          <Button onClick={handleSave} loading={saving}>Save</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/lib/editable-fields.ts
+++ b/src/lib/editable-fields.ts
@@ -1,0 +1,90 @@
+// Editable-field whitelist — single source of truth for what users can edit
+// on a property or service_location, what type each field is, and any
+// special handling (address bundle, sqft threshold).
+//
+// Both the PATCH API (for validation + side-effect routing) and the
+// PropertyDetail UI (for rendering inline editors) read this. Adding a new
+// editable field = one entry here.
+
+export type FieldKind =
+  | 'text'
+  | 'textarea'
+  | 'number'
+  | 'select'
+  | 'tags' // text[] rendered as a chip list
+
+export interface FieldSpec {
+  key: string
+  label: string
+  kind: FieldKind
+  helper?: string
+  options?: { value: string; label: string }[]
+  // 'address': editing any of these triggers re-geocode in the API
+  // 'sqft': editing this triggers a >10% threshold check that may flip
+  //   crew_strategy to 'stale'
+  group?: 'address' | 'sqft'
+}
+
+// Property-level editable fields. Order matters — UI renders in this order.
+export const PROPERTY_FIELDS: FieldSpec[] = [
+  { key: 'address_line1', label: 'Address line 1', kind: 'text', group: 'address' },
+  { key: 'address_line2', label: 'Address line 2', kind: 'text', group: 'address' },
+  { key: 'city',          label: 'City',           kind: 'text', group: 'address' },
+  { key: 'state',         label: 'State',          kind: 'text', group: 'address' },
+  { key: 'postal_code',   label: 'Postal code',    kind: 'text', group: 'address' },
+  { key: 'country',       label: 'Country',        kind: 'text', group: 'address' },
+
+  { key: 'rbm_category',    label: 'Category',     kind: 'text', helper: 'Property classification override' },
+  { key: 'rbm_subcategory', label: 'Subcategory',  kind: 'text' },
+
+  {
+    key: 'notes',
+    label: 'Notes',
+    kind: 'textarea',
+    helper: 'Internal notes — not shared with clients',
+  },
+  {
+    key: 'internal_tags',
+    label: 'Internal tags',
+    kind: 'tags',
+    helper: 'Add tags to group properties (e.g. "high-priority", "vip-account")',
+  },
+]
+
+// service_location-level editable fields.
+export const SERVICE_LOCATION_FIELDS: FieldSpec[] = [
+  { key: 'display_name',    label: 'Display name',     kind: 'text' },
+  { key: 'location_code',   label: 'Location code',    kind: 'text' },
+  { key: 'suite_or_floor',  label: 'Suite / floor',    kind: 'text' },
+  {
+    key: 'serviceable_sqft',
+    label: 'Serviceable sqft',
+    kind: 'number',
+    group: 'sqft',
+    helper: 'Changes >10% will mark Crew Strategy stale',
+  },
+  {
+    key: 'status',
+    label: 'Status',
+    kind: 'select',
+    options: [
+      { value: 'active', label: 'Active' },
+      { value: 'paused', label: 'Paused' },
+      { value: 'prospect', label: 'Prospect' },
+      { value: 'terminated', label: 'Terminated' },
+    ],
+  },
+]
+
+const PROPERTY_KEY_SET = new Set(PROPERTY_FIELDS.map((f) => f.key))
+const SL_KEY_SET = new Set(SERVICE_LOCATION_FIELDS.map((f) => f.key))
+
+export function isEditablePropertyField(key: string): boolean {
+  return PROPERTY_KEY_SET.has(key)
+}
+
+export function isEditableServiceLocationField(key: string): boolean {
+  return SL_KEY_SET.has(key)
+}
+
+export const ADDRESS_FIELD_KEYS = PROPERTY_FIELDS.filter((f) => f.group === 'address').map((f) => f.key)

--- a/src/pages/PropertyDetail.tsx
+++ b/src/pages/PropertyDetail.tsx
@@ -1,6 +1,6 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import { useParams, useNavigate, Link } from 'react-router-dom'
-import { ChevronDown, ExternalLink } from 'lucide-react'
+import { ChevronDown, ExternalLink, Pencil } from 'lucide-react'
 import { useAuth } from '../hooks/useAuth'
 import { useCountUp } from '../hooks/useCountUp'
 import Button from '../components/ui/Button'
@@ -20,9 +20,16 @@ import AppShell from '../components/layout/AppShell'
 import ComparablesPanel from '../components/analysis/ComparablesPanel'
 import ServiceMixPanel from '../components/analysis/ServiceMixPanel'
 import ConstraintsPanel from '../components/property/ConstraintsPanel'
+import EditableField from '../components/property/EditableField'
+import AddressEditDialog from '../components/property/AddressEditDialog'
+import ServiceLocationEditDialog from '../components/property/ServiceLocationEditDialog'
+import EditHistoryPanel from '../components/property/EditHistoryPanel'
+import { PROPERTY_FIELDS } from '../lib/editable-fields'
 import { CATEGORY_COLORS, STATUS_LABELS } from '../lib/constants'
 import { cn } from '../lib/cn'
 import type { ServiceLocation } from '../types'
+
+const PROPERTY_FIELD_BY_KEY = Object.fromEntries(PROPERTY_FIELDS.map((f) => [f.key, f]))
 
 // Extends Property with DB fields that aren't in the base type + joined tables
 interface PropertyDetail {
@@ -70,6 +77,8 @@ interface PropertyDetail {
   }> | null
   risk_score?: number | null
   risk_assessed_at?: string | null
+  notes?: string | null
+  internal_tags?: string[] | null
   service_locations: ServiceLocation[]
 }
 
@@ -84,30 +93,34 @@ export default function PropertyDetailPage() {
   const [enriching, setEnriching] = useState(false)
   const [enrichMsg, setEnrichMsg] = useState<string | null>(null)
   const [reassessing, setReassessing] = useState(false)
+  const [addressDialogOpen, setAddressDialogOpen] = useState(false)
+  const [editingSL, setEditingSL] = useState<ServiceLocation | null>(null)
 
   // Phase E — risk score tweens 300ms on each re-assessment so the user
   // sees the number move rather than snap.
   const animatedRiskScore = useCountUp(property?.risk_score ?? null)
+
+  const reload = useCallback(async () => {
+    if (!id) return
+    const token = await getToken()
+    const res = await fetch(`/api/v1/properties/${id}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+    if (res.ok) setProperty(await res.json())
+  }, [id, getToken])
 
   useEffect(() => {
     async function load() {
       if (!id) return
       setLoading(true)
       try {
-        const token = await getToken()
-        const res = await fetch(`/api/v1/properties/${id}`, {
-          headers: { Authorization: `Bearer ${token}` },
-        })
-        if (res.ok) {
-          const data = await res.json()
-          setProperty(data)
-        }
+        await reload()
       } finally {
         setLoading(false)
       }
     }
     load()
-  }, [id, getToken])
+  }, [id, reload])
 
   // Check Street View availability
   useEffect(() => {
@@ -296,9 +309,19 @@ export default function PropertyDetailPage() {
 
           <div className="flex items-start justify-between gap-6 flex-wrap">
             <div className="space-y-1 min-w-0">
-              <h1 className="text-2xl font-semibold tracking-tight text-fg">
-                {property.address_line1}
-              </h1>
+              <div className="flex items-baseline gap-2 flex-wrap">
+                <h1 className="text-2xl font-semibold tracking-tight text-fg">
+                  {property.address_line1}
+                </h1>
+                <button
+                  type="button"
+                  onClick={() => setAddressDialogOpen(true)}
+                  className="text-fg-subtle hover:text-accent transition-colors"
+                  aria-label="Edit address"
+                >
+                  <Pencil className="h-3.5 w-3.5" />
+                </button>
+              </div>
               {property.address_line2 && (
                 <p className="text-sm text-fg-muted">{property.address_line2}</p>
               )}
@@ -446,6 +469,7 @@ export default function PropertyDetailPage() {
                       <TableHead>Suite / floor</TableHead>
                       <TableHead className="text-right">Sqft</TableHead>
                       <TableHead>Status</TableHead>
+                      <TableHead className="w-8" />
                     </TableRow>
                   </TableHeader>
                   <TableBody>
@@ -472,6 +496,19 @@ export default function PropertyDetailPage() {
                           <Badge variant={statusBadgeVariant(loc.status)}>
                             {STATUS_LABELS[loc.status]}
                           </Badge>
+                        </TableCell>
+                        <TableCell>
+                          <button
+                            type="button"
+                            onClick={(e) => {
+                              e.stopPropagation()
+                              setEditingSL(loc)
+                            }}
+                            className="text-fg-subtle hover:text-accent transition-colors"
+                            aria-label="Edit service location"
+                          >
+                            <Pencil className="h-3.5 w-3.5" />
+                          </button>
                         </TableCell>
                       </TableRow>
                     ))}
@@ -569,16 +606,41 @@ export default function PropertyDetailPage() {
 
             {/* Service Mix Recommendation */}
             <ServiceMixPanel propertyId={property.property_id} />
+
+            {/* Edit history (collapsible, default closed) */}
+            <EditHistoryPanel propertyId={property.property_id} />
           </div>
 
           {/* Right metadata sidebar (40%) */}
           <aside className="space-y-6 lg:col-span-2">
-            {/* Business & classification — only when we have something */}
-            {(property.rbm_category || property.place_name) && (
-              <Card>
-                <CardHeader>
-                  <CardTitle>Business &amp; classification</CardTitle>
-                </CardHeader>
+            {/* Notes & tags — internal-only field for bid teams */}
+            <Card>
+              <CardHeader>
+                <CardTitle>Notes &amp; tags</CardTitle>
+              </CardHeader>
+              <div className="mt-4 space-y-5">
+                <EditableField
+                  spec={PROPERTY_FIELD_BY_KEY.notes}
+                  value={property.notes}
+                  endpoint={`/api/v1/properties/${property.property_id}`}
+                  onSaved={reload}
+                />
+                <EditableField
+                  spec={PROPERTY_FIELD_BY_KEY.internal_tags}
+                  value={property.internal_tags ?? []}
+                  endpoint={`/api/v1/properties/${property.property_id}`}
+                  onSaved={reload}
+                />
+              </div>
+            </Card>
+
+            {/* Business & classification */}
+            <Card>
+              <CardHeader>
+                <CardTitle>Business &amp; classification</CardTitle>
+              </CardHeader>
+              {(property.place_name || property.place_phone || property.place_website ||
+                property.rbm_category_confidence != null) && (
                 <DefList className="mt-4">
                   {property.place_name && (
                     <DefRow term="Place name">{property.place_name}</DefRow>
@@ -600,20 +662,6 @@ export default function PropertyDetailPage() {
                       </a>
                     </DefRow>
                   )}
-                  {property.rbm_category && (
-                    <DefRow term="RBM category">
-                      <span className="capitalize">
-                        {property.rbm_category.replace(/_/g, ' ')}
-                      </span>
-                    </DefRow>
-                  )}
-                  {property.rbm_subcategory && (
-                    <DefRow term="Subcategory">
-                      <span className="capitalize">
-                        {property.rbm_subcategory.replace(/_/g, ' ')}
-                      </span>
-                    </DefRow>
-                  )}
                   {property.rbm_category_confidence != null && (
                     <DefRow term="Confidence">
                       <span className="font-tabular">
@@ -627,8 +675,22 @@ export default function PropertyDetailPage() {
                     </DefRow>
                   )}
                 </DefList>
-              </Card>
-            )}
+              )}
+              <div className="mt-4 space-y-5 border-t border-border pt-4">
+                <EditableField
+                  spec={PROPERTY_FIELD_BY_KEY.rbm_category}
+                  value={property.rbm_category}
+                  endpoint={`/api/v1/properties/${property.property_id}`}
+                  onSaved={reload}
+                />
+                <EditableField
+                  spec={PROPERTY_FIELD_BY_KEY.rbm_subcategory}
+                  value={property.rbm_subcategory}
+                  endpoint={`/api/v1/properties/${property.property_id}`}
+                  onSaved={reload}
+                />
+              </div>
+            </Card>
 
             {/* Parcel data — hidden when nothing populated, per spec */}
             {hasParcelData && (
@@ -749,6 +811,33 @@ export default function PropertyDetailPage() {
           </aside>
         </div>
       </div>
+
+      <AddressEditDialog
+        open={addressDialogOpen}
+        onClose={() => setAddressDialogOpen(false)}
+        propertyId={property.property_id}
+        current={{
+          address_line1: property.address_line1,
+          address_line2: property.address_line2,
+          city: property.city,
+          state: property.state,
+          postal_code: property.postal_code,
+        }}
+        onSaved={() => {
+          setAddressDialogOpen(false)
+          reload()
+        }}
+      />
+
+      <ServiceLocationEditDialog
+        open={editingSL !== null}
+        onClose={() => setEditingSL(null)}
+        serviceLocation={editingSL}
+        onSaved={() => {
+          setEditingSL(null)
+          reload()
+        }}
+      />
     </AppShell>
   )
 }

--- a/supabase/migrations/20260430035227_phase4a_property_editing.sql
+++ b/supabase/migrations/20260430035227_phase4a_property_editing.sql
@@ -1,0 +1,50 @@
+-- Phase 4a PR2: Property editing — free-text notes, internal tags, and a
+-- proper audit trail.
+--
+-- The existing `property_changes` table (created out-of-band in Studio,
+-- not in any migration) only logged rbm_category edits. We're replacing it
+-- with a richer per-edit audit table that:
+--   - Captures any whitelisted field on either properties or service_locations
+--   - Stores values as jsonb so strings, numbers, arrays all fit uniformly
+--   - Is denormalized with account_id + client_id for fast tenant filtering
+--   - Records the user's email so the UI can attribute edits to a person
+--
+-- The old property_changes table is left in place (legacy data preserved).
+-- New writes go to property_edit_history; the existing service-locations
+-- /changes endpoint will be flipped to read the new table.
+
+ALTER TABLE public.properties
+  ADD COLUMN IF NOT EXISTS notes TEXT,
+  ADD COLUMN IF NOT EXISTS internal_tags TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[];
+
+CREATE TABLE IF NOT EXISTS public.property_edit_history (
+  id                   UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  property_id          UUID NOT NULL REFERENCES public.properties(id) ON DELETE CASCADE,
+
+  -- Set when the edit was on a service_location row rather than the property
+  -- itself. Both rows share the audit table so a single GET returns the full
+  -- editing history of the property + its child SLs.
+  service_location_id  UUID REFERENCES public.service_locations(id) ON DELETE CASCADE,
+
+  account_id           UUID REFERENCES public.accounts(id) ON DELETE CASCADE,
+  client_id            UUID REFERENCES public.clients(id) ON DELETE CASCADE,
+
+  field_name           TEXT NOT NULL,
+  -- jsonb, not text — stores arrays (internal_tags) and numbers
+  -- (serviceable_sqft) without lossy stringification.
+  old_value            JSONB,
+  new_value            JSONB,
+
+  changed_by           TEXT,
+  changed_at           TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS property_edit_history_property_idx
+  ON public.property_edit_history(property_id, changed_at DESC);
+
+CREATE INDEX IF NOT EXISTS property_edit_history_sl_idx
+  ON public.property_edit_history(service_location_id, changed_at DESC)
+  WHERE service_location_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS property_edit_history_tenant_idx
+  ON public.property_edit_history(account_id, client_id);


### PR DESCRIPTION
## Summary
- Bid teams can now fix property/SL data errors (sqft, addresses, classification, custom notes/tags) directly on the Property Detail page instead of round-tripping through CSV reuploads.
- Every accepted edit writes a row to a new `property_edit_history` audit table.
- Two side effects fire automatically: address edits re-validate + re-geocode; `serviceable_sqft` changes ≥10% mark the most recent completed Crew Strategy as `stale`.

## Schema
```sql
ALTER TABLE properties
  ADD COLUMN notes TEXT,
  ADD COLUMN internal_tags TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[];

CREATE TABLE property_edit_history (
  id uuid pk,
  property_id uuid -> properties(id) cascade,
  service_location_id uuid -> service_locations(id) cascade,  -- nullable
  account_id, client_id,                                       -- denormalized
  field_name text,
  old_value jsonb, new_value jsonb,
  changed_by text, changed_at timestamptz default now()
);
-- indexes: (property_id, changed_at desc), partial (sl_id), (account_id, client_id)
```

The legacy `property_changes` table (created out-of-band, only logged `rbm_category`) is left in place — no destructive change. New writes go to `property_edit_history`; the existing service-locations `/changes` endpoint is repointed at the new table.

## Editable fields whitelist (`src/lib/editable-fields.ts`)

Property: `address_line1..country` (bundle), `rbm_category`, `rbm_subcategory`, `notes`, `internal_tags`.
Service location: `display_name`, `location_code`, `suite_or_floor`, `serviceable_sqft`, `status`.

Anything not in the whitelist is silently rejected. The PATCH response includes `rejected_fields` so callers know what was dropped.

## API
- `PATCH /api/v1/properties/[id]` — whitelist + audit + re-geocode side effect
- `PATCH /api/v1/service-locations/[id]` — whitelist + audit + crew_strategy stale side effect
- `GET   /api/v1/properties/[id]/edit-history` — full property audit log (includes SL-level edits)
- `GET   /api/v1/service-locations/[id]/changes` — same data, scoped via parent property (back-compat)

## UI (PropertyDetail page)
- Edit pencil next to address → `AddressEditDialog` (saves all 6 fields together, "Save & re-geocode" CTA)
- Edit pencil per row in Service Locations table → `ServiceLocationEditDialog` (live sqft-delta percentage + warning when ≥10%)
- Sidebar "Notes & tags" Card — inline `EditableField` for `notes` (textarea) + `internal_tags` (chip list with Enter-to-add)
- Sidebar "Business & classification" Card — inline `EditableField` for `rbm_category` + `rbm_subcategory`
- "Edit history" Card at the bottom of the main column — collapsible, default closed; shows old/new chips with strikethrough on the old, attribution + timestamp

## Trade-offs
- **No optimistic UI on inline edits.** Saves through then `reload()` refetches. Simpler; geocode side effects write more than the patched field anyway.
- **Audit failures don't fail the edit** — logged to console, user's save still succeeds. Graceful degradation.
- **`building_sqft`, `lot_sqft`, `year_built`, `owner_name`, `parcel_id`, `place_*` not editable** — sourced from parcel/Places enrichment. Override via `notes` for now.
- **Side effects run synchronously inside PATCH.** Re-geocode adds latency to address saves; `maxDuration: 30s` should be plenty. If geocoding fails the edit still succeeds and the failure is logged.

## Test plan
- [ ] Edit `notes` inline → save → reload → notes persists; an entry shows up in Edit history
- [ ] Edit `internal_tags` (add then remove a tag) → both edits are audited as separate `internal_tags` field changes with old/new arrays
- [ ] Click pencil next to the address → change just `city` → save → map pin moves to the new city, verdict badge updates, audit row records `city` change (only that one field, not all 6)
- [ ] Edit a service location's `serviceable_sqft` from 10000 → 11500 (15% delta) → warning banner appears in the dialog before save → after save, the most-recent completed crew_strategy analysis flips to `stale`
- [ ] Edit `serviceable_sqft` from 10000 → 10500 (5%) → no warning, no stale flip
- [ ] Try `curl -X PATCH ... { "id": "fake", "latitude": 99 }` → API rejects unknown fields, returns 400 with `rejected: ["id", "latitude"]`
- [ ] Open Edit history → entries grouped by changed_at desc; SL-level edits show "Service location" badge
- [ ] Property with no edits → "No edits recorded yet."
- [ ] Status change on SL still fires the existing `service_location.status_changed` webhook

🤖 Generated with [Claude Code](https://claude.com/claude-code)