### PR TITLE
Phase 4b: property editing extensions (cascade module + audit log + bulk edit)

### DIFF
--- a/api/_lib/analysis/edit-cascade.ts
+++ b/api/_lib/analysis/edit-cascade.ts
@@ -1,0 +1,203 @@
+// Phase 4b: Centralized cascade logic for property + service_location edits.
+//
+// Single source of truth for "what does changing field X do to the rest of
+// the system?". Both PATCH endpoints and the bulk-edit endpoint call
+// determineCascadingEffects() and apply the returned actions.
+//
+// The output is JSON-serializable so it goes straight into the
+// property_edit_history.cascading_effects column for the audit log.
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+export type EntityType = 'property' | 'service_location'
+
+export interface FieldChange {
+  field: string
+  old: unknown
+  new: unknown
+}
+
+export type ModuleKey =
+  | 'crew_strategy'
+  | 'workforce_sizing'
+  | 'bid_pricing_structure'
+  | 'branch_optimization'
+  | 'drive_time_logistics'
+  | 'seasonality_capacity'
+  | 'geographic_distribution'
+
+export interface CascadingEffects {
+  // Module keys whose latest completed analyses should be marked 'stale'.
+  analyses_to_stale: ModuleKey[]
+  // Should we kick triggerSynthesisRefresh after the edit?
+  synthesis_refresh: boolean
+  // Should the property's comparable_properties cache be cleared?
+  comparables_invalidate: boolean
+  // Did an address field change such that the property needs re-geocoding?
+  geocode_required: boolean
+  // Why each module is being staled (field → modules) — surfaced in the UI.
+  reasons: Array<{ field: string; modules: ModuleKey[]; explanation: string }>
+}
+
+const ALL_TIER_2: ModuleKey[] = [
+  'crew_strategy',
+  'workforce_sizing',
+  'bid_pricing_structure',
+  'drive_time_logistics',
+  'seasonality_capacity',
+]
+
+const ADDRESS_FIELDS = new Set([
+  'address_line1',
+  'address_line2',
+  'city',
+  'state',
+  'postal_code',
+  'country',
+])
+
+// Threshold for sqft change. >= 10% of the OLD value flips dependent
+// modules to stale. Below the threshold, the edit is recorded but no
+// modules are staled — small rounding fixes shouldn't churn analyses.
+const SQFT_STALE_THRESHOLD = 0.1
+
+export function determineCascadingEffects(
+  entityType: EntityType,
+  changes: FieldChange[]
+): CascadingEffects {
+  const out: CascadingEffects = {
+    analyses_to_stale: [],
+    synthesis_refresh: false,
+    comparables_invalidate: false,
+    geocode_required: false,
+    reasons: [],
+  }
+
+  const stale = new Set<ModuleKey>()
+  const addStale = (
+    field: string,
+    modules: ModuleKey[],
+    explanation: string
+  ) => {
+    for (const m of modules) stale.add(m)
+    out.reasons.push({ field, modules, explanation })
+  }
+
+  for (const c of changes) {
+    if (entityType === 'property' && ADDRESS_FIELDS.has(c.field)) {
+      out.geocode_required = true
+      // Re-geocoding will eventually shift drive-time math, so flag the
+      // tier-2 modules that depend on coordinates. They'll re-run when
+      // the next dashboard interaction notices the stale flag.
+      addStale(
+        c.field,
+        ['crew_strategy', 'bid_pricing_structure', 'drive_time_logistics', 'branch_optimization'],
+        'Address change re-geocodes the property and shifts drive-time inputs.'
+      )
+      continue
+    }
+
+    if (entityType === 'service_location') {
+      if (c.field === 'serviceable_sqft') {
+        const oldN = Number(c.old) || 0
+        const newN = Number(c.new) || 0
+        if (oldN > 0 && Math.abs(newN - oldN) / oldN >= SQFT_STALE_THRESHOLD) {
+          addStale(
+            c.field,
+            ['crew_strategy', 'workforce_sizing', 'bid_pricing_structure'],
+            `Sqft changed by ≥10%; work-hour totals shift across labor + bid math.`
+          )
+        }
+        continue
+      }
+      if (c.field === 'service_offering_id') {
+        // Offering change can flip a property between project-clean and
+        // upholstery (or include/exclude it from project crew work),
+        // which moves work-hours across modules.
+        addStale(
+          c.field,
+          ALL_TIER_2,
+          'Offering change reclassifies the work; all tier-2 modules need to re-run.'
+        )
+        out.comparables_invalidate = true
+        continue
+      }
+      if (c.field === 'visits_per_year_override' || c.field === 'hours_per_visit_override') {
+        addStale(
+          c.field,
+          ['crew_strategy', 'bid_pricing_structure'],
+          'Visit/hour overrides shift annual work-hours.'
+        )
+        continue
+      }
+      if (c.field === 'crew_size_override') {
+        addStale(
+          c.field,
+          ['crew_strategy'],
+          'Per-SL crew sizing affects crew-strategy capacity math.'
+        )
+        continue
+      }
+      if (c.field === 'monthly_contract_value') {
+        addStale(
+          c.field,
+          ['bid_pricing_structure'],
+          'Contract value affects bid revenue/margin baseline.'
+        )
+        continue
+      }
+    }
+  }
+
+  out.analyses_to_stale = Array.from(stale)
+  out.synthesis_refresh = out.analyses_to_stale.length > 0
+  return out
+}
+
+// Apply the cascade: flip the latest completed row of each affected module
+// to status='stale', kick synthesis if requested. Comparables invalidation
+// for a property happens here too (clear the cached comparables row).
+//
+// Tolerates partial failures — one module not flipping shouldn't block the
+// edit. Each error is logged but the function still returns the list of
+// modules that successfully went stale.
+export async function applyCascadingEffects(
+  db: SupabaseClient,
+  effects: CascadingEffects,
+  scope: { account_id: string; client_id: string; property_id?: string }
+): Promise<{ staled: ModuleKey[]; synthesis_triggered: boolean }> {
+  const staled: ModuleKey[] = []
+  for (const moduleKey of effects.analyses_to_stale) {
+    const { data: latest } = await db
+      .from('portfolio_analyses')
+      .select('id')
+      .eq('account_id', scope.account_id)
+      .eq('client_id', scope.client_id)
+      .eq('module_key', moduleKey)
+      .eq('status', 'completed')
+      .order('created_at', { ascending: false })
+      .limit(1)
+      .maybeSingle()
+    if (!latest) continue
+    const { error } = await db
+      .from('portfolio_analyses')
+      .update({ status: 'stale' })
+      .eq('id', (latest as { id: string }).id)
+    if (!error) staled.push(moduleKey)
+    else console.error(`[edit-cascade] failed to stale ${moduleKey}:`, error.message)
+  }
+
+  let synthesisTriggered = false
+  if (effects.synthesis_refresh) {
+    // Use the existing synthesis-refresh debouncer instead of duplicating
+    // the logic here.
+    try {
+      const { triggerSynthesisRefresh } = await import('../synthesis-refresh.js')
+      await triggerSynthesisRefresh(db, scope.account_id, scope.client_id)
+      synthesisTriggered = true
+    } catch (err) {
+      console.error('[edit-cascade] synthesis refresh failed:', err)
+    }
+  }
+
+  return { staled, synthesis_triggered: synthesisTriggered }
+}

--- a/api/_lib/property-audit.ts
+++ b/api/_lib/property-audit.ts
@@ -15,6 +15,10 @@ export interface AuditScope {
 
 export interface AuditOptions {
   changedBy?: string | null
+  reason?: string | null
+  // Same cascading_effects object on every row of a single save — the
+  // audit log can then group by (entity, edited_at) to read the effects.
+  cascadingEffects?: object | null
 }
 
 // Returns the list of field names that actually changed (after deep equality
@@ -46,6 +50,8 @@ export async function recordEdits(
       old_value: oldVal === undefined ? null : oldVal,
       new_value: newVal === undefined ? null : newVal,
       changed_by: opts.changedBy ?? null,
+      reason: opts.reason ?? null,
+      cascading_effects: opts.cascadingEffects ?? null,
     })
   }
 

--- a/api/accounts/[accountId]/clients/[clientId]/edit-history.ts
+++ b/api/accounts/[accountId]/clients/[clientId]/edit-history.ts
@@ -1,0 +1,103 @@
+// GET /api/accounts/[accountId]/clients/[clientId]/edit-history
+// Audit log scoped to one tenant. Powers the admin audit page.
+//
+// Filters (all optional, query string):
+//   entity_type=property|service_location
+//   field_name=<exact match>
+//   edited_by=<email or substring>
+//   date_from=<ISO>  date_to=<ISO>
+//   has_cascading_effects=true|false
+//   page=<int, 1-based>  limit=<int, default 50, max 200>
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { createAdminClient } from '../../../../_lib/supabase.js'
+import { authenticateRequest } from '../../../../_lib/auth.js'
+
+export const config = { maxDuration: 15 }
+
+const DEFAULT_LIMIT = 50
+const MAX_LIMIT = 200
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method === 'OPTIONS') return res.status(200).end()
+  if (req.method !== 'GET') return res.status(405).json({ error: 'Method not allowed' })
+
+  try {
+    await authenticateRequest(req)
+  } catch (err: any) {
+    return res.status(err.statusCode ?? 401).json({ error: err.message ?? 'Unauthorized' })
+  }
+
+  const accountId = req.query.accountId as string
+  const clientId = req.query.clientId as string
+  if (!accountId || !clientId) {
+    return res.status(400).json({ error: 'accountId and clientId required' })
+  }
+
+  const limit = Math.min(
+    MAX_LIMIT,
+    Math.max(1, parseInt(String(req.query.limit ?? DEFAULT_LIMIT), 10) || DEFAULT_LIMIT)
+  )
+  const page = Math.max(1, parseInt(String(req.query.page ?? 1), 10) || 1)
+  const offset = (page - 1) * limit
+
+  const db = createAdminClient()
+
+  // Phase 4a's table uses property_id + service_location_id columns
+  // rather than entity_type/entity_id, so derive the discriminator on
+  // the way out. service_location_id IS NULL → 'property' edit.
+  let query = db
+    .from('property_edit_history')
+    .select('*', { count: 'exact' })
+    .eq('account_id', accountId)
+    .eq('client_id', clientId)
+    .order('changed_at', { ascending: false })
+
+  const entityType = req.query.entity_type as string | undefined
+  if (entityType === 'service_location') {
+    query = query.not('service_location_id', 'is', null)
+  } else if (entityType === 'property') {
+    query = query.is('service_location_id', null)
+  }
+
+  const fieldName = req.query.field_name as string | undefined
+  if (fieldName) query = query.eq('field_name', fieldName)
+
+  const editedBy = req.query.edited_by as string | undefined
+  if (editedBy) query = query.ilike('changed_by', `%${editedBy}%`)
+
+  const dateFrom = req.query.date_from as string | undefined
+  if (dateFrom) query = query.gte('changed_at', dateFrom)
+  const dateTo = req.query.date_to as string | undefined
+  if (dateTo) query = query.lte('changed_at', dateTo)
+
+  const hasCascading = req.query.has_cascading_effects as string | undefined
+  if (hasCascading === 'true') query = query.not('cascading_effects', 'is', null)
+  else if (hasCascading === 'false') query = query.is('cascading_effects', null)
+
+  const { data, count, error } = await query.range(offset, offset + limit - 1)
+
+  if (error) return res.status(500).json({ error: error.message })
+
+  const edits = (data ?? []).map((r: any) => ({
+    id: r.id,
+    entity_type: r.service_location_id ? 'service_location' : 'property',
+    entity_id: r.service_location_id ?? r.property_id,
+    property_id: r.property_id,
+    service_location_id: r.service_location_id,
+    field_name: r.field_name,
+    old_value: r.old_value,
+    new_value: r.new_value,
+    edited_by: r.changed_by,
+    edited_at: r.changed_at,
+    reason: r.reason ?? null,
+    cascading_effects: r.cascading_effects ?? null,
+  }))
+
+  return res.status(200).json({
+    edits,
+    total_count: count ?? 0,
+    page,
+    limit,
+    has_more: (count ?? 0) > offset + edits.length,
+  })
+}

--- a/api/properties/bulk-edit.ts
+++ b/api/properties/bulk-edit.ts
@@ -1,0 +1,148 @@
+// POST /api/properties/bulk-edit
+// Body: {
+//   property_ids: uuid[],
+//   action: 'add_tag' | 'remove_tag' | 'set_notes',
+//   value: string
+// }
+//
+// Reads each property's current state, applies the diff, persists, and
+// records one audit row per property that actually changed. Properties
+// already in the desired state are skipped (e.g. add_tag where the tag
+// already exists) and counted as 'unchanged' so the UI can show
+// "Tagged 5 of 10 (others already tagged)".
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { createAdminClient } from '../_lib/supabase.js'
+import { authenticateRequest } from '../_lib/auth.js'
+import { recordEdits } from '../_lib/property-audit.js'
+
+export const config = { maxDuration: 30 }
+
+const MAX_BULK = 500
+type BulkAction = 'add_tag' | 'remove_tag' | 'set_notes'
+const ACTIONS: BulkAction[] = ['add_tag', 'remove_tag', 'set_notes']
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'POST') return res.status(405).json({ error: 'Method not allowed' })
+
+  let ctx: Awaited<ReturnType<typeof authenticateRequest>>
+  try {
+    ctx = await authenticateRequest(req)
+  } catch (err: any) {
+    return res.status(err.statusCode ?? 401).json({ error: err.message ?? 'Unauthorized' })
+  }
+
+  const body = (req.body ?? {}) as Record<string, unknown>
+  const propertyIds = Array.isArray(body.property_ids) ? (body.property_ids as string[]) : []
+  const action = body.action as BulkAction
+  const value = body.value as string | undefined
+
+  if (propertyIds.length === 0) {
+    return res.status(400).json({ error: 'property_ids must be a non-empty array' })
+  }
+  if (propertyIds.length > MAX_BULK) {
+    return res.status(400).json({ error: `cap is ${MAX_BULK} properties per call` })
+  }
+  if (!ACTIONS.includes(action)) {
+    return res.status(400).json({ error: `action must be one of: ${ACTIONS.join(', ')}` })
+  }
+  if ((action === 'add_tag' || action === 'remove_tag') && (!value || typeof value !== 'string')) {
+    return res.status(400).json({ error: 'value (tag string) is required for tag actions' })
+  }
+  if (action === 'add_tag' && !/^[a-z0-9-]{1,50}$/i.test(value!)) {
+    return res
+      .status(400)
+      .json({ error: 'tag must be 1–50 chars, alphanumeric + dashes' })
+  }
+
+  const db = createAdminClient()
+
+  const { data: rows, error: fetchErr } = await db
+    .from('properties')
+    .select('id, account_id, client_id, internal_tags, notes')
+    .in('id', propertyIds)
+
+  if (fetchErr) return res.status(500).json({ error: fetchErr.message })
+  const found = new Set((rows ?? []).map((r) => (r as { id: string }).id))
+  const missing = propertyIds.filter((id) => !found.has(id))
+
+  let updated = 0
+  let unchanged = 0
+
+  for (const r of rows ?? []) {
+    const row = r as {
+      id: string
+      account_id: string | null
+      client_id: string | null
+      internal_tags: string[] | null
+      notes: string | null
+    }
+    const oldTags = row.internal_tags ?? []
+    const oldNotes = row.notes ?? null
+
+    let newTags = oldTags
+    let newNotes = oldNotes
+
+    if (action === 'add_tag') {
+      if (oldTags.includes(value!)) {
+        unchanged++
+        continue
+      }
+      newTags = [...oldTags, value!]
+    } else if (action === 'remove_tag') {
+      if (!oldTags.includes(value!)) {
+        unchanged++
+        continue
+      }
+      newTags = oldTags.filter((t) => t !== value)
+    } else if (action === 'set_notes') {
+      const next = typeof value === 'string' ? value : null
+      if (next === oldNotes) {
+        unchanged++
+        continue
+      }
+      newNotes = next
+    }
+
+    const patch: Record<string, unknown> = { updated_at: new Date().toISOString() }
+    if (newTags !== oldTags) patch.internal_tags = newTags
+    if (newNotes !== oldNotes) patch.notes = newNotes
+
+    const { data: updatedRow, error: updateErr } = await db
+      .from('properties')
+      .update(patch)
+      .eq('id', row.id)
+      .select('id, internal_tags, notes')
+      .single()
+
+    if (updateErr) continue
+
+    await recordEdits(
+      db,
+      {
+        propertyId: row.id,
+        accountId: row.account_id,
+        clientId: row.client_id,
+      },
+      { internal_tags: oldTags, notes: oldNotes },
+      {
+        internal_tags: (updatedRow as any).internal_tags,
+        notes: (updatedRow as any).notes,
+      },
+      newTags !== oldTags ? ['internal_tags'] : ['notes'],
+      {
+        changedBy: ctx.email ?? ctx.userId ?? null,
+        reason: `bulk-edit: ${action}`,
+      }
+    )
+
+    updated++
+  }
+
+  return res.status(200).json({
+    requested: propertyIds.length,
+    updated,
+    unchanged,
+    not_found: missing.length,
+    not_found_ids: missing,
+  })
+}

--- a/api/v1/properties/[id].ts
+++ b/api/v1/properties/[id].ts
@@ -9,6 +9,11 @@ import {
   ADDRESS_FIELD_KEYS,
   isEditablePropertyField,
 } from '../../../src/lib/editable-fields.js'
+import {
+  determineCascadingEffects,
+  applyCascadingEffects,
+  type FieldChange,
+} from '../../_lib/analysis/edit-cascade.js'
 
 export const config = { maxDuration: 30 }
 
@@ -50,6 +55,10 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
   if (req.method === 'PATCH') {
     const body = (req.body ?? {}) as Record<string, unknown>
+    const editReason =
+      typeof body.edit_reason === 'string' && body.edit_reason.trim().length > 0
+        ? body.edit_reason.trim()
+        : null
 
     // Whitelist — silently drop anything not in PROPERTY_FIELDS so callers
     // can't update system-managed columns (lat/lng, address_hash,
@@ -57,6 +66,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     const updates: Record<string, unknown> = {}
     const rejected: string[] = []
     for (const [k, v] of Object.entries(body)) {
+      if (k === 'edit_reason') continue
       if (isEditablePropertyField(k)) updates[k] = v
       else rejected.push(k)
     }
@@ -91,14 +101,38 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
     const accountId = (current as any).account_id ?? null
     const clientId = (current as any).client_id ?? null
+
+    // Phase 4b — centralized cascade. Diff old vs new, ask edit-cascade
+    // which downstream modules to stale, persist effects on the audit row.
+    const fieldChanges: FieldChange[] = Object.keys(updates)
+      .filter((k) => !deepEqual((current as any)[k], (updated as any)[k]))
+      .map((k) => ({ field: k, old: (current as any)[k], new: (updated as any)[k] }))
+    const effects = determineCascadingEffects('property', fieldChanges)
+
     const changed = await recordEdits(
       db,
       { propertyId, accountId, clientId },
       current as Record<string, unknown>,
       updated as Record<string, unknown>,
       Object.keys(updates),
-      { changedBy: ctx.email ?? ctx.userId ?? null }
+      {
+        changedBy: ctx.email ?? ctx.userId ?? null,
+        reason: editReason,
+        cascadingEffects: fieldChanges.length > 0 ? effects : null,
+      }
     )
+
+    let cascadeApplied: { staled: string[]; synthesis_triggered: boolean } = {
+      staled: [],
+      synthesis_triggered: false,
+    }
+    if (accountId && clientId && effects.analyses_to_stale.length > 0) {
+      cascadeApplied = await applyCascadingEffects(db, effects, {
+        account_id: accountId,
+        client_id: clientId,
+        property_id: propertyId,
+      })
+    }
 
     // Side effect: address change → re-validate + re-geocode + persist
     // lat/lng. Done synchronously so the user sees the corrected map pin
@@ -168,8 +202,35 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       changed_fields: changed,
       rejected_fields: rejected,
       geocode: geocodeResult,
+      cascading_effects: {
+        analyses_marked_stale: cascadeApplied.staled,
+        synthesis_refresh_triggered: cascadeApplied.synthesis_triggered,
+        comparables_invalidated: effects.comparables_invalidate,
+        reasons: effects.reasons,
+      },
+      edits_recorded: changed.length,
     })
   }
 
   return res.status(405).json({ error: 'Method not allowed' })
+}
+
+function deepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true
+  if (a == null || b == null) return a == null && b == null
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) return false
+    for (let i = 0; i < a.length; i++) if (!deepEqual(a[i], b[i])) return false
+    return true
+  }
+  if (typeof a === 'object' && typeof b === 'object') {
+    const ak = Object.keys(a as object)
+    const bk = Object.keys(b as object)
+    if (ak.length !== bk.length) return false
+    for (const k of ak) {
+      if (!deepEqual((a as Record<string, unknown>)[k], (b as Record<string, unknown>)[k])) return false
+    }
+    return true
+  }
+  return false
 }

--- a/api/v1/service-locations/[id].ts
+++ b/api/v1/service-locations/[id].ts
@@ -2,13 +2,16 @@ import type { VercelRequest, VercelResponse } from '@vercel/node'
 import { createAdminClient } from '../../_lib/supabase.js'
 import { authenticateRequest } from '../../_lib/auth.js'
 import { fireWebhook } from '../../_lib/webhooks.js'
-import { recordEdits, markCrewStrategyStale } from '../../_lib/property-audit.js'
+import { recordEdits } from '../../_lib/property-audit.js'
 import {
   SERVICE_LOCATION_FIELDS,
   isEditableServiceLocationField,
 } from '../../../src/lib/editable-fields.js'
-
-const SQFT_STALE_THRESHOLD = 0.1 // 10%
+import {
+  determineCascadingEffects,
+  applyCascadingEffects,
+  type FieldChange,
+} from '../../_lib/analysis/edit-cascade.js'
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method === 'OPTIONS') return res.status(200).end()
@@ -43,10 +46,15 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
   if (req.method === 'PATCH') {
     const body = (req.body ?? {}) as Record<string, unknown>
+    const editReason =
+      typeof body.edit_reason === 'string' && body.edit_reason.trim().length > 0
+        ? body.edit_reason.trim()
+        : null
 
     const updates: Record<string, unknown> = {}
     const rejected: string[] = []
     for (const [k, v] of Object.entries(body)) {
+      if (k === 'edit_reason') continue
       if (isEditableServiceLocationField(k)) updates[k] = v
       else rejected.push(k)
     }
@@ -78,6 +86,15 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
     const cur = current as any
     const upd = updated as any
+
+    // Phase 4b — centralized cascade: figure out which downstream modules
+    // should flip stale and whether to kick synthesis. Computed from the
+    // diff so we can record the same effects payload on each audit row.
+    const fieldChanges: FieldChange[] = Object.keys(updates)
+      .filter((k) => !deepEqual(cur[k], upd[k]))
+      .map((k) => ({ field: k, old: cur[k], new: upd[k] }))
+    const effects = determineCascadingEffects('service_location', fieldChanges)
+
     const changed = await recordEdits(
       db,
       {
@@ -89,10 +106,38 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       cur,
       upd,
       Object.keys(updates),
-      { changedBy: ctx.email ?? ctx.userId ?? null }
+      {
+        changedBy: ctx.email ?? ctx.userId ?? null,
+        reason: editReason,
+        cascadingEffects: fieldChanges.length > 0 ? effects : null,
+      }
     )
 
-    // Side effect 1: status change webhook (existing behavior)
+    let cascadeApplied: { staled: string[]; synthesis_triggered: boolean } = {
+      staled: [],
+      synthesis_triggered: false,
+    }
+    if (cur.account_id && cur.client_id && effects.analyses_to_stale.length > 0) {
+      cascadeApplied = await applyCascadingEffects(db, effects, {
+        account_id: cur.account_id,
+        client_id: cur.client_id,
+        property_id: cur.property_id,
+      })
+    }
+
+    if (effects.comparables_invalidate && cur.property_id) {
+      // Phase 4b — clear the property's comparables cache so the next view
+      // recomputes against the new offering.
+      await db
+        .from('property_comparables')
+        .delete()
+        .eq('property_id', cur.property_id)
+        .then(null, (err: { message: string }) =>
+          console.error('[edit-cascade] comparables clear failed:', err.message)
+        )
+    }
+
+    // Existing webhook (preserved from prior implementation).
     if (changed.includes('status')) {
       await fireWebhook('service_location.status_changed', {
         service_location_id: slId,
@@ -101,30 +146,40 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       })
     }
 
-    // Side effect 2: serviceable_sqft change >10% → mark Crew Strategy
-    // stale so the dashboard prompts a re-run. Skip if there's no prior
-    // sqft to compare against (first-time set is fine).
-    let crewStrategyMarkedStale = false
-    if (changed.includes('serviceable_sqft') && cur.account_id && cur.client_id) {
-      const oldSqft = Number(cur.serviceable_sqft) || 0
-      const newSqft = Number(upd.serviceable_sqft) || 0
-      if (oldSqft > 0) {
-        const delta = Math.abs(newSqft - oldSqft) / oldSqft
-        if (delta >= SQFT_STALE_THRESHOLD) {
-          await markCrewStrategyStale(db, cur.account_id, cur.client_id)
-          crewStrategyMarkedStale = true
-        }
-      }
-    }
-
     const aliasedSl = { ...upd, service_location_id: upd.id }
     return res.status(200).json({
       service_location: aliasedSl,
       changed_fields: changed,
       rejected_fields: rejected,
-      crew_strategy_marked_stale: crewStrategyMarkedStale,
+      cascading_effects: {
+        analyses_marked_stale: cascadeApplied.staled,
+        synthesis_refresh_triggered: cascadeApplied.synthesis_triggered,
+        comparables_invalidated: effects.comparables_invalidate,
+        reasons: effects.reasons,
+      },
+      edits_recorded: changed.length,
     })
   }
 
   return res.status(405).json({ error: 'Method not allowed' })
+}
+
+function deepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true
+  if (a == null || b == null) return a == null && b == null
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) return false
+    for (let i = 0; i < a.length; i++) if (!deepEqual(a[i], b[i])) return false
+    return true
+  }
+  if (typeof a === 'object' && typeof b === 'object') {
+    const ak = Object.keys(a as object)
+    const bk = Object.keys(b as object)
+    if (ak.length !== bk.length) return false
+    for (const k of ak) {
+      if (!deepEqual((a as Record<string, unknown>)[k], (b as Record<string, unknown>)[k])) return false
+    }
+    return true
+  }
+  return false
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,8 @@ import NewAccountPage from './pages/accounts/NewAccount'
 import AccountDetailPage from './pages/accounts/AccountDetail'
 import AccountAnalysisPage from './pages/accounts/AccountAnalysis'
 import ConstraintTemplatesPage from './pages/accounts/ConstraintTemplates'
+import AuditLogPage from './pages/accounts/AuditLog'
+import PropertiesAdminPage from './pages/accounts/PropertiesAdmin'
 import NewAccountClientPage from './pages/accounts/NewAccountClient'
 import ClientsListPage from './pages/clients/ClientsList'
 import NewClientPage from './pages/clients/NewClient'
@@ -119,6 +121,14 @@ export default function App() {
           <Route
             path="/accounts/:accountId/clients/:clientId/admin/constraint-templates"
             element={<AuthGuard><ConstraintTemplatesPage /></AuthGuard>}
+          />
+          <Route
+            path="/accounts/:accountId/clients/:clientId/admin/audit-log"
+            element={<AuthGuard><AuditLogPage /></AuthGuard>}
+          />
+          <Route
+            path="/accounts/:accountId/clients/:clientId/admin/properties"
+            element={<AuthGuard><PropertiesAdminPage /></AuthGuard>}
           />
           <Route path="/accounts/:id/clients/new" element={<AuthGuard><NewAccountClientPage /></AuthGuard>} />
 

--- a/src/components/property/CascadeBanner.tsx
+++ b/src/components/property/CascadeBanner.tsx
@@ -1,0 +1,93 @@
+// Phase 4b — banner shown above PropertyDetail after an edit triggers
+// downstream cascading effects (modules marked stale, synthesis kicked).
+//
+// Auto-dismisses after 12s, can be closed manually. Click "Re-run modules"
+// jumps to the dashboard analysis page so the user can immediately re-run
+// the staled modules.
+import { useEffect } from 'react'
+import { Link } from 'react-router-dom'
+import { AlertTriangle, X } from 'lucide-react'
+
+const MODULE_LABELS: Record<string, string> = {
+  crew_strategy: 'Crew Strategy',
+  workforce_sizing: 'Workforce Sizing',
+  bid_pricing_structure: 'Bid Pricing',
+  branch_optimization: 'Branch Optimization',
+  drive_time_logistics: 'Drive Time & Logistics',
+  seasonality_capacity: 'Seasonality & Capacity',
+  geographic_distribution: 'Geographic Distribution',
+}
+
+export interface CascadeInfo {
+  analyses_marked_stale: string[]
+  synthesis_refresh_triggered: boolean
+  comparables_invalidated: boolean
+  reasons?: Array<{ field: string; modules: string[]; explanation: string }>
+}
+
+interface Props {
+  cascade: CascadeInfo | null
+  accountId: string
+  clientId: string
+  onDismiss: () => void
+}
+
+export default function CascadeBanner({ cascade, accountId, clientId, onDismiss }: Props) {
+  useEffect(() => {
+    if (!cascade) return
+    const t = setTimeout(onDismiss, 12000)
+    return () => clearTimeout(t)
+  }, [cascade, onDismiss])
+
+  if (!cascade) return null
+  const { analyses_marked_stale, synthesis_refresh_triggered, comparables_invalidated } = cascade
+  if (
+    analyses_marked_stale.length === 0 &&
+    !synthesis_refresh_triggered &&
+    !comparables_invalidated
+  ) {
+    return null
+  }
+
+  const moduleNames = analyses_marked_stale
+    .map((m) => MODULE_LABELS[m] ?? m)
+    .join(', ')
+
+  return (
+    <div
+      role="status"
+      className="flex items-start gap-3 rounded-md border border-warning/40 bg-warning/5 px-4 py-3 text-sm"
+    >
+      <AlertTriangle className="h-4 w-4 text-warning shrink-0 mt-0.5" />
+      <div className="flex-1 min-w-0">
+        <p className="text-fg">
+          {moduleNames ? (
+            <>
+              <span className="font-medium">{moduleNames}</span> marked stale.
+            </>
+          ) : (
+            'Edit propagated to dependent state.'
+          )}
+          {comparables_invalidated && ' Comparables cache cleared.'}
+          {synthesis_refresh_triggered && ' Synthesis re-running in background.'}
+        </p>
+        {analyses_marked_stale.length > 0 && (
+          <Link
+            to={`/accounts/${accountId}/clients/${clientId}/analysis`}
+            className="text-xs text-accent hover:underline mt-1 inline-block"
+          >
+            Re-run modules →
+          </Link>
+        )}
+      </div>
+      <button
+        type="button"
+        onClick={onDismiss}
+        className="text-fg-subtle hover:text-fg transition-colors"
+        aria-label="Dismiss"
+      >
+        <X className="h-3.5 w-3.5" />
+      </button>
+    </div>
+  )
+}

--- a/src/components/property/CustomFieldsEditor.tsx
+++ b/src/components/property/CustomFieldsEditor.tsx
@@ -1,0 +1,111 @@
+// Generic key/value editor for jsonb fields. Used by the SL edit dialog
+// for `custom_fields`. The shape is `Record<string, string | number>` —
+// values are stored as text in the input but kept as their native type
+// when they parse cleanly as numbers, so jsonb numeric queries still work.
+import { useState } from 'react'
+import { Plus, Trash2 } from 'lucide-react'
+import Button from '../ui/Button'
+import { Input } from '../ui/Input'
+
+interface Props {
+  value: Record<string, unknown>
+  onChange: (next: Record<string, unknown>) => void
+}
+
+const KEY_RE = /^[a-z0-9_-]{1,50}$/i
+
+export default function CustomFieldsEditor({ value, onChange }: Props) {
+  const [draftKey, setDraftKey] = useState('')
+  const [draftValue, setDraftValue] = useState('')
+  const [error, setError] = useState<string | null>(null)
+
+  const entries = Object.entries(value ?? {})
+
+  function setEntry(key: string, raw: string) {
+    // Auto-convert numeric strings so jsonb numeric ops keep working.
+    const trimmed = raw.trim()
+    const asNum = Number(trimmed)
+    const next: Record<string, unknown> = { ...value }
+    if (trimmed !== '' && Number.isFinite(asNum) && trimmed === String(asNum)) {
+      next[key] = asNum
+    } else {
+      next[key] = raw
+    }
+    onChange(next)
+  }
+
+  function removeEntry(key: string) {
+    const next = { ...value }
+    delete next[key]
+    onChange(next)
+  }
+
+  function addEntry() {
+    setError(null)
+    const k = draftKey.trim()
+    if (!k) {
+      setError('Key is required.')
+      return
+    }
+    if (!KEY_RE.test(k)) {
+      setError('Key must be 1–50 chars, alphanumeric + dashes/underscores.')
+      return
+    }
+    if (k in (value ?? {})) {
+      setError(`Key "${k}" already exists.`)
+      return
+    }
+    onChange({ ...value, [k]: draftValue })
+    setDraftKey('')
+    setDraftValue('')
+  }
+
+  return (
+    <div className="space-y-2">
+      {entries.length === 0 ? (
+        <p className="text-xs text-fg-subtle italic">No custom fields yet.</p>
+      ) : (
+        <ul className="space-y-1">
+          {entries.map(([k, v]) => (
+            <li key={k} className="grid grid-cols-[1fr_2fr_auto] gap-2 items-center">
+              <span className="font-mono text-xs text-fg truncate" title={k}>
+                {k}
+              </span>
+              <Input
+                value={v == null ? '' : String(v)}
+                onChange={(e) => setEntry(k, e.target.value)}
+              />
+              <button
+                type="button"
+                onClick={() => removeEntry(k)}
+                className="text-fg-subtle hover:text-danger transition-colors"
+                aria-label={`Remove ${k}`}
+              >
+                <Trash2 className="h-3.5 w-3.5" />
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <div className="grid grid-cols-[1fr_2fr_auto] gap-2 items-center">
+        <Input
+          value={draftKey}
+          onChange={(e) => setDraftKey(e.target.value)}
+          placeholder="key"
+          className="font-mono text-xs"
+        />
+        <Input
+          value={draftValue}
+          onChange={(e) => setDraftValue(e.target.value)}
+          placeholder="value"
+          onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); addEntry() } }}
+        />
+        <Button type="button" variant="secondary" size="sm" onClick={addEntry}>
+          <Plus className="h-3.5 w-3.5" />
+        </Button>
+      </div>
+      {error && <p className="text-xs text-danger">{error}</p>}
+    </div>
+  )
+}

--- a/src/components/property/ServiceLocationEditDialog.tsx
+++ b/src/components/property/ServiceLocationEditDialog.tsx
@@ -1,5 +1,6 @@
-// Edit a single service_location row. Surfaces the >10% sqft warning so
-// the user knows their edit will mark Crew Strategy stale.
+// Edit a single service_location row. Phase 4b expands the editable
+// surface from 5 fields to ~12 and surfaces cascading effects (which
+// downstream modules will be marked stale by this save).
 import { useState, useEffect } from 'react'
 import { AlertTriangle } from 'lucide-react'
 import { useAuth } from '../../hooks/useAuth'
@@ -12,16 +13,32 @@ import {
   DialogDescription,
   DialogFooter,
 } from '../ui/Dialog'
-import { Input, FormField } from '../ui/Input'
+import { Input, Textarea, FormField } from '../ui/Input'
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '../ui/Select'
-import { SERVICE_LOCATION_FIELDS } from '../../lib/editable-fields'
+import CustomFieldsEditor from './CustomFieldsEditor'
+import { SERVICE_LOCATION_FIELDS, type FieldSpec } from '../../lib/editable-fields'
 import type { ServiceLocation } from '../../types'
+
+interface ServiceOffering {
+  id: string
+  name: string
+}
 
 interface Props {
   open: boolean
   onClose: () => void
   serviceLocation: ServiceLocation | null
-  onSaved: () => void
+  clientId: string
+  onSaved: (cascade: SaveResult['cascading_effects']) => void
+}
+
+interface SaveResult {
+  cascading_effects: {
+    analyses_marked_stale: string[]
+    synthesis_refresh_triggered: boolean
+    comparables_invalidated: boolean
+    reasons: Array<{ field: string; modules: string[]; explanation: string }>
+  }
 }
 
 const STALE_THRESHOLD = 0.1
@@ -30,23 +47,50 @@ export default function ServiceLocationEditDialog({
   open,
   onClose,
   serviceLocation,
+  clientId,
   onSaved,
 }: Props) {
   const { getToken } = useAuth()
   const [draft, setDraft] = useState<Record<string, unknown>>({})
+  const [reason, setReason] = useState('')
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [offerings, setOfferings] = useState<ServiceOffering[]>([])
 
   useEffect(() => {
     if (open && serviceLocation) {
       const next: Record<string, unknown> = {}
       for (const f of SERVICE_LOCATION_FIELDS) {
-        next[f.key] = (serviceLocation as unknown as Record<string, unknown>)[f.key] ?? ''
+        const v = (serviceLocation as unknown as Record<string, unknown>)[f.key]
+        next[f.key] = v ?? (f.kind === 'custom_fields' ? {} : '')
       }
       setDraft(next)
+      setReason('')
       setError(null)
     }
   }, [open, serviceLocation])
+
+  // Load offerings for the service_offering_id select. /api/v1/service-offerings
+  // is scoped to client_id.
+  useEffect(() => {
+    if (!open) return
+    let cancelled = false
+    async function load() {
+      try {
+        const token = await getToken()
+        const res = await fetch(`/api/v1/service-offerings?client_id=${clientId}`, {
+          headers: { Authorization: `Bearer ${token}` },
+        })
+        if (!res.ok) return
+        const data = (await res.json()) as ServiceOffering[]
+        if (!cancelled) setOfferings(data)
+      } catch {
+        // Non-fatal — the select just shows the current id without label.
+      }
+    }
+    load()
+    return () => { cancelled = true }
+  }, [open, clientId, getToken])
 
   if (!serviceLocation) return null
 
@@ -57,24 +101,37 @@ export default function ServiceLocationEditDialog({
     newSqft > 0 &&
     Math.abs(newSqft - oldSqft) / oldSqft >= STALE_THRESHOLD
 
+  const offeringChanged =
+    draft.service_offering_id != null &&
+    draft.service_offering_id !== '' &&
+    draft.service_offering_id !== (serviceLocation as any).service_offering_id
+
   async function handleSave() {
     setSaving(true)
     setError(null)
     try {
       const token = await getToken()
+      const body: Record<string, unknown> = { ...draft }
+      // Strip empty-string for nullable fields so the API doesn't write ''.
+      for (const f of SERVICE_LOCATION_FIELDS) {
+        if (f.kind !== 'custom_fields' && body[f.key] === '') body[f.key] = null
+      }
+      if (reason.trim()) body.edit_reason = reason.trim()
+
       const res = await fetch(
         `/api/v1/service-locations/${serviceLocation!.service_location_id}`,
         {
           method: 'PATCH',
           headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
-          body: JSON.stringify(draft),
+          body: JSON.stringify(body),
         }
       )
       if (!res.ok) {
-        const body = await res.json().catch(() => ({}))
-        throw new Error(body.error ?? `Save failed (${res.status})`)
+        const errBody = await res.json().catch(() => ({}))
+        throw new Error(errBody.error ?? `Save failed (${res.status})`)
       }
-      onSaved()
+      const json = (await res.json()) as SaveResult
+      onSaved(json.cascading_effects)
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err))
     } finally {
@@ -82,62 +139,108 @@ export default function ServiceLocationEditDialog({
     }
   }
 
+  function renderField(f: FieldSpec) {
+    const id = `sl-${f.key}`
+    const value = draft[f.key]
+
+    if (f.kind === 'select') {
+      const options =
+        f.key === 'service_offering_id'
+          ? offerings.map((o) => ({ value: o.id, label: o.name }))
+          : f.options ?? []
+      return (
+        <Select
+          value={String(value ?? '')}
+          onValueChange={(v) => setDraft({ ...draft, [f.key]: v })}
+        >
+          <SelectTrigger id={id}><SelectValue placeholder="(none)" /></SelectTrigger>
+          <SelectContent>
+            {options.map((o) => (
+              <SelectItem key={o.value} value={o.value}>{o.label}</SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      )
+    }
+    if (f.kind === 'number') {
+      return (
+        <Input
+          id={id}
+          type="number"
+          step="any"
+          value={value == null ? '' : String(value)}
+          onChange={(e) =>
+            setDraft({
+              ...draft,
+              [f.key]: e.target.value === '' ? null : Number(e.target.value),
+            })
+          }
+        />
+      )
+    }
+    if (f.kind === 'textarea') {
+      return (
+        <Textarea
+          id={id}
+          value={(value as string | null | undefined) ?? ''}
+          onChange={(e) => setDraft({ ...draft, [f.key]: e.target.value })}
+          rows={3}
+        />
+      )
+    }
+    if (f.kind === 'custom_fields') {
+      return (
+        <CustomFieldsEditor
+          value={(value as Record<string, unknown> | undefined) ?? {}}
+          onChange={(next) => setDraft({ ...draft, [f.key]: next })}
+        />
+      )
+    }
+    return (
+      <Input
+        id={id}
+        value={(value as string | null | undefined) ?? ''}
+        onChange={(e) => setDraft({ ...draft, [f.key]: e.target.value })}
+      />
+    )
+  }
+
   return (
     <Dialog open={open} onOpenChange={(o) => { if (!o) onClose() }}>
-      <DialogContent className="max-w-lg">
+      <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>Edit service location</DialogTitle>
-          <DialogDescription>{serviceLocation.display_name ?? serviceLocation.service_location_id}</DialogDescription>
+          <DialogDescription>
+            {serviceLocation.display_name ?? serviceLocation.service_location_id}
+          </DialogDescription>
         </DialogHeader>
 
         <div className="space-y-3">
           {SERVICE_LOCATION_FIELDS.map((f) => (
             <FormField key={f.key} label={f.label} helper={f.helper} htmlFor={`sl-${f.key}`}>
-              {f.kind === 'select' ? (
-                <Select
-                  value={String(draft[f.key] ?? '')}
-                  onValueChange={(v) => setDraft({ ...draft, [f.key]: v })}
-                >
-                  <SelectTrigger id={`sl-${f.key}`}><SelectValue /></SelectTrigger>
-                  <SelectContent>
-                    {f.options?.map((o) => (
-                      <SelectItem key={o.value} value={o.value}>{o.label}</SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              ) : f.kind === 'number' ? (
-                <Input
-                  id={`sl-${f.key}`}
-                  type="number"
-                  value={draft[f.key] == null ? '' : String(draft[f.key])}
-                  onChange={(e) =>
-                    setDraft({
-                      ...draft,
-                      [f.key]: e.target.value === '' ? null : Number(e.target.value),
-                    })
-                  }
-                />
-              ) : (
-                <Input
-                  id={`sl-${f.key}`}
-                  value={(draft[f.key] as string | null | undefined) ?? ''}
-                  onChange={(e) => setDraft({ ...draft, [f.key]: e.target.value })}
-                />
-              )}
+              {renderField(f)}
             </FormField>
           ))}
 
+          <FormField label="Reason (optional)" helper="Captured in the audit log next to this edit.">
+            <Input
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+              placeholder="e.g. Sqft corrected after walkthrough"
+            />
+          </FormField>
+
           {sqftWillStale && (
-            <div className="flex items-start gap-2 rounded-md border border-warning/40 bg-warning/5 px-3 py-2 text-xs text-fg">
-              <AlertTriangle className="h-4 w-4 text-warning shrink-0 mt-0.5" />
-              <span>
-                Sqft change of{' '}
-                <span className="font-tabular">
-                  {Math.round((Math.abs(newSqft - oldSqft) / oldSqft) * 100)}%
-                </span>{' '}
-                will mark Crew Strategy as stale.
-              </span>
-            </div>
+            <CascadeWarning
+              text={
+                `Sqft change of ` +
+                `${Math.round((Math.abs(newSqft - oldSqft) / oldSqft) * 100)}%` +
+                ` will mark Crew Strategy, Workforce Sizing, and Bid Pricing stale.`
+              }
+            />
+          )}
+          {offeringChanged && (
+            <CascadeWarning text="Offering change reclassifies the work — all tier-2 modules will be marked stale and the comparables cache will be cleared." />
           )}
 
           {error && <p className="text-xs text-danger">{error}</p>}
@@ -149,5 +252,14 @@ export default function ServiceLocationEditDialog({
         </DialogFooter>
       </DialogContent>
     </Dialog>
+  )
+}
+
+function CascadeWarning({ text }: { text: string }) {
+  return (
+    <div className="flex items-start gap-2 rounded-md border border-warning/40 bg-warning/5 px-3 py-2 text-xs text-fg">
+      <AlertTriangle className="h-4 w-4 text-warning shrink-0 mt-0.5" />
+      <span>{text}</span>
+    </div>
   )
 }

--- a/src/lib/editable-fields.ts
+++ b/src/lib/editable-fields.ts
@@ -12,6 +12,7 @@ export type FieldKind =
   | 'number'
   | 'select'
   | 'tags' // text[] rendered as a chip list
+  | 'custom_fields' // arbitrary key/value jsonb editor
 
 export interface FieldSpec {
   key: string
@@ -52,6 +53,11 @@ export const PROPERTY_FIELDS: FieldSpec[] = [
 ]
 
 // service_location-level editable fields.
+//
+// Phase 4b expanded from 5 → 12 fields. service_schedule (jsonb) stays
+// read-only — its rich editor is deferred to Phase 4f when the scheduler
+// UI lands. monthly_direct_cost / crew_size / site_contact_* / access_notes
+// would need new schema columns; deferred.
 export const SERVICE_LOCATION_FIELDS: FieldSpec[] = [
   { key: 'display_name',    label: 'Display name',     kind: 'text' },
   { key: 'location_code',   label: 'Location code',    kind: 'text' },
@@ -61,7 +67,55 @@ export const SERVICE_LOCATION_FIELDS: FieldSpec[] = [
     label: 'Serviceable sqft',
     kind: 'number',
     group: 'sqft',
-    helper: 'Changes >10% will mark Crew Strategy stale',
+    helper: 'Changes ≥10% mark Crew Strategy, Workforce Sizing, and Bid Pricing stale.',
+  },
+  {
+    key: 'service_frequency',
+    label: 'Service frequency',
+    kind: 'text',
+    helper: 'Free-form (e.g. "monthly", "quarterly", "Tu/Th").',
+  },
+  {
+    key: 'visits_per_year_override',
+    label: 'Visits per year (override)',
+    kind: 'number',
+    helper: 'Stales Crew Strategy + Bid Pricing.',
+  },
+  {
+    key: 'hours_per_visit_override',
+    label: 'Hours per visit (override)',
+    kind: 'number',
+    helper: 'Stales Crew Strategy + Bid Pricing.',
+  },
+  {
+    key: 'crew_size_override',
+    label: 'Crew size (override)',
+    kind: 'number',
+    helper: 'Stales Crew Strategy.',
+  },
+  {
+    key: 'monthly_contract_value',
+    label: 'Monthly contract value',
+    kind: 'number',
+    helper: 'Stales Bid Pricing.',
+  },
+  {
+    key: 'frequency_notes',
+    label: 'Frequency notes',
+    kind: 'textarea',
+  },
+  {
+    key: 'custom_fields',
+    label: 'Custom fields',
+    kind: 'custom_fields',
+    helper: 'Arbitrary key/value pairs stored on this service location.',
+  },
+  {
+    key: 'service_offering_id',
+    label: 'Service offering',
+    kind: 'select',
+    helper: 'Changing the offering reclassifies the work — all tier-2 modules will re-run.',
+    options: [], // populated dynamically by the dialog from /api/v1/service-offerings
   },
   {
     key: 'status',

--- a/src/pages/PropertyDetail.tsx
+++ b/src/pages/PropertyDetail.tsx
@@ -23,6 +23,7 @@ import ConstraintsPanel from '../components/property/ConstraintsPanel'
 import EditableField from '../components/property/EditableField'
 import AddressEditDialog from '../components/property/AddressEditDialog'
 import ServiceLocationEditDialog from '../components/property/ServiceLocationEditDialog'
+import CascadeBanner, { type CascadeInfo } from '../components/property/CascadeBanner'
 import EditHistoryPanel from '../components/property/EditHistoryPanel'
 import { PROPERTY_FIELDS } from '../lib/editable-fields'
 import { CATEGORY_COLORS, STATUS_LABELS } from '../lib/constants'
@@ -34,6 +35,8 @@ const PROPERTY_FIELD_BY_KEY = Object.fromEntries(PROPERTY_FIELDS.map((f) => [f.k
 // Extends Property with DB fields that aren't in the base type + joined tables
 interface PropertyDetail {
   property_id: string
+  account_id?: string | null
+  client_id?: string | null
   address_line1: string
   address_line2?: string | null
   city: string
@@ -95,6 +98,7 @@ export default function PropertyDetailPage() {
   const [reassessing, setReassessing] = useState(false)
   const [addressDialogOpen, setAddressDialogOpen] = useState(false)
   const [editingSL, setEditingSL] = useState<ServiceLocation | null>(null)
+  const [cascade, setCascade] = useState<CascadeInfo | null>(null)
 
   // Phase E — risk score tweens 300ms on each re-assessment so the user
   // sees the number move rather than snap.
@@ -298,6 +302,15 @@ export default function PropertyDetailPage() {
       ]}
     >
       <div className="mx-auto max-w-6xl px-6 py-10 space-y-10">
+        {cascade && property.account_id && property.client_id && (
+          <CascadeBanner
+            cascade={cascade}
+            accountId={property.account_id}
+            clientId={property.client_id}
+            onDismiss={() => setCascade(null)}
+          />
+        )}
+
         {/* Hero */}
         <header className="space-y-3">
           <button
@@ -833,8 +846,10 @@ export default function PropertyDetailPage() {
         open={editingSL !== null}
         onClose={() => setEditingSL(null)}
         serviceLocation={editingSL}
-        onSaved={() => {
+        clientId={property.client_id ?? ''}
+        onSaved={(cascadeInfo) => {
           setEditingSL(null)
+          setCascade(cascadeInfo)
           reload()
         }}
       />

--- a/src/pages/accounts/AccountAnalysis.tsx
+++ b/src/pages/accounts/AccountAnalysis.tsx
@@ -3,6 +3,7 @@ import { useParams, Link } from 'react-router-dom'
 import {
   Building2,
   FileText,
+  History,
   LayoutDashboard,
   ListChecks,
   Map as MapIcon,
@@ -1140,10 +1141,22 @@ function AnalysisSidebar({
 
       <SidebarSection title="Settings">
         <SidebarItem
+          icon={Building2}
+          to={`/accounts/${accountId}/clients/${clientId}/admin/properties`}
+        >
+          Properties admin
+        </SidebarItem>
+        <SidebarItem
           icon={ListChecks}
           to={`/accounts/${accountId}/clients/${clientId}/admin/constraint-templates`}
         >
           Constraint templates
+        </SidebarItem>
+        <SidebarItem
+          icon={History}
+          to={`/accounts/${accountId}/clients/${clientId}/admin/audit-log`}
+        >
+          Edit history
         </SidebarItem>
       </SidebarSection>
     </Sidebar>

--- a/src/pages/accounts/AuditLog.tsx
+++ b/src/pages/accounts/AuditLog.tsx
@@ -1,0 +1,294 @@
+// Phase 4b — account-level audit log page.
+// Route: /accounts/:accountId/clients/:clientId/admin/audit-log
+//
+// Filters: entity type, field name, edited_by, date range, has_cascading_effects.
+// Pagination 50/page.
+import { useState, useEffect, useCallback } from 'react'
+import { useParams, Link } from 'react-router-dom'
+import { Filter as FilterIcon } from 'lucide-react'
+import { useAuth } from '../../hooks/useAuth'
+import AppShell from '../../components/layout/AppShell'
+import Button from '../../components/ui/Button'
+import { Badge } from '../../components/ui/Badge'
+import { Card, CardTitle, CardDescription } from '../../components/ui/Card'
+import { Input } from '../../components/ui/Input'
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '../../components/ui/Select'
+import { EmptyState } from '../../components/ui/EmptyState'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '../../components/ui/Table'
+import { PROPERTY_FIELDS, SERVICE_LOCATION_FIELDS } from '../../lib/editable-fields'
+
+const FIELD_LABELS: Record<string, string> = Object.fromEntries(
+  [...PROPERTY_FIELDS, ...SERVICE_LOCATION_FIELDS].map((f) => [f.key, f.label])
+)
+
+interface AuditEdit {
+  id: string
+  entity_type: 'property' | 'service_location'
+  entity_id: string
+  property_id: string
+  service_location_id: string | null
+  field_name: string
+  old_value: unknown
+  new_value: unknown
+  edited_by: string | null
+  edited_at: string
+  reason: string | null
+  cascading_effects: { analyses_to_stale?: string[]; reasons?: any[] } | null
+}
+
+interface AuditResponse {
+  edits: AuditEdit[]
+  total_count: number
+  page: number
+  limit: number
+  has_more: boolean
+}
+
+const PAGE_SIZE = 50
+
+export default function AuditLogPage() {
+  const { accountId, clientId } = useParams<{ accountId: string; clientId: string }>()
+  const { getToken } = useAuth()
+
+  const [data, setData] = useState<AuditResponse | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  // Filters
+  const [entityType, setEntityType] = useState<'all' | 'property' | 'service_location'>('all')
+  const [editedBy, setEditedBy] = useState('')
+  const [hasCascade, setHasCascade] = useState<'any' | 'true' | 'false'>('any')
+  const [page, setPage] = useState(1)
+
+  const load = useCallback(async () => {
+    if (!accountId || !clientId) return
+    setLoading(true)
+    setError(null)
+    try {
+      const token = await getToken()
+      const params = new URLSearchParams()
+      params.set('limit', String(PAGE_SIZE))
+      params.set('page', String(page))
+      if (entityType !== 'all') params.set('entity_type', entityType)
+      if (editedBy.trim()) params.set('edited_by', editedBy.trim())
+      if (hasCascade !== 'any') params.set('has_cascading_effects', hasCascade)
+
+      const res = await fetch(
+        `/api/accounts/${accountId}/clients/${clientId}/edit-history?${params}`,
+        { headers: { Authorization: `Bearer ${token}` } }
+      )
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      setData(await res.json())
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setLoading(false)
+    }
+  }, [accountId, clientId, page, entityType, editedBy, hasCascade, getToken])
+
+  useEffect(() => { load() }, [load])
+
+  function applyFilters() {
+    setPage(1)
+    load()
+  }
+
+  function resetFilters() {
+    setEntityType('all')
+    setEditedBy('')
+    setHasCascade('any')
+    setPage(1)
+  }
+
+  return (
+    <AppShell
+      breadcrumb={[
+        { label: 'Accounts', to: '/accounts' },
+        { label: 'Audit log' },
+      ]}
+    >
+      <div className="mx-auto max-w-6xl px-6 py-10 space-y-6">
+        <header className="space-y-1">
+          <h1 className="text-2xl font-semibold tracking-tight text-fg">Edit history</h1>
+          <p className="text-sm text-fg-muted">
+            All property and service location edits across this client.
+          </p>
+        </header>
+
+        {/* Filter bar */}
+        <Card>
+          <div className="flex items-center gap-2 mb-3 text-xs text-fg-muted">
+            <FilterIcon className="h-3.5 w-3.5" />
+            <span>Filters</span>
+          </div>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
+            <FilterField label="Entity type">
+              <Select value={entityType} onValueChange={(v) => setEntityType(v as any)}>
+                <SelectTrigger><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">All</SelectItem>
+                  <SelectItem value="property">Property</SelectItem>
+                  <SelectItem value="service_location">Service location</SelectItem>
+                </SelectContent>
+              </Select>
+            </FilterField>
+            <FilterField label="Edited by (email contains)">
+              <Input
+                value={editedBy}
+                onChange={(e) => setEditedBy(e.target.value)}
+                placeholder="e.g. jon@"
+              />
+            </FilterField>
+            <FilterField label="Cascading effects">
+              <Select value={hasCascade} onValueChange={(v) => setHasCascade(v as any)}>
+                <SelectTrigger><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="any">Any</SelectItem>
+                  <SelectItem value="true">Yes — staled modules</SelectItem>
+                  <SelectItem value="false">No — no cascade</SelectItem>
+                </SelectContent>
+              </Select>
+            </FilterField>
+            <div className="flex items-end gap-2">
+              <Button onClick={applyFilters} loading={loading}>Apply</Button>
+              <Button variant="ghost" onClick={resetFilters}>Reset</Button>
+            </div>
+          </div>
+        </Card>
+
+        {error && <p className="text-sm text-danger">Error: {error}</p>}
+
+        {/* Results table */}
+        {loading && !data ? (
+          <p className="text-sm text-fg-muted">Loading…</p>
+        ) : !data || data.edits.length === 0 ? (
+          <EmptyState
+            title="No edits yet"
+            description="When users edit properties or service locations, the changes appear here."
+          />
+        ) : (
+          <Card padding="none">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>When</TableHead>
+                  <TableHead>Entity</TableHead>
+                  <TableHead>Field</TableHead>
+                  <TableHead>Change</TableHead>
+                  <TableHead>By</TableHead>
+                  <TableHead>Cascade</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {data.edits.map((e) => (
+                  <TableRow key={e.id}>
+                    <TableCell className="text-fg-muted whitespace-nowrap font-tabular text-xs">
+                      {new Date(e.edited_at).toLocaleString()}
+                    </TableCell>
+                    <TableCell>
+                      <Link
+                        to={`/properties/${e.property_id}`}
+                        className="text-accent hover:underline text-xs"
+                      >
+                        {e.entity_type === 'service_location' ? 'SL' : 'Property'}
+                      </Link>
+                    </TableCell>
+                    <TableCell className="text-xs">
+                      {FIELD_LABELS[e.field_name] ?? e.field_name}
+                    </TableCell>
+                    <TableCell>
+                      <DiffChips old={e.old_value} next={e.new_value} />
+                    </TableCell>
+                    <TableCell className="text-xs text-fg-muted">{e.edited_by ?? '—'}</TableCell>
+                    <TableCell>
+                      {e.cascading_effects?.analyses_to_stale &&
+                      e.cascading_effects.analyses_to_stale.length > 0 ? (
+                        <Badge variant="warning">
+                          {e.cascading_effects.analyses_to_stale.length}
+                        </Badge>
+                      ) : (
+                        <span className="text-xs text-fg-subtle">—</span>
+                      )}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </Card>
+        )}
+
+        {/* Pagination */}
+        {data && data.total_count > 0 && (
+          <div className="flex items-center justify-between text-xs text-fg-muted">
+            <span>
+              Showing{' '}
+              <span className="font-tabular">
+                {(page - 1) * PAGE_SIZE + 1}–
+                {Math.min(page * PAGE_SIZE, data.total_count)}
+              </span>{' '}
+              of <span className="font-tabular">{data.total_count}</span>
+            </span>
+            <div className="flex items-center gap-2">
+              <Button
+                size="sm"
+                variant="ghost"
+                disabled={page === 1 || loading}
+                onClick={() => setPage((p) => p - 1)}
+              >
+                ← Prev
+              </Button>
+              <Button
+                size="sm"
+                variant="ghost"
+                disabled={!data.has_more || loading}
+                onClick={() => setPage((p) => p + 1)}
+              >
+                Next →
+              </Button>
+            </div>
+          </div>
+        )}
+      </div>
+    </AppShell>
+  )
+}
+
+function FilterField({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <p className="text-[10px] font-semibold uppercase tracking-wider text-fg-subtle mb-1">
+        {label}
+      </p>
+      {children}
+    </div>
+  )
+}
+
+function DiffChips({ old: oldV, next }: { old: unknown; next: unknown }) {
+  return (
+    <div className="flex items-center gap-1 text-xs flex-wrap">
+      <code className="rounded bg-surface-elevated text-fg-muted line-through decoration-fg-subtle px-1 py-0.5 max-w-[150px] truncate">
+        {format(oldV)}
+      </code>
+      <span className="text-fg-subtle">→</span>
+      <code className="rounded bg-accent/10 text-fg px-1 py-0.5 max-w-[150px] truncate">
+        {format(next)}
+      </code>
+    </div>
+  )
+}
+
+function format(v: unknown): string {
+  if (v == null) return '—'
+  if (Array.isArray(v)) return v.length === 0 ? '[]' : `[${v.join(', ')}]`
+  if (typeof v === 'object') return JSON.stringify(v)
+  if (typeof v === 'number') return v.toLocaleString()
+  return String(v)
+}

--- a/src/pages/accounts/PropertiesAdmin.tsx
+++ b/src/pages/accounts/PropertiesAdmin.tsx
@@ -1,0 +1,334 @@
+// Phase 4b — properties admin list with bulk-edit.
+// Route: /accounts/:accountId/clients/:clientId/admin/properties
+//
+// Lists every property under (account, client) with checkbox per row. The
+// action bar appears once 1+ rows are selected and offers add-tag / remove-tag
+// / set-notes operations that POST through /api/properties/bulk-edit.
+import { useState, useEffect, useCallback, useMemo } from 'react'
+import { useParams, Link } from 'react-router-dom'
+import { Search, Tag, Trash2, FileText } from 'lucide-react'
+import { useAuth } from '../../hooks/useAuth'
+import AppShell from '../../components/layout/AppShell'
+import Button from '../../components/ui/Button'
+import { Badge } from '../../components/ui/Badge'
+import { Card, CardTitle } from '../../components/ui/Card'
+import { Input, Textarea, FormField } from '../../components/ui/Input'
+import { EmptyState } from '../../components/ui/EmptyState'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '../../components/ui/Dialog'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '../../components/ui/Table'
+
+interface PropertyRow {
+  id: string
+  address_line1: string
+  city: string
+  state: string
+  postal_code: string
+  internal_tags: string[] | null
+  notes: string | null
+}
+
+type BulkAction = 'add_tag' | 'remove_tag' | 'set_notes' | null
+
+export default function PropertiesAdminPage() {
+  const { accountId, clientId } = useParams<{ accountId: string; clientId: string }>()
+  const { getToken } = useAuth()
+
+  const [rows, setRows] = useState<PropertyRow[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [filter, setFilter] = useState('')
+  const [selected, setSelected] = useState<Set<string>>(new Set())
+  const [action, setAction] = useState<BulkAction>(null)
+  const [actionValue, setActionValue] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [resultToast, setResultToast] = useState<string | null>(null)
+
+  const load = useCallback(async () => {
+    if (!accountId || !clientId) return
+    setLoading(true)
+    setError(null)
+    try {
+      const token = await getToken()
+      const res = await fetch(
+        `/api/v1/properties?client_id=${clientId}&limit=500`,
+        { headers: { Authorization: `Bearer ${token}` } }
+      )
+      if (!res.ok) throw new Error(`Load failed (${res.status})`)
+      const data = await res.json()
+      const list: PropertyRow[] = (data.properties ?? []).map((p: any) => ({
+        id: p.id ?? p.property_id,
+        address_line1: p.address_line1,
+        city: p.city,
+        state: p.state,
+        postal_code: p.postal_code,
+        internal_tags: p.internal_tags ?? [],
+        notes: p.notes ?? null,
+      }))
+      setRows(list)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setLoading(false)
+    }
+  }, [accountId, clientId, getToken])
+
+  useEffect(() => { load() }, [load])
+
+  const filtered = useMemo(() => {
+    const q = filter.trim().toLowerCase()
+    if (!q) return rows
+    return rows.filter(
+      (r) =>
+        r.address_line1.toLowerCase().includes(q) ||
+        (r.city ?? '').toLowerCase().includes(q) ||
+        (r.state ?? '').toLowerCase().includes(q) ||
+        (r.internal_tags ?? []).some((t) => t.toLowerCase().includes(q))
+    )
+  }, [rows, filter])
+
+  const allFilteredSelected =
+    filtered.length > 0 && filtered.every((r) => selected.has(r.id))
+
+  function toggleAll(checked: boolean) {
+    if (checked) setSelected(new Set(filtered.map((r) => r.id)))
+    else setSelected(new Set())
+  }
+  function toggleOne(id: string) {
+    const next = new Set(selected)
+    if (next.has(id)) next.delete(id)
+    else next.add(id)
+    setSelected(next)
+  }
+
+  function openAction(a: BulkAction) {
+    setAction(a)
+    setActionValue('')
+    setResultToast(null)
+  }
+
+  async function commitAction() {
+    if (!action || selected.size === 0) return
+    setSubmitting(true)
+    try {
+      const token = await getToken()
+      const res = await fetch('/api/properties/bulk-edit', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        body: JSON.stringify({
+          property_ids: Array.from(selected),
+          action,
+          value: actionValue,
+        }),
+      })
+      const body = await res.json()
+      if (!res.ok) throw new Error(body.error ?? `Bulk edit failed (${res.status})`)
+      setResultToast(
+        `${body.updated} updated · ${body.unchanged} unchanged · ${body.not_found} missing`
+      )
+      setAction(null)
+      setSelected(new Set())
+      await load()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <AppShell
+      breadcrumb={[
+        { label: 'Accounts', to: '/accounts' },
+        { label: 'Properties admin' },
+      ]}
+    >
+      <div className="mx-auto max-w-6xl px-6 py-10 space-y-6">
+        <header className="flex items-start justify-between gap-6">
+          <div className="space-y-1">
+            <h1 className="text-2xl font-semibold tracking-tight text-fg">Properties</h1>
+            <p className="text-sm text-fg-muted">
+              Bulk-edit tags and notes across this client's properties.
+            </p>
+          </div>
+          <div className="relative w-72">
+            <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-4 w-4 text-fg-subtle" />
+            <Input
+              value={filter}
+              onChange={(e) => setFilter(e.target.value)}
+              placeholder="Filter…"
+              className="pl-8"
+            />
+          </div>
+        </header>
+
+        {/* Action bar */}
+        {selected.size > 0 && (
+          <div className="flex items-center justify-between gap-3 rounded-md border border-accent/40 bg-accent/5 px-4 py-2.5">
+            <p className="text-sm">
+              <span className="font-tabular font-medium">{selected.size}</span> selected
+            </p>
+            <div className="flex items-center gap-2">
+              <Button size="sm" variant="secondary" onClick={() => openAction('add_tag')}>
+                <Tag className="h-3.5 w-3.5" />
+                Add tag
+              </Button>
+              <Button size="sm" variant="secondary" onClick={() => openAction('remove_tag')}>
+                <Trash2 className="h-3.5 w-3.5" />
+                Remove tag
+              </Button>
+              <Button size="sm" variant="secondary" onClick={() => openAction('set_notes')}>
+                <FileText className="h-3.5 w-3.5" />
+                Set notes
+              </Button>
+              <Button size="sm" variant="ghost" onClick={() => setSelected(new Set())}>
+                Clear
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {resultToast && (
+          <div className="rounded-md border border-success/30 bg-success/5 px-3 py-2 text-xs text-fg">
+            {resultToast}
+          </div>
+        )}
+        {error && <p className="text-sm text-danger">{error}</p>}
+
+        {loading ? (
+          <p className="text-sm text-fg-muted">Loading…</p>
+        ) : filtered.length === 0 ? (
+          <EmptyState
+            title="No properties match"
+            description="Try a different filter."
+          />
+        ) : (
+          <Card padding="none">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="w-8">
+                    <input
+                      type="checkbox"
+                      checked={allFilteredSelected}
+                      onChange={(e) => toggleAll(e.target.checked)}
+                      className="rounded border-border accent-accent"
+                      aria-label="Select all filtered"
+                    />
+                  </TableHead>
+                  <TableHead>Address</TableHead>
+                  <TableHead>City / state</TableHead>
+                  <TableHead>Tags</TableHead>
+                  <TableHead>Notes</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {filtered.map((r) => {
+                  const checked = selected.has(r.id)
+                  return (
+                    <TableRow key={r.id}>
+                      <TableCell>
+                        <input
+                          type="checkbox"
+                          checked={checked}
+                          onChange={() => toggleOne(r.id)}
+                          className="rounded border-border accent-accent"
+                          aria-label={`Select ${r.address_line1}`}
+                        />
+                      </TableCell>
+                      <TableCell>
+                        <Link
+                          to={`/properties/${r.id}`}
+                          className="text-fg hover:text-accent text-sm"
+                        >
+                          {r.address_line1}
+                        </Link>
+                      </TableCell>
+                      <TableCell className="text-fg-muted text-xs">
+                        {r.city}, {r.state} <span className="font-tabular">{r.postal_code}</span>
+                      </TableCell>
+                      <TableCell>
+                        {r.internal_tags && r.internal_tags.length > 0 ? (
+                          <div className="flex flex-wrap gap-1">
+                            {r.internal_tags.map((t) => (
+                              <Badge key={t} variant="outline">{t}</Badge>
+                            ))}
+                          </div>
+                        ) : (
+                          <span className="text-fg-subtle text-xs">—</span>
+                        )}
+                      </TableCell>
+                      <TableCell className="text-xs text-fg-muted max-w-xs truncate">
+                        {r.notes ?? <span className="text-fg-subtle">—</span>}
+                      </TableCell>
+                    </TableRow>
+                  )
+                })}
+              </TableBody>
+            </Table>
+          </Card>
+        )}
+      </div>
+
+      <Dialog open={action !== null} onOpenChange={(o) => { if (!o) setAction(null) }}>
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>
+              {action === 'add_tag' && 'Add tag to selected'}
+              {action === 'remove_tag' && 'Remove tag from selected'}
+              {action === 'set_notes' && 'Set notes on selected'}
+            </DialogTitle>
+            <DialogDescription>
+              Will apply to {selected.size} propert{selected.size === 1 ? 'y' : 'ies'}.
+              Properties already in the desired state are skipped.
+            </DialogDescription>
+          </DialogHeader>
+
+          {action === 'set_notes' ? (
+            <FormField label="Notes">
+              <Textarea
+                value={actionValue}
+                onChange={(e) => setActionValue(e.target.value)}
+                rows={4}
+                placeholder="Leave blank to clear notes"
+              />
+            </FormField>
+          ) : (
+            <FormField label="Tag" helper="Alphanumeric + dashes, max 50 chars.">
+              <Input
+                value={actionValue}
+                onChange={(e) => setActionValue(e.target.value)}
+                placeholder="e.g. high-priority"
+                autoFocus
+              />
+            </FormField>
+          )}
+
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setAction(null)}>Cancel</Button>
+            <Button
+              onClick={commitAction}
+              loading={submitting}
+              disabled={action !== 'set_notes' && actionValue.trim().length === 0}
+            >
+              Apply
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </AppShell>
+  )
+}

--- a/supabase/migrations/20260430042852_phase4b_audit_extensions.sql
+++ b/supabase/migrations/20260430042852_phase4b_audit_extensions.sql
@@ -1,0 +1,17 @@
+-- Phase 4b: Property editing extensions (additive on top of Phase 4a PR2).
+--
+-- 4a PR2 already shipped property_edit_history with property_id +
+-- service_location_id columns. 4b spec'd entity_type + entity_id but the
+-- existing shape is functionally equivalent (entity_type is derivable
+-- from "service_location_id IS NULL ? 'property' : 'service_location'")
+-- and migrating it would invalidate existing audit rows.
+--
+-- This migration adds two columns the spec wants but PR2 didn't ship:
+--   reason: free-text rationale supplied by the editor
+--   cascading_effects: jsonb summary of which analyses got marked stale,
+--     synthesis triggered, etc. — captured on save so the audit log can
+--     show why a downstream module went stale.
+
+ALTER TABLE public.property_edit_history
+  ADD COLUMN IF NOT EXISTS reason TEXT,
+  ADD COLUMN IF NOT EXISTS cascading_effects JSONB;


### PR DESCRIPTION
## Summary
Builds on Phase 4a PR2 (#91, already merged) — that PR shipped notes, internal_tags, the audit table, inline `EditableField`, `AddressEditDialog`, `ServiceLocationEditDialog`, `EditHistoryPanel`, and a basic sqft → crew_strategy cascade. **Phase 4b expands the surface and makes cascade handling first-class.**

- Centralized `_lib/analysis/edit-cascade.ts` with rule-driven module-staling and effects payloads written into the audit row
- Service-location whitelist expanded from **5 → 12 fields** (visit/hours overrides, crew override, contract value, custom_fields, service_offering_id, etc.)
- `CascadeBanner` on Property Detail names the staled modules and links to the analysis dashboard
- `CustomFieldsEditor` — generic key/value jsonb editor used for SL `custom_fields`
- New admin pages: account-wide audit log (paginated, filterable) + properties admin list with bulk edit
- POST `/api/properties/bulk-edit` for add-tag / remove-tag / set-notes across many properties

## Schema (`supabase/migrations/20260430042852_phase4b_audit_extensions.sql`)
Additive only — kept the existing 4a PR2 table shape:

```sql
ALTER TABLE property_edit_history
  ADD COLUMN reason TEXT,
  ADD COLUMN cascading_effects JSONB;
```

The 4b spec called for `entity_type` + `entity_id` discriminator columns, but the existing `property_id` + `service_location_id` columns are functionally equivalent (entity_type is derivable from "service_location_id IS NULL"). Migrating would invalidate existing rows for no behavioral gain.

## Cascade rules (`api/_lib/analysis/edit-cascade.ts`)
| Field changed | Modules staled | Other effects |
|---|---|---|
| Property address (any of 6) | crew_strategy + bid + drive_time + branch_opt | re-geocode (already 4a) |
| `serviceable_sqft` (≥10%) | crew + workforce + bid | — |
| `service_offering_id` | **all tier-2** | clear `property_comparables` cache |
| `visits_per_year_override` / `hours_per_visit_override` | crew + bid | — |
| `crew_size_override` | crew | — |
| `monthly_contract_value` | bid | — |

`applyCascadingEffects` flips `portfolio_analyses.status='stale'` for the most-recent completed row of each staled module and calls `triggerSynthesisRefresh` (debounced).

## Service-location field whitelist (now 12)
Existing 5 (display_name, location_code, suite_or_floor, serviceable_sqft, status) **+** `service_frequency`, `visits_per_year_override`, `hours_per_visit_override`, `crew_size_override`, `monthly_contract_value`, `frequency_notes`, `custom_fields`, `service_offering_id`.

`service_schedule` (jsonb) kept read-only — rich scheduler editor is Phase 4f. `monthly_direct_cost` / `crew_size` / `site_contact_*` / `access_notes` from the spec deferred — would need new schema columns; not worth a migration when those fields aren't used by any module yet.

## API
- `PATCH /api/v1/properties/[id]` — now also accepts `edit_reason`; response carries `cascading_effects: { analyses_marked_stale, synthesis_refresh_triggered, comparables_invalidated, reasons }` and `edits_recorded`
- `PATCH /api/v1/service-locations/[id]` — same shape, expanded whitelist
- `GET /api/accounts/[accountId]/clients/[clientId]/edit-history` — paginated audit feed; filters: `entity_type`, `field_name`, `edited_by` (substring), `date_from`/`date_to`, `has_cascading_effects`, `page`, `limit` (max 200)
- `POST /api/properties/bulk-edit` — body `{ property_ids[], action: 'add_tag'|'remove_tag'|'set_notes', value }`. Append-style semantics — already-tagged properties are skipped, returned as `unchanged`. Caps at 500 properties/call.

## UI
- `ServiceLocationEditDialog` rewritten to render all 12 fields dynamically from the whitelist + offering select populated from `/api/v1/service-offerings` + sqft-stale and offering-change warnings inline + optional reason field
- `CascadeBanner` (12s auto-dismiss) above PropertyDetail naming staled modules with a "Re-run modules →" link to the analysis dashboard
- `CustomFieldsEditor` — chip-style key/value rows + add row + delete; auto-converts numeric strings so jsonb numeric queries keep working
- `/admin/audit-log` page with filter card (entity_type, edited_by, cascade-only) + paginated table (50/page) showing field labels, old → new diff chips, attribution, and a cascade badge with stale-count
- `/admin/properties` page with checkbox per row + select-all-filtered + action bar (Add tag / Remove tag / Set notes) + dialog for the action's value
- `AnalysisSidebar` gains nav links to all three admin pages (Properties admin, Constraint templates, Edit history)

## Trade-offs
- **No table-shape migration.** Spec wanted `entity_type`/`entity_id`; current schema has `property_id` + `service_location_id`. Equivalent, kept to preserve existing audit rows.
- **No bulk action for arbitrary fields.** `bulk-edit` covers tags + notes only — that's the practical 90%. Other fields stay per-row.
- **`monthly_direct_cost` and `crew_size` are NOT in the whitelist** because they don't exist as columns. Spec listed them but no module reads them. Deferring schema additions until something actually needs them.
- **Cascade applies on the next dashboard interaction**, not in-line. We mark stale; the existing dashboard polling kicks foreground re-runs. No new infra needed.

## Test plan
- [ ] Edit a service location's `serviceable_sqft` from 10000 → 11500 (15%) → SaveBanner appears: "Crew Strategy, Workforce Sizing, Bid Pricing marked stale" with Re-run link
- [ ] Edit `service_offering_id` to a different offering → CascadeBanner names all tier-2 modules + "Comparables cache cleared"
- [ ] Edit only `frequency_notes` → no cascade banner (no modules staled)
- [ ] Add a `reason` ("Sqft corrected after walkthrough") → audit log row carries the reason
- [ ] Open `/admin/audit-log` → see recent edits, filter by `has_cascading_effects=true` → only edits that staled modules
- [ ] Filter audit log by `edited_by=jon@` → narrows to user
- [ ] Open `/admin/properties` → list of all properties with tags
- [ ] Filter "high-priority" → narrows
- [ ] Select 5 properties → "Add tag" → enter "vip-2026" → all 5 get tagged → result toast: "5 updated · 0 unchanged · 0 missing"
- [ ] Select the same 5 again → "Add tag" → "vip-2026" again → "0 updated · 5 unchanged"
- [ ] Edit custom_fields on an SL → add `cleaning_frequency: weekly`, `key: 1234` → numeric value preserved as number
- [ ] DELETE existing comparables row, edit `service_offering_id` → comparables row cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)