### PR TITLE
Auto-recommend crew count + human-readable trip/cluster labels

### DIFF
--- a/api/_lib/scheduler/build-routing-template.ts
+++ b/api/_lib/scheduler/build-routing-template.ts
@@ -18,6 +18,7 @@ import {
   evaluateConstraint,
   type StoredConstraint,
 } from './constraint-evaluator.js'
+import { nearestCity } from '../analysis/constrained-kmeans.js'
 
 export interface PropertyForBuild {
   service_location_id: string
@@ -97,6 +98,7 @@ interface VisitSpec {
 
 interface ClusterSpec {
   cluster_id: string
+  cluster_label: string
   cluster_type: 'local' | 'remote'
   base_branch_index: number
   centroid_lat: number
@@ -421,10 +423,17 @@ export function buildRoutingTemplate(input: BuildTemplateInput): TemplateBuildRe
         }
 
         if (days.length > 0) {
+          const tripId = `${cluster.cluster_id}-v${visitIdx + 1}`
+          const tripLabel =
+            cluster.trips_per_cycle > 1
+              ? `${cluster.cluster_label} – Visit ${visitIdx + 1}`
+              : cluster.cluster_label
           trips.push({
-            trip_id: `${cluster.cluster_id}-v${visitIdx + 1}`,
+            trip_id: tripId,
+            trip_label: tripLabel,
             crew_index: crew.index,
             cluster_id: cluster.cluster_id,
+            cluster_label: cluster.cluster_label,
             trip_type: cluster.cluster_type === 'remote' ? 'overnight' : 'local',
             relative_start_day: tripStart,
             duration_days: days.length,
@@ -491,6 +500,7 @@ export function buildRoutingTemplate(input: BuildTemplateInput): TemplateBuildRe
     cycle_length_label: cycleResult.cycle_length_label,
     geographic_clusters: clusters.map((c) => ({
       cluster_id: c.cluster_id,
+      cluster_label: c.cluster_label,
       cluster_type: c.cluster_type,
       centroid_lat: c.centroid_lat,
       centroid_lng: c.centroid_lng,
@@ -552,6 +562,7 @@ function makeCluster(
 
   return {
     cluster_id,
+    cluster_label: makeClusterLabel(cluster_type, c, branch),
     cluster_type,
     base_branch_index,
     centroid_lat: c.lat,
@@ -562,6 +573,22 @@ function makeCluster(
     trips_per_cycle: tripsPerCycle,
     days_on_site_per_trip: daysOnSite,
   }
+}
+
+// Human-readable cluster label. For local clusters we use the branch
+// name (this is the crew's home base — most familiar to the user). For
+// remote clusters we use the nearest city to the centroid.
+function makeClusterLabel(
+  cluster_type: 'local' | 'remote',
+  c: { lat: number; lng: number },
+  branch: { name: string; lat: number; lng: number } | undefined
+): string {
+  if (cluster_type === 'local' && branch) {
+    return `${branch.name} (local)`
+  }
+  const city = nearestCity(c.lat, c.lng)
+  if (city) return `${city.city}, ${city.state_id}`
+  return `(${c.lat.toFixed(2)}, ${c.lng.toFixed(2)})`
 }
 
 function minutesFromStart(iso: string, startHHMM: string): number {

--- a/api/_lib/scheduler/generate-cycle-instance.ts
+++ b/api/_lib/scheduler/generate-cycle-instance.ts
@@ -139,6 +139,7 @@ export async function generateCycleInstance(
           cycle_instance_id: cycleInstanceId,
           template_id: templateId,
           trip_id: trip.trip_id,
+          trip_label: trip.trip_label ?? trip.trip_id,
           crew_index: trip.crew_index ?? 0,
           crew_label: `Crew ${(trip.crew_index ?? 0) + 1}`,
           scheduled_date: scheduledDate,

--- a/src/pages/accounts/scheduler/CycleDetail.tsx
+++ b/src/pages/accounts/scheduler/CycleDetail.tsx
@@ -45,6 +45,7 @@ interface Visit {
 interface CrewDay {
   id: string
   trip_id: string
+  trip_label: string | null
   crew_index: number
   scheduled_date: string
   day_type: string
@@ -190,8 +191,11 @@ export default function CycleDetailPage() {
                   <TableRow key={cd.id}>
                     <TableCell className="text-xs font-tabular">{cd.scheduled_date}</TableCell>
                     <TableCell numeric>{cd.crew_index + 1}</TableCell>
-                    <TableCell className="text-xs font-mono">
-                      {cd.trip_id} {cd.trip_total_days && cd.trip_total_days > 1 ? `(d${cd.trip_day_number}/${cd.trip_total_days})` : ''}
+                    <TableCell className="text-sm">
+                      {cd.trip_label ?? cd.trip_id}
+                      {cd.trip_total_days && cd.trip_total_days > 1
+                        ? <span className="text-fg-subtle text-xs ml-1">(day {cd.trip_day_number}/{cd.trip_total_days})</span>
+                        : null}
                     </TableCell>
                     <TableCell>
                       <Badge variant={cd.day_type === 'overnight' ? 'warning' : 'outline'}>

--- a/src/pages/accounts/scheduler/NewTemplate.tsx
+++ b/src/pages/accounts/scheduler/NewTemplate.tsx
@@ -44,21 +44,29 @@ export default function NewTemplatePage() {
   const [filter, setFilter] = useState('')
   const [selected, setSelected] = useState<Set<string>>(new Set())
   const [crewCount, setCrewCount] = useState(2)
+  const [crewCountUserEdited, setCrewCountUserEdited] = useState(false)
+  const [recommendedCrew, setRecommendedCrew] = useState<{
+    count: number
+    option: string
+  } | null>(null)
   const [cycleStartYear, setCycleStartYear] = useState(new Date().getUTCFullYear())
   const [planningMode, setPlanningMode] = useState<'auto' | 'hybrid' | 'manual'>('auto')
   const [objective, setObjective] = useState<'minimize_drive' | 'maximize_utilization' | 'balanced'>('balanced')
   const [customCycleDays, setCustomCycleDays] = useState<number | ''>('')
 
   const load = useCallback(async () => {
-    if (!clientId) return
+    if (!clientId || !accountId) return
     setLoading(true)
     try {
       const token = await getToken()
-      const [slRes, offRes] = await Promise.all([
+      const [slRes, offRes, latestRes] = await Promise.all([
         fetch(`/api/v1/service-locations?client_id=${clientId}`, {
           headers: { Authorization: `Bearer ${token}` },
         }),
         fetch(`/api/v1/service-offerings?client_id=${clientId}`, {
+          headers: { Authorization: `Bearer ${token}` },
+        }),
+        fetch(`/api/analyses/account/${accountId}/clients/${clientId}/latest`, {
           headers: { Authorization: `Bearer ${token}` },
         }),
       ])
@@ -67,12 +75,28 @@ export default function NewTemplatePage() {
         const o = await offRes.json()
         setOfferings(Array.isArray(o) ? o : o.items ?? [])
       }
+      if (latestRes.ok) {
+        const rows = await latestRes.json()
+        const cs = (rows as any[]).find((r) => r.module_key === 'crew_strategy' && r.status === 'completed')
+        if (cs?.outputs) {
+          const opt = cs.outputs.recommended_option as string | undefined
+          const count = opt
+            ? (cs.outputs.options?.[opt]?.crew_count as number | undefined)
+            : undefined
+          if (count != null) {
+            setRecommendedCrew({ count, option: opt ?? '?' })
+            // Default to recommendation only if user hasn't manually edited.
+            if (!crewCountUserEdited) setCrewCount(count)
+          }
+        }
+      }
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err))
     } finally {
       setLoading(false)
     }
-  }, [clientId, getToken])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [accountId, clientId, getToken])
 
   useEffect(() => { load() }, [load])
 
@@ -192,14 +216,38 @@ export default function NewTemplatePage() {
             <FormField label="Description (optional)">
               <Textarea value={description} onChange={(e) => setDescription(e.target.value)} rows={2} />
             </FormField>
-            <FormField label="Crew count">
+            <FormField
+              label="Crew count"
+              helper={
+                recommendedCrew
+                  ? crewCount === recommendedCrew.count
+                    ? `Recommended from Crew Strategy (Option ${recommendedCrew.option}).`
+                    : `Crew Strategy recommends ${recommendedCrew.count} (Option ${recommendedCrew.option}).`
+                  : 'Run Crew Strategy in Smart Analysis to get a recommendation.'
+              }
+            >
               <Input
                 type="number"
                 min={1}
                 max={20}
                 value={crewCount}
-                onChange={(e) => setCrewCount(Math.max(1, Number(e.target.value) || 1))}
+                onChange={(e) => {
+                  setCrewCountUserEdited(true)
+                  setCrewCount(Math.max(1, Number(e.target.value) || 1))
+                }}
               />
+              {recommendedCrew && crewCount !== recommendedCrew.count && (
+                <button
+                  type="button"
+                  onClick={() => {
+                    setCrewCountUserEdited(false)
+                    setCrewCount(recommendedCrew.count)
+                  }}
+                  className="text-xs text-accent hover:underline mt-1 self-start"
+                >
+                  Use recommended ({recommendedCrew.count})
+                </button>
+              )}
             </FormField>
             <FormField label="Cycle start year">
               <Input

--- a/src/pages/accounts/scheduler/TemplateDetail.tsx
+++ b/src/pages/accounts/scheduler/TemplateDetail.tsx
@@ -72,6 +72,10 @@ export default function TemplateDetailPage() {
   const [regenObjective, setRegenObjective] = useState<'minimize_drive' | 'maximize_utilization' | 'balanced'>('balanced')
   const [regenerating, setRegenerating] = useState(false)
   const [archiving, setArchiving] = useState(false)
+  const [recommendedCrew, setRecommendedCrew] = useState<{
+    count: number
+    option: string
+  } | null>(null)
 
   const load = useCallback(async () => {
     if (!templateId) return
@@ -93,12 +97,32 @@ export default function TemplateDetailPage() {
         const cy = await cyRes.json()
         setCycles(cy.cycles ?? [])
       }
+      // Pull crew_strategy recommendation for the regenerate dialog hint.
+      if (accountId && clientId) {
+        const latestRes = await fetch(
+          `/api/analyses/account/${accountId}/clients/${clientId}/latest`,
+          { headers: { Authorization: `Bearer ${token}` } }
+        )
+        if (latestRes.ok) {
+          const rows = await latestRes.json()
+          const cs = (rows as any[]).find(
+            (r) => r.module_key === 'crew_strategy' && r.status === 'completed'
+          )
+          if (cs?.outputs) {
+            const opt = cs.outputs.recommended_option as string | undefined
+            const count = opt
+              ? (cs.outputs.options?.[opt]?.crew_count as number | undefined)
+              : undefined
+            if (count != null) setRecommendedCrew({ count, option: opt ?? '?' })
+          }
+        }
+      }
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err))
     } finally {
       setLoading(false)
     }
-  }, [templateId, getToken])
+  }, [accountId, clientId, templateId, getToken])
 
   useEffect(() => { load() }, [load])
 
@@ -343,14 +367,14 @@ export default function TemplateDetailPage() {
                 <TableBody>
                   {(template.trips ?? []).map((t: any) => (
                     <TableRow key={t.trip_id}>
-                      <TableCell className="text-xs font-mono">{t.trip_id}</TableCell>
+                      <TableCell className="text-sm">{t.trip_label ?? t.trip_id}</TableCell>
                       <TableCell numeric>{t.crew_index + 1}</TableCell>
                       <TableCell>
                         <Badge variant={t.trip_type === 'overnight' ? 'warning' : 'outline'}>
                           {t.trip_type}
                         </Badge>
                       </TableCell>
-                      <TableCell className="text-xs">{t.cluster_id}</TableCell>
+                      <TableCell className="text-xs text-fg-muted">{t.cluster_label ?? t.cluster_id}</TableCell>
                       <TableCell numeric>{t.relative_start_day}</TableCell>
                       <TableCell numeric>{t.duration_days}d</TableCell>
                       <TableCell numeric>
@@ -404,7 +428,7 @@ export default function TemplateDetailPage() {
                 <TableBody>
                   {(template.geographic_clusters ?? []).map((c: any) => (
                     <TableRow key={c.cluster_id}>
-                      <TableCell className="text-xs font-mono">{c.cluster_id}</TableCell>
+                      <TableCell className="text-sm">{c.cluster_label ?? c.cluster_id}</TableCell>
                       <TableCell>
                         <Badge variant={c.cluster_type === 'remote' ? 'warning' : 'outline'}>
                           {c.cluster_type}
@@ -482,7 +506,16 @@ export default function TemplateDetailPage() {
               Re-runs the optimizer against the same property set with adjusted settings.
               Cycles already generated stay intact; future cycles will use the new structure.
             </p>
-            <FormField label="Crew count">
+            <FormField
+              label="Crew count"
+              helper={
+                recommendedCrew
+                  ? regenCrewCount === recommendedCrew.count
+                    ? `Recommended from Crew Strategy (Option ${recommendedCrew.option}).`
+                    : `Crew Strategy recommends ${recommendedCrew.count} (Option ${recommendedCrew.option}).`
+                  : undefined
+              }
+            >
               <Input
                 type="number"
                 min={1}
@@ -490,6 +523,15 @@ export default function TemplateDetailPage() {
                 value={regenCrewCount}
                 onChange={(e) => setRegenCrewCount(Math.max(1, Number(e.target.value) || 1))}
               />
+              {recommendedCrew && regenCrewCount !== recommendedCrew.count && (
+                <button
+                  type="button"
+                  onClick={() => setRegenCrewCount(recommendedCrew.count)}
+                  className="text-xs text-accent hover:underline mt-1 self-start"
+                >
+                  Use recommended ({recommendedCrew.count})
+                </button>
+              )}
             </FormField>
             <FormField
               label="Custom cycle length (days, optional)"

--- a/supabase/migrations/20260430123746_add_trip_label_to_crew_day_routes.sql
+++ b/supabase/migrations/20260430123746_add_trip_label_to_crew_day_routes.sql
@@ -1,0 +1,11 @@
+-- Phase 4d follow-up: human-readable trip labels.
+--
+-- The template builder generates cluster_id values like "local-0" /
+-- "remote-0" and trip_id values like "local-0-v1" — internal IDs that
+-- aren't useful in the UI. Phase 4d follow-up populates trip_label
+-- (e.g. "Frisco TX (local) – Visit 1", "El Paso, TX") on every newly-
+-- generated crew_day_route. Existing rows from earlier templates retain
+-- NULL until the template is regenerated (or backfilled by hand).
+
+ALTER TABLE public.crew_day_routes
+  ADD COLUMN IF NOT EXISTS trip_label TEXT;


### PR DESCRIPTION
## Why
Two UX rough edges from yesterday's testing session:

1. **Crew count was a free-form input** with no guidance — user had no idea whether 4 or 6 was the right number. Smart Analysis already computes a recommended crew count via Crew Strategy; we were ignoring it.
2. **Trip and cluster names were internal IDs** ("local-0", "local-0-v1", "remote-3") that meant nothing to a user. Real users think in city names.

## Crew count auto-recommendation
Both NewTemplate form and the regenerate dialog now fetch \`/api/analyses/account/[id]/clients/[id]/latest\`, find the latest completed \`crew_strategy\` row, and read \`outputs.options[recommended_option].crew_count\`.

- Defaults the input to the recommendation
- Helper text: "Recommended from Crew Strategy (Option B)" when matched, "Crew Strategy recommends 4 (Option B)" when user edited
- "Use recommended (4)" link appears if the user has overridden, restoring with one click
- Falls back to manual entry when no Crew Strategy run exists for the client

## Cluster + trip labels
Builder derives:
- \`cluster_label\`: \`"{branch.name} (local)"\` for local clusters, \`"{nearestCity.city}, {state_id}"\` for remote clusters (uses the existing \`nearestCity()\` helper from the constrained-kmeans module)
- \`trip_label\`: \`"{cluster_label}"\` when the cluster only has one trip per cycle, else \`"{cluster_label} – Visit N"\`

Both labels persist in:
- \`routing_templates.trips\` jsonb (each trip carries \`trip_label\` + \`cluster_label\`)
- \`routing_templates.geographic_clusters\` jsonb (each cluster carries \`cluster_label\`)
- \`crew_day_routes.trip_label\` — new column (small migration). Cycle generator writes the label so the cycle detail page can show it without re-joining the template.

## UI updates
- **TemplateDetail → Trips tab**: trip column shows label, cluster column shows label
- **TemplateDetail → Clusters tab**: cluster column shows label
- **CycleDetail → Crew days table**: trip column shows label with day-of-trip annotation moved to a subtle "(day 2/5)" suffix

## Backwards compat
Existing templates from before this PR have \`null\` cluster_label / trip_label values. UI falls back to the internal ID (\`{label ?? id}\`) so old data still renders. New templates and any regenerated old ones will populate the labels. The \`crew_day_routes.trip_label\` column also stays null on existing rows until those cycles are regenerated.

## Test plan
- [ ] Open NewTemplate form → "Recommended from Crew Strategy (Option X)" appears under crew count if a Crew Strategy run exists
- [ ] Generate a fresh template → Trips tab shows "Frisco TX (local)" instead of "local-0", remote clusters show "{City}, {State}"
- [ ] Generate cycle from new template → Cycle detail crew days table shows the label
- [ ] Open old template (pre-this-PR) → still renders with "local-0" fallback (no crash)
- [ ] Regenerate old template → labels populate
- [ ] Override crew count, click "Use recommended" link → input snaps back to recommendation

🤖 Generated with [Claude Code](https://claude.com/claude-code)