### PR TITLE
Phase 3.7: calculated overnight + hotel costs (replaces flat $35K)

### DIFF
--- a/api/_lib/analysis/operational-constraints.ts
+++ b/api/_lib/analysis/operational-constraints.ts
@@ -5,6 +5,24 @@
 // can just read `constraints.crew_size` and always get a number.
 import type { SupabaseClient } from '@supabase/supabase-js'
 
+export interface HotelCostConfig {
+  cost_per_night: number
+  overnight_trigger_one_way_hours: number
+  max_work_hours_per_crew_day: number
+  buffer_hours_per_day: number
+  per_diem_per_night: number
+  include_per_diem: boolean
+}
+
+export const HOTEL_COST_CONFIG_DEFAULTS: HotelCostConfig = {
+  cost_per_night: 120,
+  overnight_trigger_one_way_hours: 3,
+  max_work_hours_per_crew_day: 8,
+  buffer_hours_per_day: 2,
+  per_diem_per_night: 50,
+  include_per_diem: true,
+}
+
 export interface ExistingBranch {
   name: string
   address?: string | null
@@ -56,7 +74,15 @@ export interface OperationalConstraints {
 
   // Operational costs
   branch_overhead_annual: number
+  // Legacy flat input — kept as a fallback for cases where the calculated
+  // overnight cost can't be computed (no selected branches yet) and the
+  // user hasn't set an override. Phase 3.7 introduced a calculated value.
   hotels_annual: number
+  // Phase 3.7 — knobs for the calculated overnight cost.
+  hotel_cost_config: HotelCostConfig
+  // Phase 3.7 — when set, modules use this flat value INSTEAD of the
+  // calculated number. Lets a user pin a contractual or matched figure.
+  hotels_annual_override: number | null
   vehicle_lease_annual_per_crew: number
   supplies_pct_of_labor: number
   insurance_annual: number
@@ -151,6 +177,34 @@ function pickNumeric(row: any, key: keyof SystemDefaults): number {
   return typeof v === 'string' ? parseFloat(v) : v
 }
 
+function mergeHotelConfig(saved: any): HotelCostConfig {
+  if (!saved || typeof saved !== 'object') return { ...HOTEL_COST_CONFIG_DEFAULTS }
+  return {
+    cost_per_night:
+      typeof saved.cost_per_night === 'number' ? saved.cost_per_night : HOTEL_COST_CONFIG_DEFAULTS.cost_per_night,
+    overnight_trigger_one_way_hours:
+      typeof saved.overnight_trigger_one_way_hours === 'number'
+        ? saved.overnight_trigger_one_way_hours
+        : HOTEL_COST_CONFIG_DEFAULTS.overnight_trigger_one_way_hours,
+    max_work_hours_per_crew_day:
+      typeof saved.max_work_hours_per_crew_day === 'number'
+        ? saved.max_work_hours_per_crew_day
+        : HOTEL_COST_CONFIG_DEFAULTS.max_work_hours_per_crew_day,
+    buffer_hours_per_day:
+      typeof saved.buffer_hours_per_day === 'number'
+        ? saved.buffer_hours_per_day
+        : HOTEL_COST_CONFIG_DEFAULTS.buffer_hours_per_day,
+    per_diem_per_night:
+      typeof saved.per_diem_per_night === 'number'
+        ? saved.per_diem_per_night
+        : HOTEL_COST_CONFIG_DEFAULTS.per_diem_per_night,
+    include_per_diem:
+      typeof saved.include_per_diem === 'boolean'
+        ? saved.include_per_diem
+        : HOTEL_COST_CONFIG_DEFAULTS.include_per_diem,
+  }
+}
+
 export async function loadConstraints(
   db: SupabaseClient,
   accountId: string,
@@ -187,6 +241,13 @@ export async function loadConstraints(
     surge_premium_multiplier: pickNumeric(r, 'surge_premium_multiplier'),
     branch_overhead_annual: pickNumeric(r, 'branch_overhead_annual'),
     hotels_annual: pickNumeric(r, 'hotels_annual'),
+    hotel_cost_config: mergeHotelConfig(r?.hotel_cost_config),
+    hotels_annual_override:
+      r?.hotels_annual_override == null
+        ? null
+        : typeof r.hotels_annual_override === 'string'
+          ? parseFloat(r.hotels_annual_override)
+          : r.hotels_annual_override,
     vehicle_lease_annual_per_crew: pickNumeric(r, 'vehicle_lease_annual_per_crew'),
     supplies_pct_of_labor: pickNumeric(r, 'supplies_pct_of_labor'),
     insurance_annual: pickNumeric(r, 'insurance_annual'),

--- a/api/_lib/analysis/overnight-calculator.ts
+++ b/api/_lib/analysis/overnight-calculator.ts
@@ -1,0 +1,349 @@
+// Phase 3.7 — Calculated overnight & hotel costs.
+//
+// Replaces the flat $35K hotels_annual constant with a calculation driven
+// by which properties are >3hr from their assigned branch, geographically
+// clustered into multi-night trips, with cost rolled up across all trips
+// per year.
+//
+// Pure function. Caller provides properties (with hours_per_visit +
+// visits_per_year), branches, and config. Returns total cost + per-trip
+// breakdown.
+import { haversineMiles, driveTimeMinutes, centroid, type LatLng } from './haversine.js'
+
+export interface OvernightProperty {
+  id: string
+  address?: string | null
+  lat: number
+  lng: number
+  visits_per_year: number
+  hours_per_visit: number
+}
+
+export interface OvernightBranch {
+  name: string
+  lat: number
+  lng: number
+}
+
+export interface OvernightConfig {
+  drive_speed_mph: number
+  overnight_trigger_one_way_hours: number
+  max_work_hours_per_crew_day: number
+  buffer_hours_per_day: number
+  crew_size: number
+  cost_per_night: number
+  per_diem_per_night: number
+  include_per_diem: boolean
+}
+
+export interface OvernightTrip {
+  branch_name: string
+  cluster_id: string
+  cluster_centroid: LatLng
+  properties_in_cluster: Array<{
+    property_id: string
+    address: string | null
+    hours_per_visit: number
+    visits_per_year: number
+  }>
+  drive_hours_one_way: number
+  total_work_hours_per_visit: number
+  work_days_per_trip: number
+  nights_per_trip: number
+  trips_per_year: number
+  annual_nights: number
+  annual_hotel_cost: number
+  annual_per_diem_cost: number
+  annual_total_cost: number
+}
+
+export interface OvernightResult {
+  total_overnight_nights_per_year: number
+  total_hotel_cost: number
+  total_per_diem_cost: number
+  total_overnight_cost: number
+  trips: OvernightTrip[]
+  day_trip_property_count: number
+  avg_drive_hours_to_overnight_property: number
+  largest_cluster_size: number
+  properties_requiring_overnight: number
+  config_used: OvernightConfig
+}
+
+const CLUSTER_RADIUS_MILES = 30
+
+export function calculateOvernights(
+  properties: OvernightProperty[],
+  branches: OvernightBranch[],
+  config: OvernightConfig
+): OvernightResult {
+  // Empty result for "no branches selected" — caller decides whether to
+  // 400. We don't throw here because the dashboard wants to show this
+  // section even when the calc isn't meaningful.
+  if (branches.length === 0 || properties.length === 0) {
+    return emptyResult(config)
+  }
+
+  // ── Step 1: Assign each property to its nearest branch + check trigger ──
+  type Assigned = OvernightProperty & {
+    branch_idx: number
+    one_way_drive_hours: number
+  }
+  const assigned: Assigned[] = []
+  for (const p of properties) {
+    if (!Number.isFinite(p.lat) || !Number.isFinite(p.lng)) continue
+    let bestIdx = 0
+    let bestDist = Infinity
+    for (let i = 0; i < branches.length; i++) {
+      const d = haversineMiles({ lat: p.lat, lng: p.lng }, { lat: branches[i].lat, lng: branches[i].lng })
+      if (d < bestDist) {
+        bestDist = d
+        bestIdx = i
+      }
+    }
+    const oneWayMin = driveTimeMinutes(bestDist, config.drive_speed_mph)
+    assigned.push({
+      ...p,
+      branch_idx: bestIdx,
+      one_way_drive_hours: oneWayMin / 60,
+    })
+  }
+
+  const overnightProps = assigned.filter(
+    (p) => p.one_way_drive_hours > config.overnight_trigger_one_way_hours
+  )
+  const dayTripCount = assigned.length - overnightProps.length
+
+  if (overnightProps.length === 0) {
+    return {
+      ...emptyResult(config),
+      day_trip_property_count: dayTripCount,
+    }
+  }
+
+  // ── Step 2: Density-cluster overnight props within 30mi of each other ──
+  // Group by branch first so a single trip is always from one branch — a
+  // crew dispatched from Frisco to a Houston-area cluster wouldn't bundle
+  // in a Lubbock property even if they're geographically adjacent.
+  const byBranch = new Map<number, Assigned[]>()
+  for (const p of overnightProps) {
+    const arr = byBranch.get(p.branch_idx) ?? []
+    arr.push(p)
+    byBranch.set(p.branch_idx, arr)
+  }
+
+  const trips: OvernightTrip[] = []
+  let totalDriveSum = 0
+  let totalDriveCount = 0
+  let largestCluster = 0
+
+  for (const [branchIdx, props] of byBranch) {
+    const clusters = densityCluster(props, CLUSTER_RADIUS_MILES)
+    for (let ci = 0; ci < clusters.length; ci++) {
+      const cluster = clusters[ci]
+      if (cluster.length === 0) continue
+      if (cluster.length > largestCluster) largestCluster = cluster.length
+
+      const center = centroid(cluster.map((p) => ({ lat: p.lat, lng: p.lng })))
+      // One-way drive from the branch to the cluster centroid (uses the same
+      // drive_speed assumption as the rest of the system).
+      const distToCenterMi = haversineMiles(
+        { lat: branches[branchIdx].lat, lng: branches[branchIdx].lng },
+        center
+      )
+      const driveHoursOneWay = driveTimeMinutes(distToCenterMi, config.drive_speed_mph) / 60
+
+      // Work hours per single visit to the cluster = sum of hours_per_visit
+      // across all properties in the cluster.
+      const workHoursPerVisit = cluster.reduce((sum, p) => sum + p.hours_per_visit, 0)
+
+      // Per-day work cap is the user's configured max (default 8 of 10).
+      const workDaysPerTrip = Math.max(
+        1,
+        Math.ceil(workHoursPerVisit / config.max_work_hours_per_crew_day)
+      )
+      // Nights = work_days. Crew arrives the night before day 1, sleeps
+      // night between each work day, drives home after the last work day.
+      // (1 work day → 1 night; 3 work days → 3 nights.)
+      const nightsPerTrip = workDaysPerTrip
+
+      // Trips per year — operational simplification: max visits_per_year
+      // across cluster props, with the lower-freq props bundled into the
+      // higher-freq trip cadence.
+      const tripsPerYear = cluster.reduce((m, p) => Math.max(m, p.visits_per_year), 0)
+      const annualNights = nightsPerTrip * tripsPerYear
+
+      const annualHotelCost = annualNights * config.cost_per_night
+      const annualPerDiemCost = config.include_per_diem
+        ? annualNights * config.per_diem_per_night * config.crew_size
+        : 0
+
+      for (const p of cluster) totalDriveSum += p.one_way_drive_hours
+      totalDriveCount += cluster.length
+
+      trips.push({
+        branch_name: branches[branchIdx].name,
+        cluster_id: `${branches[branchIdx].name}-c${ci}`,
+        cluster_centroid: center,
+        properties_in_cluster: cluster.map((p) => ({
+          property_id: p.id,
+          address: p.address ?? null,
+          hours_per_visit: p.hours_per_visit,
+          visits_per_year: p.visits_per_year,
+        })),
+        drive_hours_one_way: round2(driveHoursOneWay),
+        total_work_hours_per_visit: round2(workHoursPerVisit),
+        work_days_per_trip: workDaysPerTrip,
+        nights_per_trip: nightsPerTrip,
+        trips_per_year: tripsPerYear,
+        annual_nights: annualNights,
+        annual_hotel_cost: Math.round(annualHotelCost),
+        annual_per_diem_cost: Math.round(annualPerDiemCost),
+        annual_total_cost: Math.round(annualHotelCost + annualPerDiemCost),
+      })
+    }
+  }
+
+  const totalNights = trips.reduce((s, t) => s + t.annual_nights, 0)
+  const totalHotelCost = trips.reduce((s, t) => s + t.annual_hotel_cost, 0)
+  const totalPerDiemCost = trips.reduce((s, t) => s + t.annual_per_diem_cost, 0)
+  const avgDriveHours =
+    totalDriveCount > 0 ? round2(totalDriveSum / totalDriveCount) : 0
+
+  return {
+    total_overnight_nights_per_year: totalNights,
+    total_hotel_cost: totalHotelCost,
+    total_per_diem_cost: totalPerDiemCost,
+    total_overnight_cost: totalHotelCost + totalPerDiemCost,
+    trips,
+    day_trip_property_count: dayTripCount,
+    avg_drive_hours_to_overnight_property: avgDriveHours,
+    largest_cluster_size: largestCluster,
+    properties_requiring_overnight: overnightProps.length,
+    config_used: config,
+  }
+}
+
+function emptyResult(config: OvernightConfig): OvernightResult {
+  return {
+    total_overnight_nights_per_year: 0,
+    total_hotel_cost: 0,
+    total_per_diem_cost: 0,
+    total_overnight_cost: 0,
+    trips: [],
+    day_trip_property_count: 0,
+    avg_drive_hours_to_overnight_property: 0,
+    largest_cluster_size: 0,
+    properties_requiring_overnight: 0,
+    config_used: config,
+  }
+}
+
+// Density clustering — single-link agglomerative within a fixed radius.
+// O(n²) pairwise distance check, fine for n in the hundreds. We don't
+// reach for DBSCAN proper here because we don't need noise-point handling
+// (every overnight prop belongs to some cluster, even if alone).
+//
+// Algorithm: each property starts in its own cluster. Repeatedly merge any
+// two clusters where SOME property in one is within radius of SOME property
+// in the other. Settles when no merges happen on a full pass.
+function densityCluster<T extends { lat: number; lng: number }>(
+  items: T[],
+  radiusMiles: number
+): T[][] {
+  if (items.length === 0) return []
+  const parent = items.map((_, i) => i)
+  const find = (i: number): number => {
+    while (parent[i] !== i) {
+      parent[i] = parent[parent[i]]
+      i = parent[i]
+    }
+    return i
+  }
+  const union = (a: number, b: number) => {
+    const ra = find(a)
+    const rb = find(b)
+    if (ra !== rb) parent[ra] = rb
+  }
+
+  for (let i = 0; i < items.length; i++) {
+    for (let j = i + 1; j < items.length; j++) {
+      const d = haversineMiles(items[i], items[j])
+      if (d <= radiusMiles) union(i, j)
+    }
+  }
+
+  const groups = new Map<number, T[]>()
+  for (let i = 0; i < items.length; i++) {
+    const r = find(i)
+    const arr = groups.get(r) ?? []
+    arr.push(items[i])
+    groups.set(r, arr)
+  }
+  return Array.from(groups.values())
+}
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100
+}
+
+// Resolves the final hotels_annual value used by Bid Pricing. Three cases:
+//   1. Override is set → flat value, calc still computed for comparison
+//   2. Calc has trips → use calculated total
+//   3. Empty result → fall back to legacy flat hotels_annual
+//
+// The returned `breakdown` is what Bid Pricing surfaces in cost_buildup.hotels
+// so the line-item expander can show the math (or the override + comparison).
+export interface ResolvedHotelsCost {
+  value: number
+  basis: 'override' | 'calculated' | 'flat_fallback'
+  hotel_room_cost: number
+  per_diem_cost: number
+  total_nights: number
+  cost_per_night: number
+  per_diem_per_night: number
+  crew_size: number
+  cluster_count: number
+  properties_requiring_overnight: number
+  // The full calc result, for the line-item drawer / Crew Strategy summary.
+  calculated: OvernightResult
+  // When basis === 'override', this is what the calc would have given.
+  calculated_value: number
+}
+
+export function resolveHotelsCost(
+  calc: OvernightResult,
+  override: number | null,
+  legacyFlat: number,
+  config: OvernightConfig
+): ResolvedHotelsCost {
+  const calculatedValue = calc.total_overnight_cost
+  let basis: ResolvedHotelsCost['basis']
+  let value: number
+
+  if (override != null) {
+    basis = 'override'
+    value = override
+  } else if (calc.trips.length > 0) {
+    basis = 'calculated'
+    value = calculatedValue
+  } else {
+    basis = 'flat_fallback'
+    value = legacyFlat
+  }
+
+  return {
+    value,
+    basis,
+    hotel_room_cost: calc.total_hotel_cost,
+    per_diem_cost: calc.total_per_diem_cost,
+    total_nights: calc.total_overnight_nights_per_year,
+    cost_per_night: config.cost_per_night,
+    per_diem_per_night: config.per_diem_per_night,
+    crew_size: config.crew_size,
+    cluster_count: calc.trips.length,
+    properties_requiring_overnight: calc.properties_requiring_overnight,
+    calculated: calc,
+    calculated_value: calculatedValue,
+  }
+}

--- a/api/_lib/analysis/property-hours.ts
+++ b/api/_lib/analysis/property-hours.ts
@@ -1,0 +1,86 @@
+// Per-property "how long does a crew spend here per visit, and how often" —
+// extracted from crew-strategy so overnight-calculator can reuse the same
+// math without duplicating offering classification + combo-rule logic.
+//
+// Only project_clean + upholstery offerings count. Recurring janitorial
+// is excluded (it's a separate workforce; covered by the Workforce Sizing
+// module) and "other" is excluded.
+import type { AccountProperty } from './account-data.js'
+import { classifyOffering } from './service-offerings.js'
+
+export interface PropertyHoursInputs {
+  project_clean_base_hours: number
+  project_clean_hours_per_sqft: number
+  upholstery_solo_hours: number
+  upholstery_combo_hours_pct: number
+  visits_per_year_default: number
+}
+
+export interface PropertyVisit {
+  property: AccountProperty
+  // Sum of project-crew hours across all relevant SLs for ONE visit. If a
+  // property has both project_clean and upholstery SLs the combo rule has
+  // already been applied here.
+  hours_per_visit: number
+  // Max visits_per_year across the relevant SLs. Operationally: the crew
+  // arrives this many times; on lower-frequency visits, fewer SLs are
+  // touched but trip overhead (drive, hotels) still applies, so this is
+  // the right denominator for trip-based costs.
+  visits_per_year: number
+  // Total annual project-crew hours at this property. Equals
+  // hours_per_visit * visits_per_year only as an upper bound; the true
+  // sum across SLs of (hours_per_sl × visits_sl) may differ. We expose
+  // this for callers that want the crew-strategy-style aggregate.
+  annual_hours: number
+}
+
+export function computePropertyVisitHours(
+  properties: AccountProperty[],
+  offerings: Map<string, { id: string; name: string }>,
+  inputs: PropertyHoursInputs
+): PropertyVisit[] {
+  return properties.map((p) => {
+    let hasProjectClean = false
+    let hasUpholstery = false
+    for (const sl of p.service_locations) {
+      const offering = sl.service_offering_id ? offerings.get(sl.service_offering_id) : null
+      const cls = offering ? classifyOffering(offering.name) : 'other'
+      if (cls === 'project_clean') hasProjectClean = true
+      if (cls === 'upholstery') hasUpholstery = true
+    }
+
+    let totalHoursPerVisit = 0
+    let maxVisits = 0
+    let annualHours = 0
+
+    for (const sl of p.service_locations) {
+      const offering = sl.service_offering_id ? offerings.get(sl.service_offering_id) : null
+      const cls = offering ? classifyOffering(offering.name) : 'other'
+      if (cls !== 'project_clean' && cls !== 'upholstery') continue
+
+      const sqft = sl.serviceable_sqft ?? 0
+      const visits = sl.visits_per_year_override ?? inputs.visits_per_year_default
+
+      let hoursPerVisit = 0
+      if (cls === 'project_clean') {
+        hoursPerVisit =
+          inputs.project_clean_base_hours + sqft * inputs.project_clean_hours_per_sqft
+        if (hasUpholstery) hoursPerVisit *= 1 + inputs.upholstery_combo_hours_pct
+      } else if (cls === 'upholstery') {
+        if (!hasProjectClean) hoursPerVisit = inputs.upholstery_solo_hours
+      }
+      hoursPerVisit = Math.max(hoursPerVisit, 1)
+
+      totalHoursPerVisit += hoursPerVisit
+      if (visits > maxVisits) maxVisits = visits
+      annualHours += hoursPerVisit * visits
+    }
+
+    return {
+      property: p,
+      hours_per_visit: totalHoursPerVisit,
+      visits_per_year: maxVisits || inputs.visits_per_year_default,
+      annual_hours: annualHours,
+    }
+  })
+}

--- a/api/accounts/[accountId]/clients/[clientId]/operational-constraints.ts
+++ b/api/accounts/[accountId]/clients/[clientId]/operational-constraints.ts
@@ -149,6 +149,19 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     if (body.labor_burden_breakdown && typeof body.labor_burden_breakdown === 'object') {
       upsert.labor_burden_breakdown = body.labor_burden_breakdown
     }
+    // Phase 3.7 — overnight cost knobs + flat override.
+    if (body.hotel_cost_config && typeof body.hotel_cost_config === 'object') {
+      upsert.hotel_cost_config = body.hotel_cost_config
+    }
+    if ('hotels_annual_override' in body) {
+      const raw = body.hotels_annual_override
+      if (raw === null || raw === '' || raw === undefined) {
+        upsert.hotels_annual_override = null
+      } else {
+        const n = typeof raw === 'string' ? parseFloat(raw) : raw
+        upsert.hotels_annual_override = Number.isFinite(n) ? n : null
+      }
+    }
     for (const k of numericFields) {
       const raw = body[k]
       if (raw === undefined || raw === null || raw === '') {

--- a/api/analyses/account/[accountId]/clients/[clientId]/bid-pricing-structure.ts
+++ b/api/analyses/account/[accountId]/clients/[clientId]/bid-pricing-structure.ts
@@ -18,6 +18,14 @@ import {
   requireSelectedBranches,
   NO_SELECTION_ERROR,
 } from '../../../../../_lib/analysis/operational-constraints.js'
+import { loadAccountOfferings } from '../../../../../_lib/analysis/service-offerings.js'
+import { computePropertyVisitHours } from '../../../../../_lib/analysis/property-hours.js'
+import {
+  calculateOvernights,
+  resolveHotelsCost,
+  type OvernightConfig,
+  type ResolvedHotelsCost,
+} from '../../../../../_lib/analysis/overnight-calculator.js'
 
 export const config = { maxDuration: 60 }
 
@@ -102,12 +110,58 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     const branchOpt = await fetchLatestCompletedAnalysis(db, accountId, clientId, 'branch_optimization')
     const workforce = await fetchLatestCompletedAnalysis(db, accountId, clientId, 'workforce_sizing')
 
+    // Phase 3.7 — calculate overnight cost from selected branches + property
+    // visit hours, then resolve final hotels value (override / calc / flat).
+    const offerings = await loadAccountOfferings(db, accountId, clientId)
+    const visits = computePropertyVisitHours(properties, offerings, {
+      project_clean_base_hours: constraints.project_clean_base_hours,
+      project_clean_hours_per_sqft: constraints.project_clean_hours_per_sqft,
+      upholstery_solo_hours: constraints.upholstery_solo_hours,
+      upholstery_combo_hours_pct: constraints.upholstery_combo_hours_pct,
+      visits_per_year_default: constraints.visits_per_year_default ?? 2,
+    })
+    const overnightConfig: OvernightConfig = {
+      drive_speed_mph: constraints.drive_speed_mph,
+      overnight_trigger_one_way_hours: constraints.hotel_cost_config.overnight_trigger_one_way_hours,
+      max_work_hours_per_crew_day: constraints.hotel_cost_config.max_work_hours_per_crew_day,
+      buffer_hours_per_day: constraints.hotel_cost_config.buffer_hours_per_day,
+      crew_size: constraints.crew_size,
+      cost_per_night: constraints.hotel_cost_config.cost_per_night,
+      per_diem_per_night: constraints.hotel_cost_config.per_diem_per_night,
+      include_per_diem: constraints.hotel_cost_config.include_per_diem,
+    }
+    const overnightInput = visits
+      .filter((v) => v.property.latitude != null && v.property.longitude != null && v.hours_per_visit > 0)
+      .map((v) => ({
+        id: v.property.id,
+        address: v.property.address_line1,
+        lat: v.property.latitude as number,
+        lng: v.property.longitude as number,
+        visits_per_year: v.visits_per_year,
+        hours_per_visit: v.hours_per_visit,
+      }))
+    const calc = calculateOvernights(
+      overnightInput,
+      sel.branches.map((b) => ({ name: b.name, lat: b.lat, lng: b.lng })),
+      overnightConfig
+    )
+    const hotelsResolved = resolveHotelsCost(
+      calc,
+      constraints.hotels_annual_override,
+      constraints.hotels_annual,
+      overnightConfig
+    )
+
+    // Pin the resolved value into inputs so computeBidPricing uses it.
+    inputs.hotels_annual = hotelsResolved.value
+
     const result = computeBidPricing(
       properties,
       inputs,
       crewStrategy?.outputs,
       branchOpt?.outputs,
-      workforce?.outputs
+      workforce?.outputs,
+      hotelsResolved
     )
 
     await completeAnalysisRecord(db, analysisId, {
@@ -128,7 +182,8 @@ export function computeBidPricing(
   inputs: BidInputs,
   crewStrategyOutputs: any,
   branchOptOutputs: any,
-  workforceOutputs: any
+  workforceOutputs: any,
+  hotelsResolved?: ResolvedHotelsCost
 ) {
   let resolvedLabor = inputs.total_annual_labor_cost
   let resolvedVehicleFuel = inputs.total_annual_vehicle_cost
@@ -237,7 +292,26 @@ export function computeBidPricing(
         direct_labor: Math.round(direct_labor),
         vehicle_fuel: Math.round(vehicle_fuel),
         vehicle_lease: Math.round(vehicle_lease),
-        hotels: Math.round(hotels),
+        // Phase 3.7 — hotels is now structured. When the caller hasn't passed
+        // hotelsResolved (e.g. body.hotels_annual override path), fall back
+        // to a minimal flat shape so consumers can still read .total.
+        hotels: hotelsResolved
+          ? {
+              total: Math.round(hotelsResolved.value),
+              hotel_room_cost: hotelsResolved.hotel_room_cost,
+              per_diem_cost: hotelsResolved.per_diem_cost,
+              basis: hotelsResolved.basis,
+              calculated_value: hotelsResolved.calculated_value,
+              breakdown: {
+                total_nights: hotelsResolved.total_nights,
+                cost_per_night: hotelsResolved.cost_per_night,
+                crew_size: hotelsResolved.crew_size,
+                per_diem_per_night: hotelsResolved.per_diem_per_night,
+                cluster_count: hotelsResolved.cluster_count,
+                properties_requiring_overnight: hotelsResolved.properties_requiring_overnight,
+              },
+            }
+          : { total: Math.round(hotels), basis: 'flat_fallback' as const },
         supplies: Math.round(supplies),
         branch_overhead: Math.round(branch_overhead),
         insurance: Math.round(insurance),

--- a/api/analyses/account/[accountId]/clients/[clientId]/crew-strategy.ts
+++ b/api/analyses/account/[accountId]/clients/[clientId]/crew-strategy.ts
@@ -27,6 +27,12 @@ import {
 } from '../../../../../_lib/analysis/operational-constraints.js'
 import { nearestCity, populationBand } from '../../../../../_lib/analysis/constrained-kmeans.js'
 import { regionForState } from '../../../../../_lib/analysis/regions.js'
+import { computePropertyVisitHours } from '../../../../../_lib/analysis/property-hours.js'
+import {
+  calculateOvernights,
+  type OvernightConfig,
+  type OvernightResult,
+} from '../../../../../_lib/analysis/overnight-calculator.js'
 
 // Status enum for utilization band evaluation. Order matters for severity:
 // 'overcapacity' > 'underutilized' > 'acceptable' > 'ideal'.
@@ -156,7 +162,49 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     }))
     const kUsed = constraints.selected_k ?? branches.length
 
-    const result = computeCrewStrategy(properties, offerings, branches, kUsed, inputs)
+    // Phase 3.7 — overnight cost is identical across A/B/C (same properties,
+    // same branches; what differs is the crew structure, not the work
+    // location). Compute once, attach to each option's summary.
+    const visits = computePropertyVisitHours(properties, offerings, {
+      project_clean_base_hours: inputs.project_clean_base_hours,
+      project_clean_hours_per_sqft: inputs.project_clean_hours_per_sqft,
+      upholstery_solo_hours: inputs.upholstery_solo_hours,
+      upholstery_combo_hours_pct: inputs.upholstery_combo_hours_pct,
+      visits_per_year_default: inputs.visits_per_year_default,
+    })
+    const overnightConfig: OvernightConfig = {
+      drive_speed_mph: constraints.drive_speed_mph,
+      overnight_trigger_one_way_hours:
+        constraints.hotel_cost_config.overnight_trigger_one_way_hours,
+      max_work_hours_per_crew_day:
+        constraints.hotel_cost_config.max_work_hours_per_crew_day,
+      buffer_hours_per_day: constraints.hotel_cost_config.buffer_hours_per_day,
+      crew_size: inputs.crew_size,
+      cost_per_night: constraints.hotel_cost_config.cost_per_night,
+      per_diem_per_night: constraints.hotel_cost_config.per_diem_per_night,
+      include_per_diem: constraints.hotel_cost_config.include_per_diem,
+    }
+    const overnight = calculateOvernights(
+      visits
+        .filter(
+          (v) =>
+            v.property.latitude != null &&
+            v.property.longitude != null &&
+            v.hours_per_visit > 0
+        )
+        .map((v) => ({
+          id: v.property.id,
+          address: v.property.address_line1,
+          lat: v.property.latitude as number,
+          lng: v.property.longitude as number,
+          visits_per_year: v.visits_per_year,
+          hours_per_visit: v.hours_per_visit,
+        })),
+      branches,
+      overnightConfig
+    )
+
+    const result = computeCrewStrategy(properties, offerings, branches, kUsed, inputs, overnight)
 
     await completeAnalysisRecord(db, analysisId, {
       outputs: result.outputs,
@@ -176,7 +224,8 @@ export function computeCrewStrategy(
   offerings: Map<string, { id: string; name: string }>,
   branches: Array<{ name: string; lat: number; lng: number; property_count?: number }>,
   kUsed: number,
-  inputs: CrewStrategyInputs
+  inputs: CrewStrategyInputs,
+  overnight?: OvernightResult
 ) {
   // ── Per-property work hours per year ──────────────────────────────────────
   // For each property we want total annual project-crew hours. A property may
@@ -598,6 +647,31 @@ export function computeCrewStrategy(
     }
   }
 
+  // ── Phase 3.7 — overnight summary, identical across options ───────────────
+  const largestTrip = (overnight?.trips ?? []).reduce<{
+    name: string
+    properties: number
+    nights: number
+  } | null>((best, t) => {
+    if (!best || t.properties_in_cluster.length > best.properties) {
+      return {
+        name: t.cluster_id,
+        properties: t.properties_in_cluster.length,
+        nights: t.nights_per_trip,
+      }
+    }
+    return best
+  }, null)
+  const overnightSummary = overnight
+    ? {
+        total_overnight_nights: overnight.total_overnight_nights_per_year,
+        total_overnight_cost: overnight.total_overnight_cost,
+        properties_requiring_overnight: overnight.properties_requiring_overnight,
+        cluster_count: overnight.trips.length,
+        largest_cluster: largestTrip,
+      }
+    : null
+
   // ── Output assembly ───────────────────────────────────────────────────────
   const options = {
     A: {
@@ -608,6 +682,7 @@ export function computeCrewStrategy(
       annual_vehicle_cost: Math.round(optionA_vehicle),
       total_annual_cost: Math.round(totalA),
       utilization_breakdown: { portfolio: optionA_portfolio },
+      overnight_summary: overnightSummary,
       pros: [
         'Highest utilization — pay only for actual work hours',
         'Flexible — crews go where the demand is',
@@ -634,6 +709,7 @@ export function computeCrewStrategy(
         per_region: optionB_per_region,
         portfolio: optionB_portfolio,
       },
+      overnight_summary: overnightSummary,
       pros: [
         'Simple — each crew owns one cluster',
         'Defensible to clients — predictable, named teams',
@@ -657,6 +733,7 @@ export function computeCrewStrategy(
       annual_vehicle_cost: Math.round(optionC_vehicle),
       total_annual_cost: Math.round(totalC),
       utilization_breakdown: { portfolio: optionC_portfolio },
+      overnight_summary: overnightSummary,
       pros: [
         'Lowest labor cost — FT crews highly utilized year-round',
         'Matches seasonal demand peaks (school breaks, etc.)',

--- a/api/analyses/account/[accountId]/clients/[clientId]/overnight-breakdown.ts
+++ b/api/analyses/account/[accountId]/clients/[clientId]/overnight-breakdown.ts
@@ -1,0 +1,132 @@
+// GET  /api/analyses/account/[accountId]/clients/[clientId]/overnight-breakdown
+// POST same path with { branches?, hotel_cost_config? } overrides for what-if
+//
+// Returns the full OvernightResult plus the resolved hotels value.
+// Used by the Cost Assumptions panel preview + breakdown drawer.
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { createAdminClient } from '../../../../../_lib/supabase.js'
+import { authenticateRequest } from '../../../../../_lib/auth.js'
+import { loadAccountProperties } from '../../../../../_lib/analysis/account-data.js'
+import { loadAccountOfferings } from '../../../../../_lib/analysis/service-offerings.js'
+import { computePropertyVisitHours } from '../../../../../_lib/analysis/property-hours.js'
+import {
+  loadConstraints,
+  applyExclusions,
+  requireSelectedBranches,
+  HOTEL_COST_CONFIG_DEFAULTS,
+  type HotelCostConfig,
+} from '../../../../../_lib/analysis/operational-constraints.js'
+import {
+  calculateOvernights,
+  resolveHotelsCost,
+  type OvernightConfig,
+  type OvernightBranch,
+} from '../../../../../_lib/analysis/overnight-calculator.js'
+
+export const config = { maxDuration: 30 }
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method === 'OPTIONS') return res.status(200).end()
+  if (req.method !== 'GET' && req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+
+  try {
+    await authenticateRequest(req)
+  } catch (err: any) {
+    return res.status(err.statusCode ?? 401).json({ error: err.message ?? 'Unauthorized' })
+  }
+
+  const accountId = req.query.accountId as string
+  const clientId = req.query.clientId as string
+  if (!accountId || !clientId) {
+    return res.status(400).json({ error: 'accountId and clientId required' })
+  }
+
+  const db = createAdminClient()
+  const constraints = await loadConstraints(db, accountId, clientId)
+
+  // POST body can override branches + config for what-if.
+  const body = (req.body ?? {}) as {
+    branches?: OvernightBranch[]
+    hotel_cost_config?: Partial<HotelCostConfig>
+  }
+
+  // Resolve branches: body override > saved selection > error.
+  let branches: OvernightBranch[]
+  if (Array.isArray(body.branches) && body.branches.length > 0) {
+    branches = body.branches
+  } else {
+    const sel = requireSelectedBranches(constraints)
+    if (!sel.ok) {
+      return res.status(400).json({
+        error: 'No branches selected. Select branches first to calculate overnight costs.',
+        code: 'BRANCHES_NOT_SELECTED',
+      })
+    }
+    branches = sel.branches.map((b) => ({ name: b.name, lat: b.lat, lng: b.lng }))
+  }
+
+  const mergedConfig: HotelCostConfig = {
+    ...HOTEL_COST_CONFIG_DEFAULTS,
+    ...constraints.hotel_cost_config,
+    ...(body.hotel_cost_config ?? {}),
+  }
+
+  const overnightConfig: OvernightConfig = {
+    drive_speed_mph: constraints.drive_speed_mph,
+    overnight_trigger_one_way_hours: mergedConfig.overnight_trigger_one_way_hours,
+    max_work_hours_per_crew_day: mergedConfig.max_work_hours_per_crew_day,
+    buffer_hours_per_day: mergedConfig.buffer_hours_per_day,
+    crew_size: constraints.crew_size,
+    cost_per_night: mergedConfig.cost_per_night,
+    per_diem_per_night: mergedConfig.per_diem_per_night,
+    include_per_diem: mergedConfig.include_per_diem,
+  }
+
+  const allProperties = await loadAccountProperties(db, accountId, clientId)
+  const properties = applyExclusions(allProperties, constraints.excluded_property_ids)
+  const offerings = await loadAccountOfferings(db, accountId, clientId)
+
+  const visits = computePropertyVisitHours(properties, offerings, {
+    project_clean_base_hours: constraints.project_clean_base_hours,
+    project_clean_hours_per_sqft: constraints.project_clean_hours_per_sqft,
+    upholstery_solo_hours: constraints.upholstery_solo_hours,
+    upholstery_combo_hours_pct: constraints.upholstery_combo_hours_pct,
+    visits_per_year_default: constraints.visits_per_year_default ?? 2,
+  })
+
+  const calc = calculateOvernights(
+    visits
+      .filter(
+        (v) =>
+          v.property.latitude != null &&
+          v.property.longitude != null &&
+          v.hours_per_visit > 0
+      )
+      .map((v) => ({
+        id: v.property.id,
+        address: v.property.address_line1,
+        lat: v.property.latitude as number,
+        lng: v.property.longitude as number,
+        visits_per_year: v.visits_per_year,
+        hours_per_visit: v.hours_per_visit,
+      })),
+    branches,
+    overnightConfig
+  )
+
+  const resolved = resolveHotelsCost(
+    calc,
+    constraints.hotels_annual_override,
+    constraints.hotels_annual,
+    overnightConfig
+  )
+
+  return res.status(200).json({
+    result: calc,
+    resolved,
+    config: mergedConfig,
+    override: constraints.hotels_annual_override,
+  })
+}

--- a/src/components/analysis/CostAssumptionsPanel.tsx
+++ b/src/components/analysis/CostAssumptionsPanel.tsx
@@ -10,6 +10,7 @@ import Button from '../ui/Button'
 import { Badge } from '../ui/Badge'
 import { Input } from '../ui/Input'
 import { cn } from '../../lib/cn'
+import OvernightLodgingSection from './OvernightLodgingSection'
 
 export interface CostAssumptionsConstraints {
   crew_size: number
@@ -39,12 +40,32 @@ export interface CostAssumptionsConstraints {
   surge_premium_multiplier: number
   branch_overhead_annual: number
   hotels_annual: number
+  hotel_cost_config: HotelCostConfig
+  hotels_annual_override: number | null
   supplies_pct_of_labor: number
   insurance_annual: number
   corporate_overhead_pct: number
   target_gross_margin_pct: number
 
   system_defaults?: Record<string, number>
+}
+
+export interface HotelCostConfig {
+  cost_per_night: number
+  overnight_trigger_one_way_hours: number
+  max_work_hours_per_crew_day: number
+  buffer_hours_per_day: number
+  per_diem_per_night: number
+  include_per_diem: boolean
+}
+
+const HOTEL_CONFIG_DEFAULTS: HotelCostConfig = {
+  cost_per_night: 120,
+  overnight_trigger_one_way_hours: 3,
+  max_work_hours_per_crew_day: 8,
+  buffer_hours_per_day: 2,
+  per_diem_per_night: 50,
+  include_per_diem: true,
 }
 
 const PHASE35_DEFAULTS = {
@@ -116,9 +137,10 @@ const GROUPS: Array<{
   },
   {
     title: 'Branch & operational costs',
+    description:
+      'Hotels & overnight stays are now calculated below per Phase 3.7. Override available when needed.',
     fields: [
       { key: 'branch_overhead_annual', label: 'Branch overhead per year' },
-      { key: 'hotels_annual', label: 'Hotels & overnight stays per year' },
       { key: 'supplies_pct_of_labor', label: 'Supplies (% of labor)' },
       { key: 'insurance_annual', label: 'Insurance per year' },
       { key: 'corporate_overhead_pct', label: 'Corporate overhead (% of direct cost)' },
@@ -353,6 +375,9 @@ export default function CostAssumptionsPanel({
               <h4 className="text-[10px] font-semibold uppercase tracking-wider text-fg-subtle">
                 {g.title}
               </h4>
+              {g.description && (
+                <p className="text-xs text-fg-subtle">{g.description}</p>
+              )}
               <ul className="divide-y divide-border rounded-md border border-border bg-surface">
                 {g.fields.map((f) => {
                   const cur =
@@ -438,6 +463,18 @@ export default function CostAssumptionsPanel({
               </ul>
             </section>
           ))}
+
+          <OvernightLodgingSection
+            accountId={accountId}
+            clientId={clientId}
+            config={data.hotel_cost_config ?? HOTEL_CONFIG_DEFAULTS}
+            override={data.hotels_annual_override}
+            constraintsRow={data}
+            onSaved={() => {
+              refresh()
+              onSaved?.()
+            }}
+          />
         </div>
       )}
     </div>

--- a/src/components/analysis/OvernightBreakdownDrawer.tsx
+++ b/src/components/analysis/OvernightBreakdownDrawer.tsx
@@ -1,0 +1,259 @@
+// Overnight breakdown drawer — opens from the Cost Assumptions panel and
+// shows cluster-by-cluster detail (which properties go on which trips,
+// how many nights, annual cost). Built fresh on design tokens rather than
+// reusing SlideOver because we need a wider panel + tabular data layout.
+import { useEffect, useState } from 'react'
+import { X } from 'lucide-react'
+import { useAuth } from '../../hooks/useAuth'
+import { Badge } from '../ui/Badge'
+import { cn } from '../../lib/cn'
+
+interface Trip {
+  branch_name: string
+  cluster_id: string
+  cluster_centroid: { lat: number; lng: number }
+  drive_hours_one_way: number
+  total_work_hours_per_visit: number
+  work_days_per_trip: number
+  nights_per_trip: number
+  trips_per_year: number
+  annual_nights: number
+  annual_hotel_cost: number
+  annual_per_diem_cost: number
+  annual_total_cost: number
+  properties_in_cluster: Array<{
+    property_id: string
+    address: string | null
+    hours_per_visit: number
+    visits_per_year: number
+  }>
+}
+
+interface BreakdownData {
+  result: {
+    total_overnight_nights_per_year: number
+    total_hotel_cost: number
+    total_per_diem_cost: number
+    total_overnight_cost: number
+    trips: Trip[]
+    properties_requiring_overnight: number
+    day_trip_property_count: number
+    avg_drive_hours_to_overnight_property: number
+  }
+  resolved: {
+    value: number
+    basis: 'override' | 'calculated' | 'flat_fallback'
+    calculated_value: number
+  }
+}
+
+interface Props {
+  open: boolean
+  onClose: () => void
+  accountId: string
+  clientId: string
+}
+
+export default function OvernightBreakdownDrawer({
+  open,
+  onClose,
+  accountId,
+  clientId,
+}: Props) {
+  const { getToken } = useAuth()
+  const [data, setData] = useState<BreakdownData | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!open) return
+    let cancelled = false
+    async function load() {
+      setLoading(true)
+      setError(null)
+      try {
+        const token = await getToken()
+        const res = await fetch(
+          `/api/analyses/account/${accountId}/clients/${clientId}/overnight-breakdown`,
+          { headers: { Authorization: `Bearer ${token}` } }
+        )
+        if (!res.ok) throw new Error(`HTTP ${res.status}`)
+        if (!cancelled) setData(await res.json())
+      } catch (err) {
+        if (!cancelled) setError(err instanceof Error ? err.message : String(err))
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+    load()
+    return () => { cancelled = true }
+  }, [open, accountId, clientId, getToken])
+
+  useEffect(() => {
+    if (!open) return
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose() }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  }, [open, onClose])
+
+  if (!open) return null
+
+  return (
+    <>
+      <div
+        className="fixed inset-0 z-40 bg-fg/30 backdrop-blur-sm"
+        onClick={onClose}
+      />
+      <div
+        className={cn(
+          'fixed right-0 top-0 bottom-0 z-50 w-full max-w-2xl bg-surface-elevated shadow-2xl',
+          'border-l border-border flex flex-col'
+        )}
+      >
+        <header className="flex items-start justify-between gap-4 border-b border-border px-6 py-4">
+          <div>
+            <h2 className="text-lg font-semibold tracking-tight text-fg">
+              Overnight breakdown
+            </h2>
+            <p className="text-xs text-fg-muted mt-0.5">
+              Per-cluster detail of overnight trips driving the calculated annual cost.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-fg-muted hover:text-fg transition-colors"
+            aria-label="Close"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </header>
+
+        <div className="flex-1 overflow-y-auto px-6 py-5 space-y-5">
+          {loading && <p className="text-sm text-fg-muted">Loading…</p>}
+          {error && <p className="text-sm text-danger">{error}</p>}
+          {data && (
+            <>
+              <SummaryStrip data={data} />
+              {data.result.trips.length === 0 ? (
+                <div className="rounded-md border border-border bg-surface-subtle px-4 py-6 text-sm text-fg-muted text-center">
+                  No overnight stays required — all properties are within{' '}
+                  the trigger threshold of their nearest branch.
+                </div>
+              ) : (
+                <ul className="space-y-4">
+                  {data.result.trips.map((trip) => (
+                    <li
+                      key={trip.cluster_id}
+                      className="rounded-md border border-border bg-surface p-4"
+                    >
+                      <div className="flex items-start justify-between gap-3 flex-wrap">
+                        <div className="space-y-0.5 min-w-0">
+                          <p className="text-sm font-semibold text-fg">
+                            {trip.cluster_id}
+                          </p>
+                          <p className="text-xs text-fg-muted">
+                            from <span className="text-fg">{trip.branch_name}</span> ·{' '}
+                            <span className="font-tabular">{trip.drive_hours_one_way}</span> hr one-way
+                          </p>
+                        </div>
+                        <Badge variant="accent">
+                          ${trip.annual_total_cost.toLocaleString()}/yr
+                        </Badge>
+                      </div>
+
+                      <dl className="mt-3 grid grid-cols-2 sm:grid-cols-4 gap-3 text-xs">
+                        <Stat label="Properties" value={trip.properties_in_cluster.length} />
+                        <Stat label="Work hrs/visit" value={trip.total_work_hours_per_visit} />
+                        <Stat label="Work days/trip" value={trip.work_days_per_trip} />
+                        <Stat label="Nights/trip" value={trip.nights_per_trip} />
+                        <Stat label="Trips/year" value={trip.trips_per_year} />
+                        <Stat label="Annual nights" value={trip.annual_nights} />
+                        <Stat
+                          label="Hotel"
+                          value={`$${trip.annual_hotel_cost.toLocaleString()}`}
+                        />
+                        <Stat
+                          label="Per diem"
+                          value={`$${trip.annual_per_diem_cost.toLocaleString()}`}
+                        />
+                      </dl>
+
+                      <details className="mt-3 group">
+                        <summary className="cursor-pointer text-xs text-accent hover:underline">
+                          {trip.properties_in_cluster.length} propert
+                          {trip.properties_in_cluster.length === 1 ? 'y' : 'ies'} in cluster
+                        </summary>
+                        <ul className="mt-2 divide-y divide-border rounded-md border border-border bg-surface-subtle">
+                          {trip.properties_in_cluster.map((p) => (
+                            <li
+                              key={p.property_id}
+                              className="px-3 py-2 text-xs flex items-center justify-between gap-2"
+                            >
+                              <span className="text-fg truncate">
+                                {p.address ?? p.property_id.slice(0, 8)}
+                              </span>
+                              <span className="text-fg-muted whitespace-nowrap font-tabular">
+                                {p.hours_per_visit}h × {p.visits_per_year}/yr
+                              </span>
+                            </li>
+                          ))}
+                        </ul>
+                      </details>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+    </>
+  )
+}
+
+function SummaryStrip({ data }: { data: BreakdownData }) {
+  return (
+    <div className="rounded-md border border-border bg-surface-subtle px-4 py-3">
+      <div className="flex items-baseline justify-between gap-3 flex-wrap">
+        <p className="text-xs uppercase tracking-wider text-fg-subtle">
+          {data.resolved.basis === 'override' ? 'Annual cost (override)' : 'Annual cost (calculated)'}
+        </p>
+        <p className="font-mono text-2xl font-semibold tabular-nums text-fg">
+          ${data.resolved.value.toLocaleString()}
+        </p>
+      </div>
+      {data.resolved.basis === 'override' && (
+        <p className="mt-1 text-xs text-fg-muted">
+          Calculated would have been:{' '}
+          <span className="font-tabular">
+            ${data.resolved.calculated_value.toLocaleString()}
+          </span>
+        </p>
+      )}
+      <dl className="mt-3 grid grid-cols-2 sm:grid-cols-4 gap-3 text-xs">
+        <Stat label="Hotel total" value={`$${data.result.total_hotel_cost.toLocaleString()}`} />
+        <Stat label="Per diem total" value={`$${data.result.total_per_diem_cost.toLocaleString()}`} />
+        <Stat label="Total nights" value={data.result.total_overnight_nights_per_year} />
+        <Stat label="Clusters" value={data.result.trips.length} />
+        <Stat label="Overnight properties" value={data.result.properties_requiring_overnight} />
+        <Stat label="Day-trip properties" value={data.result.day_trip_property_count} />
+        <Stat
+          label="Avg drive (overnight)"
+          value={`${data.result.avg_drive_hours_to_overnight_property} hr`}
+        />
+      </dl>
+    </div>
+  )
+}
+
+function Stat({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div>
+      <dt className="text-[10px] uppercase tracking-wider text-fg-subtle">{label}</dt>
+      <dd className="font-mono font-medium tabular-nums text-fg">
+        {typeof value === 'number' ? value.toLocaleString() : value}
+      </dd>
+    </div>
+  )
+}

--- a/src/components/analysis/OvernightLodgingSection.tsx
+++ b/src/components/analysis/OvernightLodgingSection.tsx
@@ -1,0 +1,370 @@
+// Phase 3.7 — "Overnight & Lodging" subsection on the Cost Assumptions
+// panel. Replaces the legacy flat hotels_annual row.
+//
+// Reads/writes hotel_cost_config (jsonb) + hotels_annual_override (numeric)
+// through the same /operational-constraints PUT that the rest of the panel
+// uses, then re-fetches the calculated overnight breakdown for the live
+// total preview.
+import { useEffect, useState, useCallback } from 'react'
+import { ExternalLink, RotateCcw } from 'lucide-react'
+import { useAuth } from '../../hooks/useAuth'
+import Button from '../ui/Button'
+import { Badge } from '../ui/Badge'
+import { Input } from '../ui/Input'
+import OvernightBreakdownDrawer from './OvernightBreakdownDrawer'
+import type {
+  CostAssumptionsConstraints,
+  HotelCostConfig,
+} from './CostAssumptionsPanel'
+
+// Mirror the resolved-cost shape returned by /overnight-breakdown.
+interface BreakdownResponse {
+  result: {
+    total_overnight_nights_per_year: number
+    total_hotel_cost: number
+    total_per_diem_cost: number
+    total_overnight_cost: number
+    trips: any[]
+    properties_requiring_overnight: number
+    day_trip_property_count: number
+  }
+  resolved: {
+    value: number
+    basis: 'override' | 'calculated' | 'flat_fallback'
+    calculated_value: number
+  }
+}
+
+const FIELDS: Array<{
+  key: keyof HotelCostConfig
+  label: string
+  format: (n: number) => string
+  inputMode: 'currency' | 'hours' | 'number'
+}> = [
+  { key: 'cost_per_night', label: 'Hotel cost per night', format: (n) => `$${n}`, inputMode: 'currency' },
+  { key: 'overnight_trigger_one_way_hours', label: 'Overnight trigger (one-way drive)', format: (n) => `${n} hr`, inputMode: 'hours' },
+  { key: 'max_work_hours_per_crew_day', label: 'Max work hours per crew day', format: (n) => `${n} hr`, inputMode: 'hours' },
+  { key: 'per_diem_per_night', label: 'Per diem per crew member per night', format: (n) => `$${n}`, inputMode: 'currency' },
+]
+
+const DEFAULTS: Record<keyof HotelCostConfig, number | boolean> = {
+  cost_per_night: 120,
+  overnight_trigger_one_way_hours: 3,
+  max_work_hours_per_crew_day: 8,
+  buffer_hours_per_day: 2,
+  per_diem_per_night: 50,
+  include_per_diem: true,
+}
+
+interface Props {
+  accountId: string
+  clientId: string
+  config: HotelCostConfig
+  override: number | null
+  constraintsRow: CostAssumptionsConstraints
+  onSaved: () => void
+}
+
+export default function OvernightLodgingSection({
+  accountId,
+  clientId,
+  config,
+  override,
+  constraintsRow,
+  onSaved,
+}: Props) {
+  const { getToken } = useAuth()
+  const [breakdown, setBreakdown] = useState<BreakdownResponse | null>(null)
+  const [loadingBreakdown, setLoadingBreakdown] = useState(false)
+  const [breakdownError, setBreakdownError] = useState<string | null>(null)
+  const [editingKey, setEditingKey] = useState<keyof HotelCostConfig | null>(null)
+  const [editValue, setEditValue] = useState('')
+  const [saving, setSaving] = useState(false)
+  const [drawerOpen, setDrawerOpen] = useState(false)
+  const [overrideEditing, setOverrideEditing] = useState(false)
+  const [overrideDraft, setOverrideDraft] = useState('')
+
+  const loadBreakdown = useCallback(async () => {
+    setLoadingBreakdown(true)
+    setBreakdownError(null)
+    try {
+      const token = await getToken()
+      const res = await fetch(
+        `/api/analyses/account/${accountId}/clients/${clientId}/overnight-breakdown`,
+        { headers: { Authorization: `Bearer ${token}` } }
+      )
+      if (res.status === 400) {
+        const body = await res.json().catch(() => ({}))
+        if (body.code === 'BRANCHES_NOT_SELECTED') {
+          setBreakdown(null)
+          setBreakdownError('Select branches first to calculate overnight costs.')
+          return
+        }
+      }
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      setBreakdown(await res.json())
+    } catch (err) {
+      setBreakdownError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setLoadingBreakdown(false)
+    }
+  }, [accountId, clientId, getToken])
+
+  useEffect(() => {
+    loadBreakdown()
+  }, [loadBreakdown, config, override])
+
+  async function saveConstraint(patch: Record<string, unknown>) {
+    setSaving(true)
+    try {
+      const token = await getToken()
+      // /operational-constraints expects the full row shape — pass through
+      // the existing fields we already loaded so unrelated values don't
+      // get nulled out by the upsert.
+      const payload: Record<string, unknown> = {
+        client_id: (constraintsRow as any).client_id ?? null,
+        existing_branches: (constraintsRow as any).existing_branches ?? [],
+        excluded_property_ids: (constraintsRow as any).excluded_property_ids ?? [],
+        excluded_property_reason: (constraintsRow as any).excluded_property_reason ?? null,
+        population_constraint: (constraintsRow as any).population_constraint ?? undefined,
+        utilization_constraint: (constraintsRow as any).utilization_constraint ?? undefined,
+        ...patch,
+      }
+      const res = await fetch(
+        `/api/accounts/${accountId}/clients/${clientId}/operational-constraints`,
+        {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+          body: JSON.stringify(payload),
+        }
+      )
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      onSaved()
+    } finally {
+      setSaving(false)
+      setEditingKey(null)
+      setEditValue('')
+      setOverrideEditing(false)
+    }
+  }
+
+  function commitFieldEdit() {
+    if (editingKey == null) return
+    const n = Number(editValue.trim())
+    if (!Number.isFinite(n)) return
+    saveConstraint({ hotel_cost_config: { ...config, [editingKey]: n } })
+  }
+
+  function toggleIncludePerDiem(next: boolean) {
+    saveConstraint({ hotel_cost_config: { ...config, include_per_diem: next } })
+  }
+
+  function startOverrideEdit() {
+    setOverrideEditing(true)
+    setOverrideDraft(override == null ? '' : String(override))
+  }
+
+  function commitOverride() {
+    const trimmed = overrideDraft.trim()
+    if (trimmed === '') {
+      saveConstraint({ hotels_annual_override: null })
+      return
+    }
+    const n = Number(trimmed)
+    if (!Number.isFinite(n)) return
+    saveConstraint({ hotels_annual_override: n })
+  }
+
+  function clearOverride() {
+    saveConstraint({ hotels_annual_override: null })
+  }
+
+  return (
+    <section className="space-y-2" id="cost-group-overnight-and-lodging">
+      <h4 className="text-[10px] font-semibold uppercase tracking-wider text-fg-subtle">
+        Overnight & lodging
+      </h4>
+      <p className="text-xs text-fg-subtle">
+        Calculated from selected branches + property coverage. Phase 3.7 replaces the flat $35K assumption.
+      </p>
+
+      <ul className="divide-y divide-border rounded-md border border-border bg-surface">
+        {FIELDS.map((f) => {
+          const cur = (config[f.key] as number | undefined) ?? (DEFAULTS[f.key] as number)
+          const def = DEFAULTS[f.key] as number
+          const overridden = Math.abs(cur - def) > 1e-9
+          const isEditing = editingKey === f.key
+          return (
+            <li key={f.key} className="flex flex-wrap items-center justify-between gap-3 px-4 py-2.5 text-sm">
+              <div className="min-w-0 flex-1">
+                <p className="font-medium text-fg">{f.label}</p>
+                <div className="mt-0.5 flex items-center gap-2 text-xs text-fg-muted">
+                  <span>Default: <span className="font-tabular">{f.format(def)}</span></span>
+                  {overridden && <Badge variant="accent">Overridden</Badge>}
+                </div>
+              </div>
+              {isEditing ? (
+                <div className="flex items-center gap-2">
+                  <Input
+                    type="number"
+                    step="any"
+                    value={editValue}
+                    onChange={(e) => setEditValue(e.target.value)}
+                    autoFocus
+                    disabled={saving}
+                    className="w-32 font-mono"
+                  />
+                  <Button size="sm" onClick={commitFieldEdit} loading={saving}>Save</Button>
+                  <Button variant="ghost" size="sm" onClick={() => setEditingKey(null)} disabled={saving}>
+                    Cancel
+                  </Button>
+                </div>
+              ) : (
+                <div className="flex items-center gap-3">
+                  <p className="min-w-[100px] text-right font-mono font-semibold tabular-nums text-fg">
+                    {f.format(cur)}
+                  </p>
+                  <button
+                    type="button"
+                    onClick={() => { setEditingKey(f.key); setEditValue(String(cur)) }}
+                    className="rounded-sm text-xs text-accent hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent disabled:opacity-50"
+                    disabled={saving}
+                  >
+                    Edit
+                  </button>
+                  {overridden && (
+                    <button
+                      type="button"
+                      onClick={() => saveConstraint({ hotel_cost_config: { ...config, [f.key]: def } })}
+                      className="inline-flex items-center gap-1 rounded-sm text-xs text-fg-muted hover:text-danger focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent disabled:opacity-50"
+                      disabled={saving}
+                      title="Reset to default"
+                    >
+                      <RotateCcw className="h-3 w-3" />
+                      Reset
+                    </button>
+                  )}
+                </div>
+              )}
+            </li>
+          )
+        })}
+
+        {/* Per-diem toggle */}
+        <li className="flex items-center justify-between gap-3 px-4 py-2.5 text-sm">
+          <div className="min-w-0 flex-1">
+            <p className="font-medium text-fg">Include per diem in cost?</p>
+            <p className="mt-0.5 text-xs text-fg-muted">
+              Multiplies per-diem rate × crew size × nights into the rolled-up overnight cost.
+            </p>
+          </div>
+          <label className="inline-flex items-center cursor-pointer gap-2 text-xs text-fg-muted">
+            <input
+              type="checkbox"
+              checked={config.include_per_diem ?? true}
+              onChange={(e) => toggleIncludePerDiem(e.target.checked)}
+              className="rounded border-border accent-accent"
+              disabled={saving}
+            />
+            {config.include_per_diem ? 'Yes' : 'No'}
+          </label>
+        </li>
+      </ul>
+
+      {/* Calculated total preview */}
+      <div className="rounded-md border border-border bg-surface-subtle px-4 py-3">
+        {loadingBreakdown ? (
+          <p className="text-sm text-fg-muted">Calculating overnight cost…</p>
+        ) : breakdownError ? (
+          <p className="text-sm text-danger">{breakdownError}</p>
+        ) : breakdown ? (
+          <>
+            <div className="flex items-baseline justify-between gap-3">
+              <p className="text-xs uppercase tracking-wider text-fg-subtle">
+                {override != null
+                  ? 'Calculated annual overnight cost (overridden)'
+                  : 'Calculated annual overnight cost'}
+              </p>
+              <p className="font-mono text-xl font-semibold tabular-nums text-fg">
+                ${(override ?? breakdown.result.total_overnight_cost).toLocaleString()}
+              </p>
+            </div>
+            {override != null && (
+              <p className="mt-1 text-xs text-fg-muted">
+                Calculated would have been:{' '}
+                <span className="font-tabular">
+                  ${breakdown.result.total_overnight_cost.toLocaleString()}
+                </span>
+              </p>
+            )}
+            <p className="mt-1 text-xs text-fg-muted">
+              Based on{' '}
+              <span className="font-tabular">{breakdown.result.trips.length}</span> cluster
+              {breakdown.result.trips.length === 1 ? '' : 's'} ·{' '}
+              <span className="font-tabular">
+                {breakdown.result.total_overnight_nights_per_year}
+              </span>{' '}
+              total nights ·{' '}
+              <span className="font-tabular">
+                {breakdown.result.properties_requiring_overnight}
+              </span>{' '}
+              propert{breakdown.result.properties_requiring_overnight === 1 ? 'y' : 'ies'}
+              {breakdown.result.day_trip_property_count > 0 && (
+                <>
+                  {' '}(+ <span className="font-tabular">{breakdown.result.day_trip_property_count}</span>{' '}
+                  day-trip propert
+                  {breakdown.result.day_trip_property_count === 1 ? 'y' : 'ies'})
+                </>
+              )}
+            </p>
+            <div className="mt-3 flex flex-wrap items-center gap-2">
+              <Button
+                size="sm"
+                variant="secondary"
+                onClick={() => setDrawerOpen(true)}
+                disabled={breakdown.result.trips.length === 0}
+              >
+                <ExternalLink className="h-3.5 w-3.5" />
+                View detailed breakdown
+              </Button>
+              {override == null ? (
+                <Button size="sm" variant="ghost" onClick={startOverrideEdit}>
+                  Override with flat value
+                </Button>
+              ) : (
+                <Button size="sm" variant="ghost" onClick={clearOverride} loading={saving}>
+                  Use calculated value instead
+                </Button>
+              )}
+            </div>
+            {overrideEditing && (
+              <div className="mt-3 flex items-center gap-2">
+                <Input
+                  type="number"
+                  step="any"
+                  value={overrideDraft}
+                  onChange={(e) => setOverrideDraft(e.target.value)}
+                  placeholder="Flat annual cost (e.g. 35000)"
+                  autoFocus
+                  disabled={saving}
+                  className="w-48 font-mono"
+                />
+                <Button size="sm" onClick={commitOverride} loading={saving}>Save override</Button>
+                <Button size="sm" variant="ghost" onClick={() => setOverrideEditing(false)} disabled={saving}>
+                  Cancel
+                </Button>
+              </div>
+            )}
+          </>
+        ) : null}
+      </div>
+
+      <OvernightBreakdownDrawer
+        open={drawerOpen}
+        onClose={() => setDrawerOpen(false)}
+        accountId={accountId}
+        clientId={clientId}
+      />
+    </section>
+  )
+}

--- a/supabase/migrations/20260430041456_phase37_overnight_costs.sql
+++ b/supabase/migrations/20260430041456_phase37_overnight_costs.sql
@@ -1,0 +1,33 @@
+-- Phase 3.7: Calculated overnight & hotel costs.
+--
+-- Replaces the flat $35K hotels_annual constant with a calculated value
+-- based on which properties are >3hr from their nearest branch, density-
+-- clustered geographically, with work_days_per_trip and nights_per_trip
+-- driving the cost rollup.
+--
+-- Two new columns:
+--   hotel_cost_config: knobs for the calc (cost_per_night, trigger hours,
+--     work-hour cap, per diem). Stored as jsonb so the schema can extend
+--     without migrations (e.g. regional pricing later).
+--   hotels_annual_override: nullable numeric. When set, modules use this
+--     flat value INSTEAD of the calculated number. Lets a user pin a
+--     specific dollar figure (matched bid number, contractual amount,
+--     etc.) without losing the ability to compare against the calc.
+--
+-- The legacy hotels_annual column stays — it's now a "fallback default"
+-- for situations where calculation isn't possible (no selected branches
+-- on the dashboard yet) and the user hasn't set an override.
+
+ALTER TABLE public.account_operational_constraints
+  ADD COLUMN IF NOT EXISTS hotel_cost_config JSONB
+    DEFAULT '{
+      "cost_per_night": 120,
+      "overnight_trigger_one_way_hours": 3,
+      "max_work_hours_per_crew_day": 8,
+      "buffer_hours_per_day": 2,
+      "per_diem_per_night": 50,
+      "include_per_diem": true
+    }'::jsonb;
+
+ALTER TABLE public.account_operational_constraints
+  ADD COLUMN IF NOT EXISTS hotels_annual_override NUMERIC DEFAULT NULL;


### PR DESCRIPTION
## Summary
- Replaces the flat `hotels_annual = $35,000` constant with a calculated value driven by which properties are >3hr from their nearest branch, density-clustered geographically into multi-night trips.
- Adds `hotel_cost_config` (knobs) and `hotels_annual_override` (optional flat pin) to `account_operational_constraints`.
- Bid Pricing now emits a structured `cost_buildup.hotels` (room cost + per diem + breakdown). Crew Strategy options carry an `overnight_summary`.
- New `/overnight-breakdown` endpoint + Cost Assumptions panel section + cluster-by-cluster drawer.

## Algorithm (`api/_lib/analysis/overnight-calculator.ts`)
1. Assign each property to its nearest selected branch.
2. Filter to overnight-required: `one_way_drive_hours > overnight_trigger_one_way_hours` (default 3).
3. Group by branch (a Frisco-dispatched crew shouldn't bundle a Lubbock prop into a Houston cluster).
4. Density-cluster overnight properties within **30 miles** using single-link union-find. Cheap O(n²) — fine for portfolios in the hundreds.
5. For each cluster:
   - `total_work_hours_per_visit = Σ hours_per_visit` across properties
   - `work_days_per_trip = ceil(total_work_hours / max_work_hours_per_crew_day)`
   - `nights_per_trip = work_days_per_trip` (arrive night before day 1, sleep between days, drive home after last day)
   - `trips_per_year = max(visits_per_year)` across cluster
   - `annual_nights = nights_per_trip × trips_per_year`
   - `annual_hotel_cost = annual_nights × cost_per_night`
   - `annual_per_diem_cost = annual_nights × per_diem × crew_size` (if `include_per_diem`)

## Resolution priority for `hotels_annual` in Bid Pricing
1. `hotels_annual_override` is set → flat value, basis `'override'`
2. Calc has trips → calculated total, basis `'calculated'`
3. Empty calc → fall back to legacy flat `hotels_annual`, basis `'flat_fallback'`

## Schema
```sql
ALTER TABLE account_operational_constraints
  ADD COLUMN hotel_cost_config JSONB DEFAULT '{
    "cost_per_night": 120,
    "overnight_trigger_one_way_hours": 3,
    "max_work_hours_per_crew_day": 8,
    "buffer_hours_per_day": 2,
    "per_diem_per_night": 50,
    "include_per_diem": true
  }'::jsonb,
  ADD COLUMN hotels_annual_override NUMERIC DEFAULT NULL;
```

## API
- `GET/POST /api/analyses/account/[accountId]/clients/[clientId]/overnight-breakdown` — returns full `OvernightResult` + resolved hotels value. POST body accepts `{ branches?, hotel_cost_config? }` for what-if.
- `PUT /api/accounts/[accountId]/clients/[clientId]/operational-constraints` — accepts `hotel_cost_config` (full object) + `hotels_annual_override` (numeric or null to clear).

## Output shape — Bid Pricing
```ts
cost_buildup: {
  ...
  hotels: {
    total: 42360,
    hotel_room_cost: 34320,
    per_diem_cost: 42900,
    basis: 'calculated' | 'override' | 'flat_fallback',
    calculated_value: 42360,
    breakdown: {
      total_nights: 286,
      cost_per_night: 120,
      crew_size: 3,
      per_diem_per_night: 50,
      cluster_count: 12,
      properties_requiring_overnight: 89,
    }
  }
}
```

## Output shape — Crew Strategy (per option A/B/C)
```ts
overnight_summary: {
  total_overnight_nights: 286,
  total_overnight_cost: 77220,
  properties_requiring_overnight: 89,
  cluster_count: 12,
  largest_cluster: { name: 'Frisco-c2', properties: 14, nights: 4 }
}
```

(Same value across A/B/C — same properties + branches → same trips. The crew structure choice doesn't change overnight nights.)

## UI
- **Cost Assumptions panel** drops the flat `hotels_annual` row. New "Overnight & lodging" section below the existing groups with edit-in-place fields (cost/night, trigger hours, max work hrs/day, per diem) + per-diem inclusion toggle + live calc preview ("Based on 12 clusters · 286 total nights · 89 properties").
- **Override flow**: "Override with flat value" → number input → save into `hotels_annual_override`. When set, the preview shows both the override AND what the calc would have given. "Use calculated value instead" clears it.
- **Breakdown drawer** (right-side, max-w-2xl, design-token aware) — summary strip + per-cluster cards with drive hours, work days, nights, trips/yr, annual cost; expandable property list per cluster.

## Refactor
Extracted the per-property "hours_per_visit + visits_per_year" math from `crew-strategy.ts` into `api/_lib/analysis/property-hours.ts` so the overnight calculator and bid pricing both reuse the same offering classification + combo-rule logic.

## Trade-offs
- **30mi cluster radius** is fixed. Tight enough to keep cluster work cohesive, loose enough that nearby cities (Frisco/Plano/McKinney) cluster together. Configurable later if portfolios show different patterns.
- **Per-diem = nights × rate × crew_size**. One room per crew, one rate. Regional pricing + multi-room logic deferred per spec out-of-scope.
- **`trips_per_year = max(visits_per_year)`** in the cluster — slightly over-estimates if visit frequencies vary, but operationally bundling lower-freq into higher-freq trips is what crews actually do.
- **Single-link union-find at O(n²)** clustering. Fine for hundreds of overnight properties; if a portfolio gets to thousands we'd swap in DBSCAN.
- **Legacy `hotels_annual` column kept** for the flat-fallback case (no selected branches yet). UI hides it but DB still carries the value for back-compat.

## Test plan
- [ ] Existing accounts: load Cost Assumptions panel → "Overnight & lodging" section appears, flat row gone
- [ ] Without selected branches → preview shows "Select branches first…"
- [ ] With JLL Red River + K=3 (Frisco/Houston/Albuquerque): expect ~50–150 overnight nights/yr (UT/AZ/NM properties drive overnight clusters)
- [ ] Edit `cost_per_night` from $120 → $150 → save → preview total updates
- [ ] Edit `overnight_trigger_one_way_hours` from 3 → 4 → fewer properties qualify, total drops
- [ ] Toggle "Include per diem" off → total drops by `nights × $50 × crew_size`
- [ ] Click "View detailed breakdown" → drawer opens with per-cluster cards
- [ ] Expand a cluster → property list shows addresses + per-property hours/year
- [ ] Click "Override with flat value" → enter $35000 → preview shows both, calculated row reads "Calculated would have been: $42,360"
- [ ] Click "Use calculated value instead" → override clears, preview shows calc again
- [ ] Run Bid Pricing → `cost_buildup.hotels` is the structured object
- [ ] Run Crew Strategy → each option's `overnight_summary` matches the panel preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)