### PR TITLE
Include city + state on Unplaced rows

### DIFF
--- a/api/scheduler/templates/[templateId]/regenerate.ts
+++ b/api/scheduler/templates/[templateId]/regenerate.ts
@@ -195,7 +195,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     return {
       service_location_id: r.sl.id,
       property_id: r.sl.property_id,
-      address: propRow?.address_line1 ?? '',
+      address: formatAddress(propRow),
       lat: Number(propRow?.latitude ?? NaN),
       lng: Number(propRow?.longitude ?? NaN),
       parent_offering_id: r.offering.id,
@@ -281,4 +281,13 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       .eq('id', templateId)
     return res.status(500).json({ error: err?.message ?? 'Regenerate failed' })
   }
+}
+
+function formatAddress(row: any): string {
+  if (!row) return ''
+  const parts: string[] = []
+  if (row.address_line1) parts.push(String(row.address_line1))
+  const cityState = [row.city, row.state].filter(Boolean).join(', ')
+  if (cityState) parts.push(cityState)
+  return parts.join(', ')
 }

--- a/api/scheduler/templates/index.ts
+++ b/api/scheduler/templates/index.ts
@@ -212,7 +212,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       return {
         service_location_id: r.sl.id,
         property_id: r.sl.property_id,
-        address: propRow?.address_line1 ?? '',
+        address: formatAddress(propRow),
         lat: Number(propRow?.latitude ?? NaN),
         lng: Number(propRow?.longitude ?? NaN),
         parent_offering_id: r.offering.id,
@@ -332,4 +332,16 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   }
 
   return res.status(405).json({ error: 'Method not allowed' })
+}
+
+// Compose "123 Main St, Plano, TX" from a properties row. Falls back
+// gracefully when city/state are missing so unplaced rows still
+// surface something useful.
+function formatAddress(row: any): string {
+  if (!row) return ''
+  const parts: string[] = []
+  if (row.address_line1) parts.push(String(row.address_line1))
+  const cityState = [row.city, row.state].filter(Boolean).join(', ')
+  if (cityState) parts.push(cityState)
+  return parts.join(', ')
 }


### PR DESCRIPTION
## Why
Unplaced rows showed just \`address_line1\` ("123 Main St"). Not enough to identify the property when you're trying to figure out why something couldn't fit.

## Fix
Format the address as \`"{address_line1}, {city}, {state}"\` in both \`POST /scheduler/templates\` and \`POST /scheduler/templates/[id]/regenerate\` where \`PropertyForBuild\` is constructed. Falls back gracefully when city or state is missing.

The same \`address\` field flows into route stops too, so cycle visits will also show the fuller address.

## Test plan
- [ ] Regenerate template → Unplaced tab now shows "123 Main St, Plano, TX" instead of just "123 Main St"
- [ ] Cycle detail visit rows show the same fuller address
- [ ] Properties with missing city or state degrade cleanly (no trailing commas)

🤖 Generated with [Claude Code](https://claude.com/claude-code)