### PR TITLE
Fix template builder under-placement + add regenerate flow

### DIFF
--- a/api/_lib/scheduler/build-routing-template.ts
+++ b/api/_lib/scheduler/build-routing-template.ts
@@ -293,9 +293,19 @@ export function buildRoutingTemplate(input: BuildTemplateInput): TemplateBuildRe
     for (const clusterId of crew.cluster_ids) {
       const cluster = clusters.find((c) => c.cluster_id === clusterId)!
       for (let visitIdx = 0; visitIdx < cluster.trips_per_cycle; visitIdx++) {
-        const tripDuration = cluster.cluster_type === 'remote' ? cluster.days_on_site_per_trip : 1
-        const targetStart = Math.floor((cycleDays * (visitIdx + 0.5)) / cluster.trips_per_cycle)
-        const tripStart = Math.max(targetStart, nextAvailableDay)
+        const tripDuration = cluster.days_on_site_per_trip
+        // Remote trips spread across the cycle (target the midpoint of
+        // each visit segment); local trips pack sequentially from day 0
+        // since they're continuous work, not discrete visits.
+        let tripStart: number
+        if (cluster.cluster_type === 'remote') {
+          const targetStart = Math.floor(
+            (cycleDays * (visitIdx + 0.5)) / cluster.trips_per_cycle
+          )
+          tripStart = Math.max(targetStart, nextAvailableDay)
+        } else {
+          tripStart = nextAvailableDay
+        }
 
         // Build per-day routes via routeDay(). Visits eligible for THIS
         // visit_index of THIS cluster:
@@ -380,24 +390,22 @@ export function buildRoutingTemplate(input: BuildTemplateInput): TemplateBuildRe
           const placedIds = new Set(dayResult.route.map((s) => s.service_location_id))
           remaining = remaining.filter((v) => !placedIds.has(v.service_location_id))
 
-          // Day end → set next day's start to the last stop's lat/lng
-          // (will be a hotel near the cluster centroid in reality — for
-          // template purposes we use the last stop as the proxy origin
-          // for day N+1).
-          if (remaining.length > 0 && dayNumber < tripDuration) {
-            const lastStop = stopsWithAddons[stopsWithAddons.length - 1]
-            const lastSpec = visitsForThisInstance.find(
-              (v) => v.service_location_id === lastStop.service_location_id
-            )
-            if (lastSpec) {
-              dayStartLoc = {
-                type: 'overnight_anchor',
-                name: `Hotel near ${cluster.cluster_id}`,
-                lat: cluster.centroid_lat,
-                lng: cluster.centroid_lng,
-              }
+          // For REMOTE multi-day trips: day N+1 starts from a hotel near
+          // the cluster centroid. For LOCAL multi-day trips: day N+1
+          // starts back at the branch (crew goes home each evening).
+          if (
+            remaining.length > 0 &&
+            dayNumber < tripDuration &&
+            cluster.cluster_type === 'remote'
+          ) {
+            dayStartLoc = {
+              type: 'overnight_anchor',
+              name: `Hotel near ${cluster.cluster_id}`,
+              lat: cluster.centroid_lat,
+              lng: cluster.centroid_lng,
             }
           }
+          // For local clusters, dayStartLoc stays as the branch (no change).
 
           dayNumber++
         }
@@ -532,12 +540,15 @@ function makeCluster(
       ? driveTimeMinutes(haversineMiles(c, branch), input.config.drive_speed_mph) / 60
       : 0
 
-  let daysOnSite = 1
-  if (cluster_type === 'remote') {
-    // Work hours per single visit (one trip of trips_per_cycle)
-    const workPerTrip = totalWork / tripsPerCycle
-    daysOnSite = Math.max(1, Math.ceil(workPerTrip / input.config.max_work_hours_per_crew_day))
-  }
+  // Multi-day applies to local clusters too — a crew working its
+  // local cluster doesn't fit ~85 properties × 3hr in one 10hr day.
+  // Local: each day starts/ends at the branch (no overnight). Remote:
+  // each day after the first starts from a hotel anchor.
+  const workPerTrip = totalWork / tripsPerCycle
+  const daysOnSite = Math.max(
+    1,
+    Math.ceil(workPerTrip / input.config.max_work_hours_per_crew_day)
+  )
 
   return {
     cluster_id,

--- a/api/scheduler/templates/[templateId]/regenerate.ts
+++ b/api/scheduler/templates/[templateId]/regenerate.ts
@@ -1,0 +1,284 @@
+// POST /api/scheduler/templates/[templateId]/regenerate
+//
+// Re-runs buildRoutingTemplate against the same routed_service_location_ids
+// + branches the template was originally built from, optionally overriding
+// crew_count or config knobs. Writes the new result back into the same
+// template row (status flips to 'optimizing' → 'active' or 'failed').
+//
+// Useful when:
+// - The first run produced too many unplaced visits (raise crew_count)
+// - User wants to try a different cycle length
+// - Config defaults changed and they want a fresh pass
+//
+// Cycle instances generated from the OLD template snapshot remain
+// untouched (their scheduled_visits + crew_day_routes are already
+// materialized). Future generate-cycle calls use the new snapshot.
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { createAdminClient } from '../../../_lib/supabase.js'
+import { authenticateRequest } from '../../../_lib/auth.js'
+import {
+  loadConstraints,
+} from '../../../_lib/analysis/operational-constraints.js'
+import { loadAccountOfferings } from '../../../_lib/analysis/service-offerings.js'
+import { computePropertyVisitHours } from '../../../_lib/analysis/property-hours.js'
+import {
+  buildRoutingTemplate,
+  type PropertyForBuild,
+} from '../../../_lib/scheduler/build-routing-template.js'
+import {
+  applyCohortAssignments,
+  loadEligibleProperties,
+} from '../../../_lib/scheduler/cohort-assigner.js'
+import type { StoredConstraint } from '../../../_lib/scheduler/constraint-evaluator.js'
+
+export const config = { maxDuration: 120 }
+
+interface Body {
+  crew_count?: number
+  custom_cycle_length_days?: number | null
+  config?: Record<string, unknown>
+  preferences?: {
+    objective?: 'minimize_drive' | 'maximize_utilization' | 'balanced'
+    soft_constraint_weight?: number
+    allow_hard_constraint_violation?: boolean
+  }
+}
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'POST') return res.status(405).json({ error: 'Method not allowed' })
+  try { await authenticateRequest(req) } catch (err: any) {
+    return res.status(err.statusCode ?? 401).json({ error: err.message ?? 'Unauthorized' })
+  }
+  const templateId = req.query.templateId as string
+  const body = (req.body ?? {}) as Body
+
+  const db = createAdminClient()
+
+  const { data: tplRow, error: tplErr } = await db
+    .from('routing_templates')
+    .select('*')
+    .eq('id', templateId)
+    .single()
+  if (tplErr || !tplRow) return res.status(404).json({ error: 'Template not found' })
+  const tpl = tplRow as any
+
+  const accountId = tpl.account_id as string
+  const clientId = tpl.client_id as string
+  const slIds = (tpl.routed_service_location_ids ?? []) as string[]
+  const crewCount = body.crew_count ?? tpl.crew_count ?? 1
+  const customCycleDays = body.custom_cycle_length_days !== undefined
+    ? body.custom_cycle_length_days ?? undefined
+    : (tpl.is_custom_cycle_length ? tpl.cycle_length_days : undefined)
+
+  const constraints = await loadConstraints(db, accountId, clientId)
+  const branches = (tpl.branches ?? []) as Array<{ name: string; lat: number; lng: number }>
+  if (branches.length === 0) {
+    return res.status(400).json({ error: 'Template has no branches snapshot' })
+  }
+
+  // Mark optimizing
+  await db
+    .from('routing_templates')
+    .update({ status: 'optimizing', updated_at: new Date().toISOString() })
+    .eq('id', templateId)
+
+  // Re-load offerings + property hours + cohorts
+  const { data: slRows } = await db
+    .from('service_locations')
+    .select('id, property_id, service_offering_id, serviceable_sqft, hours_per_visit_override, property:properties(id, address_line1, latitude, longitude)')
+    .in('id', slIds)
+  const { data: offeringRows } = await db
+    .from('service_offerings')
+    .select('id, name, is_routed, offering_role, visit_interval_years, attaches_to_offering_ids, uses_cohort_rotation')
+    .eq('client_id', clientId)
+  const offerings = new Map<string, any>()
+  for (const o of offeringRows ?? []) offerings.set((o as any).id, o)
+
+  type RoutedRow = { sl: any; offering: any }
+  const routed: RoutedRow[] = []
+  for (const r of slRows ?? []) {
+    const sl = r as any
+    const off = offerings.get(sl.service_offering_id)
+    if (off?.is_routed && off.offering_role === 'parent') routed.push({ sl, offering: off })
+  }
+
+  // Re-ensure cohorts
+  const parentOfferingIds = new Set(routed.map((r) => r.offering.id))
+  const addonOfferings = (offeringRows ?? []).filter((o: any) =>
+    o.is_routed &&
+    o.offering_role === 'addon' &&
+    ((o.attaches_to_offering_ids ?? []) as string[]).some((id) => parentOfferingIds.has(id))
+  )
+  for (const addon of addonOfferings) {
+    const a = addon as any
+    const eligible = await loadEligibleProperties(db, accountId, clientId, (a.attaches_to_offering_ids ?? []) as string[])
+    const { data: existing } = await db
+      .from('addon_cohort_assignments')
+      .select('service_location_id')
+      .eq('service_offering_id', a.id)
+      .eq('client_id', clientId)
+    const assigned = new Set((existing ?? []).map((x: any) => x.service_location_id))
+    const unassigned = eligible.filter((e) => !assigned.has(e.service_location_id))
+    if (unassigned.length > 0) {
+      await applyCohortAssignments(db, {
+        account_id: accountId,
+        client_id: clientId,
+        service_offering_id: a.id,
+        cohort_total: Math.max(1, Math.round(Number(a.visit_interval_years ?? 1))),
+        start_year: new Date().getUTCFullYear(),
+        method: 'geographic',
+        preserve_existing: true,
+        eligible_properties: eligible,
+      })
+    }
+  }
+  const { data: cohortRows } = await db
+    .from('addon_cohort_assignments')
+    .select('id, service_location_id, service_offering_id, cohort_index, next_due_year')
+    .in('service_location_id', routed.map((r) => r.sl.id))
+  const { data: constraintRows } = await db
+    .from('service_location_constraints')
+    .select('id, service_location_id, constraint_type, enforcement, config, notes')
+    .in('service_location_id', routed.map((r) => r.sl.id))
+  const constraintsBySl = new Map<string, StoredConstraint[]>()
+  for (const c of constraintRows ?? []) {
+    const arr = constraintsBySl.get((c as any).service_location_id) ?? []
+    arr.push(c as StoredConstraint)
+    constraintsBySl.set((c as any).service_location_id, arr)
+  }
+
+  const allOfferingMap = await loadAccountOfferings(db, accountId, clientId)
+  const propIds = Array.from(new Set(routed.map((r) => r.sl.property_id)))
+  const { data: propRows } = await db
+    .from('properties')
+    .select('*, service_locations(*)')
+    .in('id', propIds)
+  const visits = computePropertyVisitHours((propRows ?? []) as any, allOfferingMap, {
+    project_clean_base_hours: constraints.project_clean_base_hours,
+    project_clean_hours_per_sqft: constraints.project_clean_hours_per_sqft,
+    upholstery_solo_hours: constraints.upholstery_solo_hours,
+    upholstery_combo_hours_pct: constraints.upholstery_combo_hours_pct,
+    visits_per_year_default: constraints.visits_per_year_default ?? 2,
+  })
+  const visitsByPropId = new Map<string, { hours_per_visit: number }>()
+  for (const v of visits) visitsByPropId.set(v.property.id, { hours_per_visit: v.hours_per_visit })
+
+  const propertiesForBuild: PropertyForBuild[] = routed.map((r) => {
+    const propVisit = visitsByPropId.get(r.sl.property_id)
+    const slSqft = r.sl.serviceable_sqft ?? 0
+    const propRow = (propRows as any)?.find((p: any) => p.id === r.sl.property_id)
+    const allSlForProp = propRow?.service_locations ?? []
+    const totalSqft = allSlForProp.reduce((s: number, x: any) => s + (x.serviceable_sqft ?? 0), 0)
+    const ratio = totalSqft > 0 ? slSqft / totalSqft : 1 / Math.max(1, allSlForProp.length)
+    const baseHours = r.sl.hours_per_visit_override ?? (propVisit ? propVisit.hours_per_visit * ratio : 1)
+
+    const eligibleAddons: PropertyForBuild['eligible_addons'] = []
+    for (const addon of addonOfferings) {
+      const a = addon as any
+      const parents = (a.attaches_to_offering_ids ?? []) as string[]
+      if (!parents.includes(r.offering.id)) continue
+      const cohort = (cohortRows ?? []).find((c: any) =>
+        c.service_location_id === r.sl.id && c.service_offering_id === a.id
+      ) as any
+      if (!cohort) continue
+      eligibleAddons.push({
+        cohort_assignment_id: cohort.id,
+        offering_id: a.id,
+        offering_name: a.name,
+        visit_interval_years: Number(a.visit_interval_years ?? 0),
+        hours_addition: constraints.upholstery_solo_hours,
+        cohort_index: cohort.cohort_index,
+        next_due_year: cohort.next_due_year,
+      })
+    }
+
+    return {
+      service_location_id: r.sl.id,
+      property_id: r.sl.property_id,
+      address: propRow?.address_line1 ?? '',
+      lat: Number(propRow?.latitude ?? NaN),
+      lng: Number(propRow?.longitude ?? NaN),
+      parent_offering_id: r.offering.id,
+      parent_offering_name: r.offering.name,
+      parent_visit_interval_years: Number(r.offering.visit_interval_years ?? 0.5),
+      base_hours_per_visit: baseHours,
+      constraints: constraintsBySl.get(r.sl.id) ?? [],
+      eligible_addons: eligibleAddons,
+    }
+  }).filter((p) => Number.isFinite(p.lat) && Number.isFinite(p.lng))
+
+  try {
+    const tplConfig = (tpl.config ?? {}) as Record<string, unknown>
+    const cfg = {
+      crew_size: constraints.crew_size,
+      hours_per_day: constraints.hours_per_day,
+      work_start_time: '08:00',
+      work_end_time: '18:00',
+      buffer_minutes_per_stop: 15,
+      drive_speed_mph: constraints.drive_speed_mph,
+      overnight_trigger_one_way_hours: constraints.hotel_cost_config.overnight_trigger_one_way_hours,
+      cluster_radius_miles: 30,
+      max_work_hours_per_crew_day: constraints.hotel_cost_config.max_work_hours_per_crew_day,
+      fuel_cost_per_mile: constraints.fuel_cost_per_mile,
+      hourly_loaded_labor_cost: constraints.hourly_loaded_labor_cost,
+      cost_per_night: constraints.hotel_cost_config.cost_per_night,
+      per_diem_per_night: constraints.hotel_cost_config.per_diem_per_night,
+      ...tplConfig,
+      ...(body.config ?? {}),
+    }
+    const result = buildRoutingTemplate({
+      account_id: accountId,
+      client_id: clientId,
+      routed_properties: propertiesForBuild,
+      branches,
+      crew_count: crewCount,
+      config: cfg as any,
+      custom_cycle_length_days: customCycleDays,
+      preferences: {
+        objective: body.preferences?.objective ?? 'balanced',
+        soft_constraint_weight: body.preferences?.soft_constraint_weight ?? 0.5,
+        allow_hard_constraint_violation: body.preferences?.allow_hard_constraint_violation ?? false,
+      },
+      cycle_start_year: new Date().getUTCFullYear(),
+    })
+
+    const status = result.total_visits_per_cycle === 0 ? 'failed' : 'active'
+    await db
+      .from('routing_templates')
+      .update({
+        status,
+        crew_count: crewCount,
+        config: cfg,
+        is_custom_cycle_length: !!customCycleDays,
+        optimized_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+        cycle_length_days: result.cycle_length_days,
+        cycle_length_label: result.cycle_length_label,
+        geographic_clusters: result.geographic_clusters,
+        crew_assignments: result.crew_assignments,
+        trips: result.trips,
+        unplaced_visits: result.unplaced_visits,
+        total_visits_required_per_cycle: result.total_visits_required_per_cycle,
+        total_visits_per_cycle: result.total_visits_per_cycle,
+        total_drive_minutes_per_cycle: result.total_drive_minutes_per_cycle,
+        total_work_minutes_per_cycle: result.total_work_minutes_per_cycle,
+        total_overnight_nights_per_cycle: result.total_overnight_nights_per_cycle,
+        total_drive_miles_per_cycle: result.total_drive_miles_per_cycle,
+        total_estimated_cost_per_cycle: result.total_estimated_cost_per_cycle,
+        total_estimated_cost_per_year: result.total_estimated_cost_per_year,
+        hard_constraint_violations: result.hard_constraint_violations,
+        soft_constraint_violations: result.soft_constraint_violations,
+        optimization_score: result.optimization_score,
+        optimizer_notes: result.optimizer_notes,
+      })
+      .eq('id', templateId)
+    const { data: full } = await db.from('routing_templates').select('*').eq('id', templateId).single()
+    return res.status(200).json({ template: full })
+  } catch (err: any) {
+    await db
+      .from('routing_templates')
+      .update({ status: 'failed', optimizer_notes: err?.message ?? String(err), updated_at: new Date().toISOString() })
+      .eq('id', templateId)
+    return res.status(500).json({ error: err?.message ?? 'Regenerate failed' })
+  }
+}

--- a/src/pages/accounts/scheduler/TemplateDetail.tsx
+++ b/src/pages/accounts/scheduler/TemplateDetail.tsx
@@ -3,7 +3,7 @@
 // trip/crew tabs. Map + rich Gantt deferred to 4f.
 import { useState, useEffect, useCallback } from 'react'
 import { useParams, useNavigate, Link } from 'react-router-dom'
-import { Plus, Play } from 'lucide-react'
+import { Plus, Play, RefreshCw, Trash2 } from 'lucide-react'
 import { useAuth } from '../../../hooks/useAuth'
 import AppShell from '../../../components/layout/AppShell'
 import Button from '../../../components/ui/Button'
@@ -24,6 +24,7 @@ interface Template {
   description: string | null
   status: string
   crew_count: number
+  is_custom_cycle_length: boolean
   cycle_length_days: number
   cycle_length_label: string
   total_visits_per_cycle: number | null
@@ -65,6 +66,12 @@ export default function TemplateDetailPage() {
   const [generateOpen, setGenerateOpen] = useState(false)
   const [genStartDate, setGenStartDate] = useState(() => new Date().toISOString().slice(0, 10))
   const [generating, setGenerating] = useState(false)
+  const [regenOpen, setRegenOpen] = useState(false)
+  const [regenCrewCount, setRegenCrewCount] = useState<number>(1)
+  const [regenCycleDays, setRegenCycleDays] = useState<number | ''>('')
+  const [regenObjective, setRegenObjective] = useState<'minimize_drive' | 'maximize_utilization' | 'balanced'>('balanced')
+  const [regenerating, setRegenerating] = useState(false)
+  const [archiving, setArchiving] = useState(false)
 
   const load = useCallback(async () => {
     if (!templateId) return
@@ -94,6 +101,69 @@ export default function TemplateDetailPage() {
   }, [templateId, getToken])
 
   useEffect(() => { load() }, [load])
+
+  // Seed regen dialog defaults from current template values when opened
+  useEffect(() => {
+    if (template) {
+      setRegenCrewCount(template.crew_count)
+      setRegenCycleDays(template.is_custom_cycle_length ? template.cycle_length_days : '')
+    }
+  }, [template])
+
+  async function handleRegenerate() {
+    if (!templateId) return
+    setRegenerating(true)
+    setError(null)
+    try {
+      const token = await getToken()
+      const body: Record<string, unknown> = {
+        crew_count: regenCrewCount,
+        preferences: { objective: regenObjective },
+      }
+      if (regenCycleDays !== '' && Number.isFinite(regenCycleDays)) {
+        body.custom_cycle_length_days = regenCycleDays
+      } else {
+        body.custom_cycle_length_days = null
+      }
+      const res = await fetch(`/api/scheduler/templates/${templateId}/regenerate`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        body: JSON.stringify(body),
+      })
+      if (!res.ok) {
+        const errBody = await res.json().catch(() => ({}))
+        throw new Error(errBody.error ?? `Regenerate failed (${res.status})`)
+      }
+      setRegenOpen(false)
+      await load()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setRegenerating(false)
+    }
+  }
+
+  async function handleArchive() {
+    if (!templateId) return
+    if (!confirm('Archive this template? Cycles already generated stay; the template won\'t show in the active list.')) return
+    setArchiving(true)
+    try {
+      const token = await getToken()
+      const res = await fetch(`/api/scheduler/templates/${templateId}`, {
+        method: 'DELETE',
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}))
+        throw new Error(body.error ?? `Archive failed (${res.status})`)
+      }
+      navigate(`/accounts/${accountId}/clients/${clientId}/scheduler/templates`)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setArchiving(false)
+    }
+  }
 
   async function handleGenerate() {
     if (!templateId) return
@@ -155,6 +225,16 @@ export default function TemplateDetailPage() {
               <Play className="h-3.5 w-3.5" />
               Generate cycle
             </Button>
+            <Button variant="secondary" onClick={() => setRegenOpen(true)}>
+              <RefreshCw className="h-3.5 w-3.5" />
+              Regenerate
+            </Button>
+            {template.status !== 'archived' && (
+              <Button variant="ghost" onClick={handleArchive} loading={archiving}>
+                <Trash2 className="h-3.5 w-3.5" />
+                Archive
+              </Button>
+            )}
           </div>
         </header>
 
@@ -388,6 +468,55 @@ export default function TemplateDetailPage() {
           <DialogFooter>
             <Button variant="ghost" onClick={() => setGenerateOpen(false)}>Cancel</Button>
             <Button onClick={handleGenerate} loading={generating}>Generate</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={regenOpen} onOpenChange={(o) => { if (!o) setRegenOpen(false) }}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Regenerate template</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-3">
+            <p className="text-xs text-fg-muted">
+              Re-runs the optimizer against the same property set with adjusted settings.
+              Cycles already generated stay intact; future cycles will use the new structure.
+            </p>
+            <FormField label="Crew count">
+              <Input
+                type="number"
+                min={1}
+                max={20}
+                value={regenCrewCount}
+                onChange={(e) => setRegenCrewCount(Math.max(1, Number(e.target.value) || 1))}
+              />
+            </FormField>
+            <FormField
+              label="Custom cycle length (days, optional)"
+              helper="Leave blank to auto-compute from parent visit intervals."
+            >
+              <Input
+                type="number"
+                value={regenCycleDays === '' ? '' : String(regenCycleDays)}
+                onChange={(e) => setRegenCycleDays(e.target.value === '' ? '' : Number(e.target.value))}
+                placeholder="auto"
+              />
+            </FormField>
+            <FormField label="Optimization objective">
+              <select
+                className="h-9 w-full rounded-md border border-border bg-surface px-3 text-sm"
+                value={regenObjective}
+                onChange={(e) => setRegenObjective(e.target.value as any)}
+              >
+                <option value="minimize_drive">Minimize drive</option>
+                <option value="maximize_utilization">Maximize utilization</option>
+                <option value="balanced">Balanced</option>
+              </select>
+            </FormField>
+          </div>
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setRegenOpen(false)}>Cancel</Button>
+            <Button onClick={handleRegenerate} loading={regenerating}>Regenerate</Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>


### PR DESCRIPTION
## Why
Generated a template for Property Reserve with 6 crews → only 100 of 509 properties placed, 409 unplaced. Root cause: local clusters were always set to \`days_on_site_per_trip = 1\`, so a crew working its ~80-property local cluster could fit ~3 properties before \`work_end_time\` rejected the rest. With 6 local clusters × ~3 properties = ~18 placed; everything else bucketed as "time_overflow."

## Algorithm fix (`api/_lib/scheduler/build-routing-template.ts`)
1. \`daysOnSite = ceil(workPerTrip / max_work_hours_per_crew_day)\` for **all** cluster types (was \`if cluster_type === 'remote'\` only).
2. For **local** multi-day trips, dayStartLoc stays at the branch each morning. For **remote** it still shifts to the cluster centroid (overnight anchor).
3. **Local clusters pack sequentially from day 0** instead of targeting the midpoint of their visit segment — they're continuous work, not discrete trips. Remote clusters still use midpoint targeting because they're discrete trips that benefit from being spread across the cycle.

Expected after fix on Property Reserve: ~509 placements with 6 crews and a 6-month cycle, since each crew now uses many days of cycle capacity instead of just one.

## Recovery flow (new)
There was no path to recover from a bad result short of archiving and starting over. Added:

**`POST /api/scheduler/templates/[id]/regenerate`** — re-runs the builder against the template's same property set with optional overrides:
- \`crew_count\` (defaults to current value)
- \`custom_cycle_length_days\` (set to a number, or \`null\` to clear and re-auto-compute)
- \`preferences.objective\` (\`minimize_drive\` | \`maximize_utilization\` | \`balanced\`)

Writes back to the same row (status flips to \`optimizing\` → \`active\` or \`failed\`). Existing cycle instances stay intact; future \`generate-cycle\` calls use the new snapshot.

**Template detail page:**
- **Regenerate** button → dialog with crew_count / custom cycle length / objective inputs (seeded from current values)
- **Archive** button (was only described in help text, no actual UI control)

## Test plan
- [ ] Open the existing Property Reserve template → click Regenerate → leave settings same → save. Result should now show ~509 placed (or close to it) instead of 100
- [ ] Try with 4 crews instead of 6 — should still place most properties, with longer per-crew durations
- [ ] Try cycle length override (e.g. 91 days) — visits-per-cycle math doubles for 0.5yr-interval properties
- [ ] Click Archive on a template → returns to templates list, template doesn't show in active list
- [ ] Check Trips tab: each local trip now has \`duration_days\` > 1 (was always 1 before)
- [ ] Generate cycle 1 → \`crew_day_routes\` rows match the multi-day trip structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)