### PR TITLE
Dedupe service_offerings — drop unused null-account copies for JLL client

### DIFF
--- a/supabase/migrations/20260430121156_dedupe_service_offerings_null_account.sql
+++ b/supabase/migrations/20260430121156_dedupe_service_offerings_null_account.sql
@@ -1,0 +1,22 @@
+-- Dedupe service_offerings for the JLL Property Reserve client.
+--
+-- Setup created paired rows: one with account_id=NULL, one scoped to the
+-- account. The account-scoped row is the "real" one (has all the
+-- service_locations pointing at it); the null-account row is leftover
+-- from an earlier import and unused.
+--
+-- Verified pre-migration that each null-account ID has 0 FK references
+-- in service_locations, so deletion is safe — no FK repointing needed.
+--
+-- Targeted deletes only — leaves typo variants ("Project Clean & Power
+-- Wash" vs "Project Clean & Powerwashing", "Upholstery, High Clean Stage"
+-- vs "Upholstery, HIgh Clean Stage") for the user to resolve manually
+-- since they have actually-different names. UNIQUE constraint deferred
+-- until those are reconciled.
+
+DELETE FROM public.service_offerings
+WHERE id IN (
+  '439a4f86-ea0d-48f9-b3d0-8ea9777bb445',  -- Mission Home Housekeeping (null acct)
+  '985c9ffb-c362-45ae-af36-bf89ac2163b0',  -- S and I Housekeeping (null acct)
+  '45a05809-9055-4c13-8345-9a3d664839f4'   -- S and I Project Clean (null acct)
+);


### PR DESCRIPTION
## Why
Phase 4d's Service Offerings UI was showing each offering twice for JLL → Property Reserve. Investigation showed the DB had paired rows for several offerings: one with \`account_id=NULL\` and one with \`account_id=<JLL>\`. The null-account copies were leftover from an earlier import — verified zero \`service_locations\` reference them.

## What this does
\`DELETE\` three specific rows by id:
- Mission Home Housekeeping (null-account copy, 0 SL refs)
- S&I Housekeeping (null-account copy, 0 SL refs)
- S&I Project Clean (null-account copy, 0 SL refs)

The account-scoped copies stay (13 / 32 / 15 SL refs respectively).

## What this doesn't do
Two pairs that *look* like duplicates but actually have different names — needs your call before we can dedupe:
- "Project Clean & Power Wash" (null acct, currently set to parent / 0.5y) vs "Project Clean & Powerwashing" (account-scoped, standalone)
- "Upholstery, High Clean Stage" (account-scoped) vs "Upholstery, HIgh Clean Stage" (null acct, case typo)

These are skipped here. Once you decide canonical spelling, I'll ship a follow-up migration that merges them and adds a `UNIQUE (name, client_id)` constraint to prevent dupes from coming back.

## Test plan
- [ ] After merge, reload `/admin/service-offerings` for JLL → Property Reserve
- [ ] Mission Home Housekeeping appears once
- [ ] S&I Housekeeping appears once
- [ ] S&I Project Clean appears once (with parent role + 0.5yr interval already set)
- [ ] Upholstery and "Project Clean & ..." pairs still both visible (expected — typo variants)
- [ ] No service_location lost its offering link

🤖 Generated with [Claude Code](https://claude.com/claude-code)