### PR TITLE
Dedupe typo-variant service_offerings for JLL

### DIFF
--- a/supabase/migrations/20260430121816_dedupe_service_offerings_typo_variants.sql
+++ b/supabase/migrations/20260430121816_dedupe_service_offerings_typo_variants.sql
@@ -1,0 +1,29 @@
+-- Phase 4d follow-up: dedupe the typo-variant service_offerings for JLL.
+--
+-- "Project Clean & Power Wash"  (id fd8e87c7…)  → 0 SLs   — DELETE
+-- "Project Clean & Powerwashing" (id e4a17081…) → 499 SLs — KEEP
+--   Transfer routing config (parent / 0.5yr / routed) onto the kept row
+--   first so the user's manual configuration isn't lost.
+--
+-- "Upholstery, HIgh Clean Stage" (id 549e8463…) → 0 SLs   — DELETE
+-- "Upholstery, High Clean Stage" (id 5c500028…) → 473 SLs — KEEP
+--   Both have identical routing flags (standalone / not routed); nothing
+--   to transfer. The user can configure this as an addon via the UI when
+--   ready — neither row got the addon role from the Phase 4d backfill
+--   because the spec's ILIKE 'Upholstery' is exact-match and these names
+--   don't match.
+
+-- 1. Transfer routing config from soon-to-be-deleted Project Clean row
+--    to the kept row.
+UPDATE public.service_offerings
+   SET is_routed            = TRUE,
+       offering_role        = 'parent',
+       visit_interval_years = 0.5
+ WHERE id = 'e4a17081-7691-4ab5-8dcd-849634c41a0f';
+
+-- 2. Delete the two unused typo-variant rows.
+DELETE FROM public.service_offerings
+ WHERE id IN (
+   'fd8e87c7-8184-4f22-b806-ebc3798f6145',
+   '549e8463-08cc-4e0f-9174-fcfef4cf7b99'
+ );


### PR DESCRIPTION
## Why
After the null-account dedupe (#97), two pairs remained — same offering, slightly different spelling, splitting the data:

- **Project Clean & Power Wash** (0 SLs, set to parent/0.5yr) vs **Project Clean & Powerwashing** (499 SLs, standalone) → keep the one with data, **transfer routing config** so the manually-set parent/0.5yr config isn't lost
- **Upholstery, HIgh Clean Stage** (0 SLs, case typo) vs **Upholstery, High Clean Stage** (473 SLs) → keep the correct-case one. Both have identical flags so no transfer needed

## What this does
1. `UPDATE` the kept "Project Clean & Powerwashing" row → `is_routed=true, parent, 0.5yr`
2. `DELETE` the two zero-SL typo variants

## What this doesn't do
Neither Upholstery row was set as an addon by Phase 4d's backfill (the spec's `ILIKE 'Upholstery'` is exact-match and these names are "Upholstery, [...] Clean Stage"). To wire up the addon flow with cohort rotation, edit "Upholstery, High Clean Stage" in the Service Offerings page and set role=addon, interval=3, attaches to "Project Clean & Powerwashing" + "S&I Project Clean".

## Test plan
- [ ] Reload `/admin/service-offerings` → Project Clean and Upholstery each appear once
- [ ] "Project Clean & Powerwashing" shows as parent / 0.5yr / routed
- [ ] "Upholstery, High Clean Stage" still shows as standalone (configure manually)
- [ ] Service locations still tied to their offerings (499 + 473 unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)