### PR TITLE
Phase 4f-1: scheduler view scaffold + crew utilization + undo/redo foundation

### DIFF
--- a/api/_lib/scheduler/crew-utilization.ts
+++ b/api/_lib/scheduler/crew-utilization.ts
@@ -1,0 +1,220 @@
+// Phase 4f — crew utilization computation.
+//
+// For each crew × workday in a cycle, classify the day's state. This
+// powers the color-coding on every view (Gantt cells, calendar bars,
+// map crew status, list state column).
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+export type CrewDayStateKind =
+  | 'fully_utilized'
+  | 'partial'
+  | 'idle'
+  | 'between_trips'
+  | 'travel_day'
+  | 'rest_day'
+  | 'overnight_continuation'
+
+export interface CrewDayState {
+  kind: CrewDayStateKind
+  work_hours: number
+  unused_hours: number
+  // For 'between_trips': info about the surrounding trips.
+  last_trip_end?: string
+  next_trip_start?: string
+  gap_days?: number
+  // For 'overnight_continuation': flags away-from-branch.
+  away_from_branch?: boolean
+}
+
+export interface CrewUtilizationDay {
+  crew_index: number
+  crew_label: string
+  scheduled_date: string // 'YYYY-MM-DD'
+  state: CrewDayState
+  work_hours_scheduled: number
+  work_hours_capacity: number
+  utilization_pct: number
+  is_workday: boolean
+  // Pass-through for UI rendering
+  trip_id: string | null
+  trip_label: string | null
+  trip_day_number: number | null
+  trip_total_days: number | null
+  day_type: string | null
+}
+
+interface ComputeOptions {
+  include_weekends?: boolean
+  workdays_capacity_hours?: number
+  between_trips_gap_max_days?: number
+}
+
+const DEFAULT_CAPACITY_HOURS = 8
+const DEFAULT_GAP_MAX_DAYS = 3
+
+export async function computeCrewUtilization(
+  db: SupabaseClient,
+  cycleInstanceId: string,
+  options: ComputeOptions = {}
+): Promise<CrewUtilizationDay[]> {
+  const includeWeekends = options.include_weekends ?? false
+  const capacity = options.workdays_capacity_hours ?? DEFAULT_CAPACITY_HOURS
+  const gapMax = options.between_trips_gap_max_days ?? DEFAULT_GAP_MAX_DAYS
+
+  const { data: cycle, error: cycleErr } = await db
+    .from('cycle_instances')
+    .select('id, start_date, end_date, template_id')
+    .eq('id', cycleInstanceId)
+    .single()
+  if (cycleErr || !cycle) throw new Error('Cycle not found')
+
+  const { data: tpl } = await db
+    .from('routing_templates')
+    .select('crew_count, crew_assignments')
+    .eq('id', (cycle as any).template_id)
+    .single()
+  const crewCount = (tpl as any)?.crew_count ?? 1
+
+  const { data: routes } = await db
+    .from('crew_day_routes')
+    .select(
+      'crew_index, crew_label, scheduled_date, day_type, total_work_minutes, trip_id, trip_label, trip_day_number, trip_total_days'
+    )
+    .eq('cycle_instance_id', cycleInstanceId)
+
+  // Index routes by (crew_index, scheduled_date) for O(1) lookup.
+  const routeByKey = new Map<string, any>()
+  for (const r of routes ?? []) {
+    const row = r as any
+    routeByKey.set(`${row.crew_index}|${row.scheduled_date}`, row)
+  }
+
+  // Build the calendar of workdays in the cycle.
+  const start = new Date((cycle as any).start_date + 'T00:00:00Z')
+  const end = new Date((cycle as any).end_date + 'T00:00:00Z')
+  const days: string[] = []
+  for (
+    let d = new Date(start);
+    d <= end;
+    d.setUTCDate(d.getUTCDate() + 1)
+  ) {
+    const dow = d.getUTCDay()
+    const isWeekend = dow === 0 || dow === 6
+    if (!includeWeekends && isWeekend) continue
+    days.push(d.toISOString().slice(0, 10))
+  }
+
+  // First pass: classify each (crew, day) without between-trips context.
+  const initial: CrewUtilizationDay[] = []
+  for (let crewIdx = 0; crewIdx < crewCount; crewIdx++) {
+    for (const date of days) {
+      const route = routeByKey.get(`${crewIdx}|${date}`)
+      if (route) {
+        const workHours = (route.total_work_minutes ?? 0) / 60
+        const utilPct =
+          capacity > 0 ? Math.round((workHours / capacity) * 100) : 0
+        let kind: CrewDayStateKind
+        if (route.day_type === 'travel') {
+          kind = 'travel_day'
+        } else if (route.day_type === 'rest') {
+          kind = 'rest_day'
+        } else if (
+          route.trip_total_days &&
+          route.trip_total_days > 1 &&
+          route.trip_day_number != null &&
+          route.trip_day_number < route.trip_total_days &&
+          route.trip_day_number > 1
+        ) {
+          // Mid-stretch of a multi-day overnight trip.
+          kind = 'overnight_continuation'
+        } else if (utilPct >= 90) {
+          kind = 'fully_utilized'
+        } else if (utilPct >= 30) {
+          kind = 'partial'
+        } else {
+          kind = 'idle'
+        }
+        initial.push({
+          crew_index: crewIdx,
+          crew_label: route.crew_label ?? `Crew ${crewIdx + 1}`,
+          scheduled_date: date,
+          state: {
+            kind,
+            work_hours: workHours,
+            unused_hours: Math.max(0, capacity - workHours),
+            away_from_branch: kind === 'overnight_continuation',
+          },
+          work_hours_scheduled: workHours,
+          work_hours_capacity: capacity,
+          utilization_pct: utilPct,
+          is_workday: true,
+          trip_id: route.trip_id ?? null,
+          trip_label: route.trip_label ?? null,
+          trip_day_number: route.trip_day_number ?? null,
+          trip_total_days: route.trip_total_days ?? null,
+          day_type: route.day_type ?? null,
+        })
+      } else {
+        initial.push({
+          crew_index: crewIdx,
+          crew_label: `Crew ${crewIdx + 1}`,
+          scheduled_date: date,
+          state: { kind: 'idle', work_hours: 0, unused_hours: capacity },
+          work_hours_scheduled: 0,
+          work_hours_capacity: capacity,
+          utilization_pct: 0,
+          is_workday: true,
+          trip_id: null,
+          trip_label: null,
+          trip_day_number: null,
+          trip_total_days: null,
+          day_type: null,
+        })
+      }
+    }
+  }
+
+  // Second pass: convert 'idle' to 'between_trips' when surrounded by
+  // trips within the gap-max window.
+  const byCrew = new Map<number, CrewUtilizationDay[]>()
+  for (const d of initial) {
+    const arr = byCrew.get(d.crew_index) ?? []
+    arr.push(d)
+    byCrew.set(d.crew_index, arr)
+  }
+  for (const arr of byCrew.values()) {
+    arr.sort((a, b) => a.scheduled_date.localeCompare(b.scheduled_date))
+    for (let i = 0; i < arr.length; i++) {
+      const day = arr[i]
+      if (day.state.kind !== 'idle') continue
+      // Look back for the previous workday with work
+      let prevWorkIdx = -1
+      for (let j = i - 1; j >= Math.max(0, i - gapMax); j--) {
+        if (arr[j].state.kind !== 'idle') {
+          prevWorkIdx = j
+          break
+        }
+      }
+      // Look forward for the next workday with work
+      let nextWorkIdx = -1
+      for (let j = i + 1; j < Math.min(arr.length, i + 1 + gapMax); j++) {
+        if (arr[j].state.kind !== 'idle') {
+          nextWorkIdx = j
+          break
+        }
+      }
+      if (prevWorkIdx !== -1 && nextWorkIdx !== -1) {
+        day.state = {
+          kind: 'between_trips',
+          work_hours: 0,
+          unused_hours: capacity,
+          last_trip_end: arr[prevWorkIdx].scheduled_date,
+          next_trip_start: arr[nextWorkIdx].scheduled_date,
+          gap_days: nextWorkIdx - prevWorkIdx - 1,
+        }
+      }
+    }
+  }
+
+  return initial
+}

--- a/api/_lib/scheduler/edit-history.ts
+++ b/api/_lib/scheduler/edit-history.ts
@@ -1,0 +1,199 @@
+// Phase 4f — undo stack helpers.
+//
+// Every cycle-level edit endpoint must:
+//   1. Compute reverse_payload BEFORE applying the change
+//   2. Apply the change
+//   3. recordEdit() with both payloads
+//   4. invalidateRedoBranch() to drop any newer-but-undone entries
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+export type EditType =
+  | 'move_visit'
+  | 'move_trip'
+  | 'reassign_cluster'
+  | 'add_visit'
+  | 'remove_visit'
+  | 'lock_visit'
+  | 'unlock_visit'
+  | 'lock_day'
+  | 'unlock_day'
+  | 'mark_complete'
+  | 'mark_cancelled'
+  | 'bulk_operation'
+
+export interface RecordEditInput {
+  cycle_instance_id: string
+  edit_type: EditType
+  forward_payload: Record<string, unknown>
+  reverse_payload: Record<string, unknown>
+  description: string
+  edited_by?: string | null
+  propagated_to_template?: boolean
+  template_change_payload?: Record<string, unknown> | null
+}
+
+export async function recordEdit(
+  db: SupabaseClient,
+  input: RecordEditInput
+): Promise<{ id: string; edit_index: number }> {
+  // Drop any "redo" branch — new edits invalidate previously-undone ones.
+  await db
+    .from('cycle_edit_history')
+    .delete()
+    .eq('cycle_instance_id', input.cycle_instance_id)
+    .eq('is_active', false)
+
+  // Next index = max(edit_index) + 1, or 1 if none.
+  const { data: latest } = await db
+    .from('cycle_edit_history')
+    .select('edit_index')
+    .eq('cycle_instance_id', input.cycle_instance_id)
+    .order('edit_index', { ascending: false })
+    .limit(1)
+    .maybeSingle()
+  const nextIndex = (latest as { edit_index?: number } | null)?.edit_index
+    ? (latest as { edit_index: number }).edit_index + 1
+    : 1
+
+  const { data, error } = await db
+    .from('cycle_edit_history')
+    .insert({
+      cycle_instance_id: input.cycle_instance_id,
+      edit_index: nextIndex,
+      edit_type: input.edit_type,
+      forward_payload: input.forward_payload,
+      reverse_payload: input.reverse_payload,
+      propagated_to_template: input.propagated_to_template ?? false,
+      template_change_payload: input.template_change_payload ?? null,
+      description: input.description,
+      edited_by: input.edited_by ?? null,
+      is_active: true,
+    })
+    .select('id, edit_index')
+    .single()
+  if (error) throw new Error(`recordEdit: ${error.message}`)
+
+  // Trim to last 50 active entries — keep the table bounded per cycle.
+  await trimHistory(db, input.cycle_instance_id, 50)
+
+  return data as { id: string; edit_index: number }
+}
+
+async function trimHistory(
+  db: SupabaseClient,
+  cycleInstanceId: string,
+  keep: number
+): Promise<void> {
+  const { data: ids } = await db
+    .from('cycle_edit_history')
+    .select('id, edit_index')
+    .eq('cycle_instance_id', cycleInstanceId)
+    .eq('is_active', true)
+    .order('edit_index', { ascending: false })
+    .range(keep, keep + 1000) // anything past `keep`
+  const toDelete = (ids ?? []).map((r) => (r as { id: string }).id)
+  if (toDelete.length === 0) return
+  await db.from('cycle_edit_history').delete().in('id', toDelete)
+}
+
+// Apply a payload to scheduled_visits — used by both the original
+// edit endpoints and the undo/redo flow. Keeps the apply logic in one
+// place so undo doesn't drift from the forward path.
+export interface VisitMovePayload {
+  visit_id: string
+  to_date: string
+  to_crew_index?: number
+  to_sequence?: number
+}
+export async function applyVisitMove(
+  db: SupabaseClient,
+  payload: VisitMovePayload
+): Promise<void> {
+  const update: Record<string, unknown> = {
+    scheduled_date: payload.to_date,
+    updated_at: new Date().toISOString(),
+  }
+  if (payload.to_sequence != null) update.sequence_in_day = payload.to_sequence
+  await db.from('scheduled_visits').update(update).eq('id', payload.visit_id)
+}
+
+export interface VisitLockPayload {
+  visit_id: string
+  is_locked: boolean
+  locked_by?: string | null
+}
+export async function applyVisitLock(
+  db: SupabaseClient,
+  payload: VisitLockPayload
+): Promise<void> {
+  const update = payload.is_locked
+    ? {
+        is_locked: true,
+        locked_at: new Date().toISOString(),
+        locked_by: payload.locked_by ?? null,
+        updated_at: new Date().toISOString(),
+      }
+    : {
+        is_locked: false,
+        locked_at: null,
+        locked_by: null,
+        updated_at: new Date().toISOString(),
+      }
+  await db.from('scheduled_visits').update(update).eq('id', payload.visit_id)
+}
+
+export interface VisitStatusPayload {
+  visit_id: string
+  status: 'placed' | 'completed' | 'cancelled' | 'unplaced'
+  completed_at?: string | null
+}
+export async function applyVisitStatus(
+  db: SupabaseClient,
+  payload: VisitStatusPayload
+): Promise<void> {
+  const update: Record<string, unknown> = {
+    status: payload.status,
+    updated_at: new Date().toISOString(),
+  }
+  if (payload.status === 'completed') {
+    update.completed_at = payload.completed_at ?? new Date().toISOString()
+  } else if (payload.status === 'placed') {
+    update.completed_at = null
+  }
+  await db.from('scheduled_visits').update(update).eq('id', payload.visit_id)
+}
+
+// Reverse application: given a history row, apply its reverse_payload
+// based on edit_type. Returns the resulting state for the caller.
+export async function applyReverse(
+  db: SupabaseClient,
+  edit_type: EditType,
+  reverse: Record<string, unknown>
+): Promise<void> {
+  switch (edit_type) {
+    case 'move_visit':
+      await applyVisitMove(db, reverse as unknown as VisitMovePayload)
+      break
+    case 'lock_visit':
+    case 'unlock_visit':
+      await applyVisitLock(db, reverse as unknown as VisitLockPayload)
+      break
+    case 'mark_complete':
+    case 'mark_cancelled':
+      await applyVisitStatus(db, reverse as unknown as VisitStatusPayload)
+      break
+    default:
+      // Other edit types not yet supported in undo; surface to caller.
+      throw new Error(`Undo not yet supported for edit_type: ${edit_type}`)
+  }
+}
+
+export async function applyForward(
+  db: SupabaseClient,
+  edit_type: EditType,
+  forward: Record<string, unknown>
+): Promise<void> {
+  // Forward and reverse use the same applier shapes — they just carry
+  // different "to" values.
+  await applyReverse(db, edit_type, forward)
+}

--- a/api/scheduler/cycles/[cycleId]/crew-utilization.ts
+++ b/api/scheduler/cycles/[cycleId]/crew-utilization.ts
@@ -1,0 +1,23 @@
+// GET /api/scheduler/cycles/[cycleId]/crew-utilization
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { createAdminClient } from '../../../_lib/supabase.js'
+import { authenticateRequest } from '../../../_lib/auth.js'
+import { computeCrewUtilization } from '../../../_lib/scheduler/crew-utilization.js'
+
+export const config = { maxDuration: 30 }
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'GET') return res.status(405).json({ error: 'Method not allowed' })
+  try { await authenticateRequest(req) } catch (err: any) {
+    return res.status(err.statusCode ?? 401).json({ error: err.message ?? 'Unauthorized' })
+  }
+  const cycleId = req.query.cycleId as string
+  const includeWeekends = String(req.query.include_weekends ?? '').toLowerCase() === 'true'
+  const db = createAdminClient()
+  try {
+    const days = await computeCrewUtilization(db, cycleId, { include_weekends: includeWeekends })
+    return res.status(200).json({ days })
+  } catch (err: any) {
+    return res.status(500).json({ error: err?.message ?? String(err) })
+  }
+}

--- a/api/scheduler/cycles/[cycleId]/edit-history.ts
+++ b/api/scheduler/cycles/[cycleId]/edit-history.ts
@@ -1,0 +1,22 @@
+// GET /api/scheduler/cycles/[cycleId]/edit-history
+// Returns the last 50 edits (active + undone) for the history drawer.
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { createAdminClient } from '../../../_lib/supabase.js'
+import { authenticateRequest } from '../../../_lib/auth.js'
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'GET') return res.status(405).json({ error: 'Method not allowed' })
+  try { await authenticateRequest(req) } catch (err: any) {
+    return res.status(err.statusCode ?? 401).json({ error: err.message ?? 'Unauthorized' })
+  }
+  const cycleId = req.query.cycleId as string
+  const db = createAdminClient()
+  const { data, error } = await db
+    .from('cycle_edit_history')
+    .select('id, edit_index, edit_type, description, edited_by, edited_at, is_active, undone_at, propagated_to_template')
+    .eq('cycle_instance_id', cycleId)
+    .order('edit_index', { ascending: false })
+    .limit(50)
+  if (error) return res.status(500).json({ error: error.message })
+  return res.status(200).json({ edits: data ?? [] })
+}

--- a/api/scheduler/cycles/[cycleId]/redo.ts
+++ b/api/scheduler/cycles/[cycleId]/redo.ts
@@ -1,0 +1,38 @@
+// POST /api/scheduler/cycles/[cycleId]/redo
+// Reapplies the most recently undone edit.
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { createAdminClient } from '../../../_lib/supabase.js'
+import { authenticateRequest } from '../../../_lib/auth.js'
+import { applyForward, type EditType } from '../../../_lib/scheduler/edit-history.js'
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'POST') return res.status(405).json({ error: 'Method not allowed' })
+  try { await authenticateRequest(req) } catch (err: any) {
+    return res.status(err.statusCode ?? 401).json({ error: err.message ?? 'Unauthorized' })
+  }
+  const cycleId = req.query.cycleId as string
+  const db = createAdminClient()
+
+  const { data: undone } = await db
+    .from('cycle_edit_history')
+    .select('id, edit_type, forward_payload, edit_index, description')
+    .eq('cycle_instance_id', cycleId)
+    .eq('is_active', false)
+    .order('undone_at', { ascending: false })
+    .limit(1)
+    .maybeSingle()
+  if (!undone) return res.status(400).json({ error: 'Nothing to redo' })
+  const row = undone as any
+  try {
+    await applyForward(db, row.edit_type as EditType, row.forward_payload as Record<string, unknown>)
+  } catch (err: any) {
+    return res.status(500).json({ error: err?.message ?? 'Redo failed' })
+  }
+  await db
+    .from('cycle_edit_history')
+    .update({ is_active: true, undone_at: null })
+    .eq('id', row.id)
+  return res.status(200).json({
+    redone: { id: row.id, edit_index: row.edit_index, description: row.description },
+  })
+}

--- a/api/scheduler/cycles/[cycleId]/undo.ts
+++ b/api/scheduler/cycles/[cycleId]/undo.ts
@@ -1,0 +1,38 @@
+// POST /api/scheduler/cycles/[cycleId]/undo
+// Reverses the most recent active edit.
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { createAdminClient } from '../../../_lib/supabase.js'
+import { authenticateRequest } from '../../../_lib/auth.js'
+import { applyReverse, type EditType } from '../../../_lib/scheduler/edit-history.js'
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'POST') return res.status(405).json({ error: 'Method not allowed' })
+  try { await authenticateRequest(req) } catch (err: any) {
+    return res.status(err.statusCode ?? 401).json({ error: err.message ?? 'Unauthorized' })
+  }
+  const cycleId = req.query.cycleId as string
+  const db = createAdminClient()
+
+  const { data: latest } = await db
+    .from('cycle_edit_history')
+    .select('id, edit_type, reverse_payload, edit_index, description')
+    .eq('cycle_instance_id', cycleId)
+    .eq('is_active', true)
+    .order('edit_index', { ascending: false })
+    .limit(1)
+    .maybeSingle()
+  if (!latest) return res.status(400).json({ error: 'Nothing to undo' })
+  const row = latest as any
+  try {
+    await applyReverse(db, row.edit_type as EditType, row.reverse_payload as Record<string, unknown>)
+  } catch (err: any) {
+    return res.status(500).json({ error: err?.message ?? 'Undo failed' })
+  }
+  await db
+    .from('cycle_edit_history')
+    .update({ is_active: false, undone_at: new Date().toISOString() })
+    .eq('id', row.id)
+  return res.status(200).json({
+    undone: { id: row.id, edit_index: row.edit_index, description: row.description },
+  })
+}

--- a/api/scheduler/visits/[visitId]/lock.ts
+++ b/api/scheduler/visits/[visitId]/lock.ts
@@ -3,6 +3,7 @@ import type { VercelRequest, VercelResponse } from '@vercel/node'
 import { createAdminClient } from '../../../_lib/supabase.js'
 import { authenticateRequest } from '../../../_lib/auth.js'
 import { lockVisit } from '../../../_lib/scheduler/edit-propagation.js'
+import { recordEdit } from '../../../_lib/scheduler/edit-history.js'
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method !== 'POST') return res.status(405).json({ error: 'Method not allowed' })
@@ -12,6 +13,29 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   }
   const visitId = req.query.visitId as string
   const db = createAdminClient()
+  const { data: before } = await db
+    .from('scheduled_visits')
+    .select('cycle_instance_id, is_locked, locked_by, service_locations(display_name)')
+    .eq('id', visitId)
+    .single()
+  const beforeRow = before as any
+
   await lockVisit(db, visitId, ctx.email ?? ctx.userId ?? null)
+
+  if (beforeRow?.cycle_instance_id) {
+    const addr = beforeRow.service_locations?.display_name ?? visitId.slice(0, 8)
+    try {
+      await recordEdit(db, {
+        cycle_instance_id: beforeRow.cycle_instance_id,
+        edit_type: 'lock_visit',
+        forward_payload: { visit_id: visitId, is_locked: true, locked_by: ctx.email ?? ctx.userId ?? null },
+        reverse_payload: { visit_id: visitId, is_locked: !!beforeRow.is_locked, locked_by: beforeRow.locked_by },
+        description: `Locked "${addr}"`,
+        edited_by: ctx.email ?? ctx.userId ?? null,
+      })
+    } catch (err) {
+      console.error('[lock-visit] history record failed:', err)
+    }
+  }
   return res.status(200).json({ ok: true })
 }

--- a/api/scheduler/visits/[visitId]/mark-completed.ts
+++ b/api/scheduler/visits/[visitId]/mark-completed.ts
@@ -6,18 +6,49 @@ import type { VercelRequest, VercelResponse } from '@vercel/node'
 import { createAdminClient } from '../../../_lib/supabase.js'
 import { authenticateRequest } from '../../../_lib/auth.js'
 import { markVisitCompleted } from '../../../_lib/scheduler/edit-propagation.js'
+import { recordEdit } from '../../../_lib/scheduler/edit-history.js'
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method !== 'POST') return res.status(405).json({ error: 'Method not allowed' })
-  try { await authenticateRequest(req) } catch (err: any) {
+  let ctx
+  try { ctx = await authenticateRequest(req) } catch (err: any) {
     return res.status(err.statusCode ?? 401).json({ error: err.message ?? 'Unauthorized' })
   }
   const visitId = req.query.visitId as string
   const body = (req.body ?? {}) as Record<string, unknown>
   const completionDate = (body.completion_date as string | undefined) ?? null
   const db = createAdminClient()
+  const { data: before } = await db
+    .from('scheduled_visits')
+    .select('cycle_instance_id, status, completed_at, service_locations(display_name)')
+    .eq('id', visitId)
+    .single()
+  const beforeRow = before as any
   try {
     const result = await markVisitCompleted(db, visitId, completionDate)
+    if (beforeRow?.cycle_instance_id) {
+      const addr = beforeRow.service_locations?.display_name ?? visitId.slice(0, 8)
+      try {
+        await recordEdit(db, {
+          cycle_instance_id: beforeRow.cycle_instance_id,
+          edit_type: 'mark_complete',
+          forward_payload: {
+            visit_id: visitId,
+            status: 'completed',
+            completed_at: completionDate ?? new Date().toISOString().slice(0, 10),
+          },
+          reverse_payload: {
+            visit_id: visitId,
+            status: beforeRow.status ?? 'placed',
+            completed_at: beforeRow.completed_at ?? null,
+          },
+          description: `Marked "${addr}" completed`,
+          edited_by: ctx.email ?? ctx.userId ?? null,
+        })
+      } catch (err) {
+        console.error('[mark-completed] history record failed:', err)
+      }
+    }
     return res.status(200).json(result)
   } catch (err: any) {
     return res.status(500).json({ error: err?.message ?? String(err) })

--- a/api/scheduler/visits/[visitId]/move.ts
+++ b/api/scheduler/visits/[visitId]/move.ts
@@ -4,6 +4,7 @@ import type { VercelRequest, VercelResponse } from '@vercel/node'
 import { createAdminClient } from '../../../_lib/supabase.js'
 import { authenticateRequest, type AuthContext } from '../../../_lib/auth.js'
 import { moveVisit } from '../../../_lib/scheduler/edit-propagation.js'
+import { recordEdit } from '../../../_lib/scheduler/edit-history.js'
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method !== 'POST') return res.status(405).json({ error: 'Method not allowed' })
@@ -15,6 +16,14 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   const body = (req.body ?? {}) as Record<string, unknown>
   const db = createAdminClient()
   try {
+    // Snapshot pre-edit state for the reverse payload + history description.
+    const { data: before } = await db
+      .from('scheduled_visits')
+      .select('cycle_instance_id, scheduled_date, sequence_in_day, service_locations(display_name, property:properties(address_line1))')
+      .eq('id', visitId)
+      .single()
+    const beforeRow = before as any
+
     const result = await moveVisit(db, {
       visitId,
       newScheduledDate: body.new_scheduled_date as string | undefined,
@@ -23,6 +32,35 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       propagateToTemplate: body.propagate_to_template === true,
       editedBy: ctx.email ?? ctx.userId ?? null,
     })
+
+    if (beforeRow?.cycle_instance_id) {
+      const newDate = (body.new_scheduled_date as string | undefined) ?? beforeRow.scheduled_date
+      const newSeq = (body.new_sequence as number | undefined) ?? beforeRow.sequence_in_day
+      const addr = beforeRow.service_locations?.display_name
+        ?? beforeRow.service_locations?.property?.address_line1
+        ?? visitId.slice(0, 8)
+      try {
+        await recordEdit(db, {
+          cycle_instance_id: beforeRow.cycle_instance_id,
+          edit_type: 'move_visit',
+          forward_payload: {
+            visit_id: visitId,
+            to_date: newDate,
+            to_sequence: newSeq,
+          },
+          reverse_payload: {
+            visit_id: visitId,
+            to_date: beforeRow.scheduled_date,
+            to_sequence: beforeRow.sequence_in_day,
+          },
+          description: `Moved "${addr}" from ${beforeRow.scheduled_date} to ${newDate}`,
+          edited_by: ctx.email ?? ctx.userId ?? null,
+          propagated_to_template: result.template_updated,
+        })
+      } catch (err) {
+        console.error('[move-visit] history record failed:', err)
+      }
+    }
     return res.status(200).json(result)
   } catch (err: any) {
     return res.status(500).json({ error: err?.message ?? String(err) })

--- a/api/scheduler/visits/[visitId]/unlock.ts
+++ b/api/scheduler/visits/[visitId]/unlock.ts
@@ -3,14 +3,39 @@ import type { VercelRequest, VercelResponse } from '@vercel/node'
 import { createAdminClient } from '../../../_lib/supabase.js'
 import { authenticateRequest } from '../../../_lib/auth.js'
 import { unlockVisit } from '../../../_lib/scheduler/edit-propagation.js'
+import { recordEdit } from '../../../_lib/scheduler/edit-history.js'
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method !== 'POST') return res.status(405).json({ error: 'Method not allowed' })
-  try { await authenticateRequest(req) } catch (err: any) {
+  let ctx
+  try { ctx = await authenticateRequest(req) } catch (err: any) {
     return res.status(err.statusCode ?? 401).json({ error: err.message ?? 'Unauthorized' })
   }
   const visitId = req.query.visitId as string
   const db = createAdminClient()
+  const { data: before } = await db
+    .from('scheduled_visits')
+    .select('cycle_instance_id, is_locked, locked_by, service_locations(display_name)')
+    .eq('id', visitId)
+    .single()
+  const beforeRow = before as any
+
   await unlockVisit(db, visitId)
+
+  if (beforeRow?.cycle_instance_id) {
+    const addr = beforeRow.service_locations?.display_name ?? visitId.slice(0, 8)
+    try {
+      await recordEdit(db, {
+        cycle_instance_id: beforeRow.cycle_instance_id,
+        edit_type: 'unlock_visit',
+        forward_payload: { visit_id: visitId, is_locked: false },
+        reverse_payload: { visit_id: visitId, is_locked: !!beforeRow.is_locked, locked_by: beforeRow.locked_by },
+        description: `Unlocked "${addr}"`,
+        edited_by: ctx.email ?? ctx.userId ?? null,
+      })
+    } catch (err) {
+      console.error('[unlock-visit] history record failed:', err)
+    }
+  }
   return res.status(200).json({ ok: true })
 }

--- a/src/components/scheduler/CalendarView.tsx
+++ b/src/components/scheduler/CalendarView.tsx
@@ -1,0 +1,164 @@
+// Phase 4f-1 MVP Calendar view — month grid with crew bars per day.
+// Drag-drop ships in 4f-2.
+import { useMemo } from 'react'
+import { ChevronLeft, ChevronRight, AlertTriangle } from 'lucide-react'
+import { useState } from 'react'
+import Button from '../ui/Button'
+import { cn } from '../../lib/cn'
+import type { UtilDay } from './GanttView'
+
+const CREW_COLORS = [
+  'bg-indigo-500',
+  'bg-teal-500',
+  'bg-amber-500',
+  'bg-rose-500',
+  'bg-emerald-500',
+  'bg-violet-500',
+  'bg-slate-500',
+]
+
+const MONTH_NAMES = [
+  'January', 'February', 'March', 'April', 'May', 'June',
+  'July', 'August', 'September', 'October', 'November', 'December',
+]
+
+interface Props {
+  days: UtilDay[]
+  onDayClick?: (date: string) => void
+}
+
+export default function CalendarView({ days, onDayClick }: Props) {
+  const dates = useMemo(() => {
+    const set = new Set(days.map((d) => d.scheduled_date))
+    return Array.from(set).sort()
+  }, [days])
+
+  const [monthIndex, setMonthIndex] = useState(0)
+
+  // Group dates into months for navigation
+  const months = useMemo(() => {
+    const m = new Map<string, string[]>()
+    for (const d of dates) {
+      const key = d.slice(0, 7) // YYYY-MM
+      const arr = m.get(key) ?? []
+      arr.push(d)
+      m.set(key, arr)
+    }
+    return Array.from(m.keys()).sort()
+  }, [dates])
+
+  // Build per-date crew bar data
+  const cellsByDate = useMemo(() => {
+    const map = new Map<string, UtilDay[]>()
+    for (const d of days) {
+      const arr = map.get(d.scheduled_date) ?? []
+      arr.push(d)
+      map.set(d.scheduled_date, arr)
+    }
+    for (const arr of map.values()) arr.sort((a, b) => a.crew_index - b.crew_index)
+    return map
+  }, [days])
+
+  if (months.length === 0) {
+    return (
+      <div className="rounded-md border border-border bg-surface p-6 text-sm text-fg-muted">
+        No crew-days to display. Generate a cycle first.
+      </div>
+    )
+  }
+
+  const currentMonthKey = months[Math.min(monthIndex, months.length - 1)]
+  const [year, month] = currentMonthKey.split('-').map(Number)
+  // Build 7-col grid for the calendar (Sunday-start). Pad with blanks.
+  const firstDay = new Date(Date.UTC(year, month - 1, 1))
+  const padBefore = firstDay.getUTCDay()
+  const daysInMonth = new Date(Date.UTC(year, month, 0)).getUTCDate()
+  const cells: Array<{ date: string | null; dom: number | null }> = []
+  for (let i = 0; i < padBefore; i++) cells.push({ date: null, dom: null })
+  for (let d = 1; d <= daysInMonth; d++) {
+    const dt = new Date(Date.UTC(year, month - 1, d)).toISOString().slice(0, 10)
+    cells.push({ date: dt, dom: d })
+  }
+  // Pad to next 7 boundary
+  while (cells.length % 7 !== 0) cells.push({ date: null, dom: null })
+
+  return (
+    <div className="rounded-md border border-border bg-surface overflow-hidden">
+      <div className="flex items-center justify-between border-b border-border px-3 py-2 bg-surface-subtle">
+        <Button
+          size="sm"
+          variant="ghost"
+          disabled={monthIndex === 0}
+          onClick={() => setMonthIndex((i) => Math.max(0, i - 1))}
+        >
+          <ChevronLeft className="h-3.5 w-3.5" />
+        </Button>
+        <p className="text-sm font-semibold text-fg">
+          {MONTH_NAMES[month - 1]} {year}
+        </p>
+        <Button
+          size="sm"
+          variant="ghost"
+          disabled={monthIndex === months.length - 1}
+          onClick={() => setMonthIndex((i) => Math.min(months.length - 1, i + 1))}
+        >
+          <ChevronRight className="h-3.5 w-3.5" />
+        </Button>
+      </div>
+
+      <div className="grid grid-cols-7 border-b border-border bg-surface-subtle">
+        {['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'].map((d) => (
+          <div key={d} className="px-2 py-1 text-[10px] uppercase tracking-wider text-fg-subtle font-semibold text-center">
+            {d}
+          </div>
+        ))}
+      </div>
+
+      <div className="grid grid-cols-7">
+        {cells.map((c, i) => {
+          if (!c.date) {
+            return <div key={i} className="border-r border-b border-border bg-surface-subtle/30" style={{ minHeight: 96 }} />
+          }
+          const cellDays = cellsByDate.get(c.date) ?? []
+          const hasIdle = cellDays.some((d) => d.state.kind === 'idle')
+          return (
+            <button
+              key={c.date}
+              type="button"
+              onClick={() => onDayClick?.(c.date!)}
+              className={cn(
+                'border-r border-b border-border p-1.5 text-left flex flex-col gap-1 hover:bg-surface-subtle transition-colors',
+                hasIdle && 'bg-warning/5'
+              )}
+              style={{ minHeight: 96 }}
+            >
+              <p className="text-xs font-tabular text-fg-muted">{c.dom}</p>
+              {cellDays.map((d) => {
+                const pct = d.utilization_pct
+                const isIdle = d.state.kind === 'idle' || d.state.kind === 'between_trips'
+                return (
+                  <div
+                    key={d.crew_index}
+                    className={cn(
+                      'h-1.5 rounded-sm',
+                      isIdle ? 'bg-fg-subtle/30' : CREW_COLORS[d.crew_index % CREW_COLORS.length],
+                      d.state.kind === 'partial' && 'opacity-50'
+                    )}
+                    style={{ width: `${Math.max(10, pct)}%` }}
+                    title={`${d.crew_label}: ${d.work_hours_scheduled.toFixed(1)}h · ${d.state.kind}`}
+                  />
+                )
+              })}
+              {hasIdle && (
+                <div className="text-[10px] text-danger flex items-center gap-1 mt-auto">
+                  <AlertTriangle className="h-2.5 w-2.5" />
+                  {cellDays.filter((d) => d.state.kind === 'idle').length} idle
+                </div>
+              )}
+            </button>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/src/components/scheduler/CrewUtilizationChip.tsx
+++ b/src/components/scheduler/CrewUtilizationChip.tsx
@@ -1,0 +1,92 @@
+// Phase 4f — small reusable chip showing a crew-day's state.
+// Used in Gantt cells, calendar bars, list rows, map crew status.
+import { AlertTriangle, Bed, Plane, Coffee } from 'lucide-react'
+import { cn } from '../../lib/cn'
+
+export type CrewDayStateKind =
+  | 'fully_utilized'
+  | 'partial'
+  | 'idle'
+  | 'between_trips'
+  | 'travel_day'
+  | 'rest_day'
+  | 'overnight_continuation'
+
+export interface CrewDayState {
+  kind: CrewDayStateKind
+  work_hours: number
+  unused_hours: number
+  away_from_branch?: boolean
+}
+
+const STATE_LABEL: Record<CrewDayStateKind, string> = {
+  fully_utilized: 'Full',
+  partial: 'Partial',
+  idle: 'Idle',
+  between_trips: 'Between',
+  travel_day: 'Travel',
+  rest_day: 'Rest',
+  overnight_continuation: 'Overnight',
+}
+
+export function stateClass(kind: CrewDayStateKind): string {
+  switch (kind) {
+    case 'fully_utilized':
+      return 'bg-accent/90 text-white border-accent'
+    case 'partial':
+      return 'bg-accent/40 text-fg border-accent/50'
+    case 'idle':
+      return 'bg-danger/15 text-danger border-danger/30'
+    case 'between_trips':
+      return 'bg-fg-subtle/15 text-fg-muted border-fg-subtle/20'
+    case 'travel_day':
+      return 'bg-warning/30 text-fg border-warning/40'
+    case 'rest_day':
+      return 'bg-surface-subtle text-fg-muted border-border'
+    case 'overnight_continuation':
+      return 'bg-accent/70 text-white border-accent'
+  }
+}
+
+export function StateIcon({ kind, className }: { kind: CrewDayStateKind; className?: string }) {
+  switch (kind) {
+    case 'idle':
+    case 'between_trips':
+      return <AlertTriangle className={cn('h-3 w-3', className)} />
+    case 'overnight_continuation':
+      return <Bed className={cn('h-3 w-3', className)} />
+    case 'travel_day':
+      return <Plane className={cn('h-3 w-3', className)} />
+    case 'rest_day':
+      return <Coffee className={cn('h-3 w-3', className)} />
+    default:
+      return null
+  }
+}
+
+export default function CrewUtilizationChip({
+  state,
+  utilization_pct,
+  size = 'sm',
+}: {
+  state: CrewDayState
+  utilization_pct: number
+  size?: 'sm' | 'md'
+}) {
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center gap-1 rounded border font-mono tabular-nums',
+        size === 'sm' ? 'px-1.5 py-0.5 text-[10px]' : 'px-2 py-1 text-xs',
+        stateClass(state.kind)
+      )}
+      title={`${STATE_LABEL[state.kind]} — ${state.work_hours.toFixed(1)}h scheduled`}
+    >
+      <StateIcon kind={state.kind} />
+      {STATE_LABEL[state.kind]}
+      {state.kind !== 'idle' && state.kind !== 'between_trips' && state.kind !== 'rest_day' && (
+        <span> · {utilization_pct}%</span>
+      )}
+    </span>
+  )
+}

--- a/src/components/scheduler/GanttView.tsx
+++ b/src/components/scheduler/GanttView.tsx
@@ -1,0 +1,183 @@
+// Phase 4f-1 MVP Gantt view — color-coded crew × day grid.
+// Drag-drop, multi-select, keyboard shortcuts ship in 4f-2.
+import { useMemo } from 'react'
+import { stateClass, StateIcon, type CrewDayStateKind } from './CrewUtilizationChip'
+import { cn } from '../../lib/cn'
+
+export interface UtilDay {
+  crew_index: number
+  crew_label: string
+  scheduled_date: string
+  state: { kind: CrewDayStateKind; work_hours: number; unused_hours: number }
+  work_hours_scheduled: number
+  work_hours_capacity: number
+  utilization_pct: number
+  trip_id: string | null
+  trip_label: string | null
+}
+
+interface Props {
+  days: UtilDay[]
+  onCellClick?: (day: UtilDay) => void
+}
+
+const CREW_COLORS = [
+  'bg-indigo-500',
+  'bg-teal-500',
+  'bg-amber-500',
+  'bg-rose-500',
+  'bg-emerald-500',
+  'bg-violet-500',
+  'bg-slate-500',
+]
+
+export default function GanttView({ days, onCellClick }: Props) {
+  // Group by crew, sort dates ascending. Build a sparse 2D grid keyed
+  // by crew_index → { date → day }.
+  const { crews, allDates } = useMemo(() => {
+    const crewMap = new Map<number, { label: string; cells: Map<string, UtilDay> }>()
+    const dateSet = new Set<string>()
+    for (const d of days) {
+      const slot = crewMap.get(d.crew_index) ?? { label: d.crew_label, cells: new Map() }
+      slot.cells.set(d.scheduled_date, d)
+      crewMap.set(d.crew_index, slot)
+      dateSet.add(d.scheduled_date)
+    }
+    const crews = Array.from(crewMap.entries())
+      .sort(([a], [b]) => a - b)
+      .map(([i, v]) => ({ index: i, label: v.label, cells: v.cells }))
+    const allDates = Array.from(dateSet).sort()
+    return { crews, allDates }
+  }, [days])
+
+  // Per-crew totals
+  const crewSummaries = useMemo(() => {
+    return crews.map((c) => {
+      const arr = Array.from(c.cells.values())
+      const idle = arr.filter((d) => d.state.kind === 'idle').length
+      const partial = arr.filter((d) => d.state.kind === 'partial').length
+      const between = arr.filter((d) => d.state.kind === 'between_trips').length
+      const fullDays = arr.filter((d) => d.state.kind === 'fully_utilized' || d.state.kind === 'overnight_continuation').length
+      const totalHours = arr.reduce((s, d) => s + d.work_hours_scheduled, 0)
+      const totalCapacity = arr.reduce((s, d) => s + d.work_hours_capacity, 0)
+      const util = totalCapacity > 0 ? Math.round((totalHours / totalCapacity) * 100) : 0
+      return { idle, partial, between, fullDays, totalHours, util }
+    })
+  }, [crews])
+
+  if (crews.length === 0) {
+    return (
+      <div className="rounded-md border border-border bg-surface p-6 text-sm text-fg-muted">
+        No crew-days to display. Generate a cycle first.
+      </div>
+    )
+  }
+
+  return (
+    <div className="rounded-md border border-border bg-surface overflow-hidden">
+      <div className="overflow-x-auto">
+        <table className="border-collapse min-w-full">
+          <thead>
+            <tr className="bg-surface-subtle">
+              <th className="sticky left-0 z-10 bg-surface-subtle border-b border-r border-border px-3 py-2 text-left text-[10px] uppercase tracking-wider text-fg-subtle font-semibold">
+                Crew
+              </th>
+              {allDates.map((d) => {
+                const dt = new Date(d + 'T00:00:00Z')
+                const isMonday = dt.getUTCDay() === 1
+                return (
+                  <th
+                    key={d}
+                    className={cn(
+                      'border-b border-border px-1 py-1 text-[9px] text-fg-subtle font-mono whitespace-nowrap',
+                      isMonday && 'border-l border-border-strong'
+                    )}
+                    style={{ minWidth: 28 }}
+                  >
+                    {dt.getUTCDate()}
+                  </th>
+                )
+              })}
+            </tr>
+          </thead>
+          <tbody>
+            {crews.map((crew, ci) => {
+              const summary = crewSummaries[ci]
+              return (
+                <tr key={crew.index}>
+                  <th
+                    className="sticky left-0 z-10 bg-surface border-b border-r border-border px-3 py-2 text-left whitespace-nowrap"
+                    style={{ minWidth: 180 }}
+                  >
+                    <div className="flex items-center gap-2">
+                      <span
+                        className={cn(
+                          'h-2.5 w-2.5 rounded-full',
+                          CREW_COLORS[ci % CREW_COLORS.length]
+                        )}
+                      />
+                      <div>
+                        <p className="text-sm font-medium text-fg">{crew.label}</p>
+                        <p className="text-[10px] text-fg-muted font-mono">
+                          {summary.util}% · {summary.idle}I {summary.partial}P {summary.between}B
+                        </p>
+                      </div>
+                    </div>
+                  </th>
+                  {allDates.map((d) => {
+                    const cell = crew.cells.get(d)
+                    if (!cell) {
+                      return (
+                        <td
+                          key={d}
+                          className="border-b border-border bg-surface-subtle/30"
+                          style={{ minWidth: 28, height: 36 }}
+                        />
+                      )
+                    }
+                    return (
+                      <td
+                        key={d}
+                        className={cn(
+                          'border-b border-border cursor-pointer transition-opacity hover:opacity-80',
+                          stateClass(cell.state.kind)
+                        )}
+                        style={{ minWidth: 28, height: 36 }}
+                        title={`${cell.crew_label} · ${cell.scheduled_date}\n${cell.work_hours_scheduled.toFixed(1)}h · ${cell.utilization_pct}%${cell.trip_label ? `\n${cell.trip_label}` : ''}`}
+                        onClick={() => onCellClick?.(cell)}
+                      >
+                        <div className="flex items-center justify-center h-full">
+                          <StateIcon kind={cell.state.kind} className="opacity-60" />
+                        </div>
+                      </td>
+                    )
+                  })}
+                </tr>
+              )
+            })}
+          </tbody>
+        </table>
+      </div>
+      <div className="border-t border-border bg-surface-subtle px-3 py-2 text-xs text-fg-muted flex items-center gap-4 flex-wrap">
+        <span className="flex items-center gap-1">
+          <span className="inline-block h-3 w-3 rounded bg-accent/90" /> Full
+        </span>
+        <span className="flex items-center gap-1">
+          <span className="inline-block h-3 w-3 rounded bg-accent/40" /> Partial
+        </span>
+        <span className="flex items-center gap-1">
+          <span className="inline-block h-3 w-3 rounded bg-danger/15 border border-danger/30" /> Idle
+        </span>
+        <span className="flex items-center gap-1">
+          <span className="inline-block h-3 w-3 rounded bg-fg-subtle/15 border border-fg-subtle/20" /> Between
+        </span>
+        <span className="flex items-center gap-1">
+          <span className="inline-block h-3 w-3 rounded bg-warning/30 border border-warning/40" /> Travel
+        </span>
+        <span className="flex items-center gap-1">
+          <span className="inline-block h-3 w-3 rounded bg-accent/70" /> Overnight
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/src/components/scheduler/HistoryDrawer.tsx
+++ b/src/components/scheduler/HistoryDrawer.tsx
@@ -1,0 +1,187 @@
+// Phase 4f-1 — undo/redo history drawer.
+// Floating button toggles the drawer. Lists last 50 edits with
+// undo/redo actions.
+import { useEffect, useState, useCallback } from 'react'
+import { History, Undo2, Redo2, X } from 'lucide-react'
+import { useAuth } from '../../hooks/useAuth'
+import Button from '../ui/Button'
+import { cn } from '../../lib/cn'
+
+interface EditRow {
+  id: string
+  edit_index: number
+  edit_type: string
+  description: string | null
+  edited_by: string | null
+  edited_at: string
+  is_active: boolean
+  undone_at: string | null
+  propagated_to_template: boolean
+}
+
+interface Props {
+  cycleId: string
+  onChange: () => void // called after undo/redo so caller can reload
+}
+
+export default function HistoryDrawer({ cycleId, onChange }: Props) {
+  const { getToken } = useAuth()
+  const [open, setOpen] = useState(false)
+  const [edits, setEdits] = useState<EditRow[]>([])
+  const [loading, setLoading] = useState(false)
+  const [busy, setBusy] = useState<'undo' | 'redo' | null>(null)
+
+  const load = useCallback(async () => {
+    if (!cycleId) return
+    setLoading(true)
+    try {
+      const token = await getToken()
+      const res = await fetch(`/api/scheduler/cycles/${cycleId}/edit-history`, {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      if (res.ok) {
+        const data = await res.json()
+        setEdits(data.edits ?? [])
+      }
+    } finally {
+      setLoading(false)
+    }
+  }, [cycleId, getToken])
+
+  useEffect(() => {
+    if (open) load()
+  }, [open, load])
+
+  const undo = useCallback(async () => {
+    setBusy('undo')
+    try {
+      const token = await getToken()
+      const res = await fetch(`/api/scheduler/cycles/${cycleId}/undo`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      if (res.ok) {
+        await load()
+        onChange()
+      }
+    } finally {
+      setBusy(null)
+    }
+  }, [cycleId, getToken, load, onChange])
+
+  const redo = useCallback(async () => {
+    setBusy('redo')
+    try {
+      const token = await getToken()
+      const res = await fetch(`/api/scheduler/cycles/${cycleId}/redo`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      if (res.ok) {
+        await load()
+        onChange()
+      }
+    } finally {
+      setBusy(null)
+    }
+  }, [cycleId, getToken, load, onChange])
+
+  // Keyboard shortcuts: H toggles drawer, Cmd+Z undo, Cmd+Shift+Z redo
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      // Don't intercept when typing in inputs
+      const target = e.target as HTMLElement
+      if (target?.tagName === 'INPUT' || target?.tagName === 'TEXTAREA' || target?.isContentEditable) return
+      const meta = e.metaKey || e.ctrlKey
+      if (meta && e.key === 'z' && !e.shiftKey) {
+        e.preventDefault()
+        undo()
+      } else if (meta && (e.key === 'Z' || (e.shiftKey && e.key === 'z'))) {
+        e.preventDefault()
+        redo()
+      } else if (e.key === 'h' && !meta && !e.shiftKey) {
+        e.preventDefault()
+        setOpen((o) => !o)
+      }
+    }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  }, [undo, redo])
+
+  const activeCount = edits.filter((e) => e.is_active).length
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="fixed bottom-16 right-4 z-30 flex items-center gap-2 rounded-md border border-border bg-surface-elevated px-3 py-2 text-sm shadow-md hover:bg-surface-subtle transition-colors"
+        title="History (H)"
+      >
+        <History className="h-4 w-4" />
+        <span className="font-tabular text-xs">History · {activeCount}</span>
+      </button>
+
+      {open && (
+        <>
+          <div className="fixed inset-0 z-40 bg-fg/30" onClick={() => setOpen(false)} />
+          <aside className="fixed right-0 top-0 bottom-0 z-50 w-96 bg-surface-elevated border-l border-border shadow-2xl flex flex-col">
+            <header className="flex items-center justify-between border-b border-border px-4 py-3">
+              <div>
+                <p className="text-base font-semibold text-fg">Edit history</p>
+                <p className="text-xs text-fg-muted">
+                  Cmd+Z to undo · Cmd+Shift+Z to redo
+                </p>
+              </div>
+              <button onClick={() => setOpen(false)} className="text-fg-muted hover:text-fg">
+                <X className="h-4 w-4" />
+              </button>
+            </header>
+            <div className="flex items-center gap-2 border-b border-border px-4 py-2 bg-surface-subtle">
+              <Button size="sm" variant="secondary" onClick={undo} loading={busy === 'undo'}>
+                <Undo2 className="h-3.5 w-3.5" /> Undo
+              </Button>
+              <Button size="sm" variant="secondary" onClick={redo} loading={busy === 'redo'}>
+                <Redo2 className="h-3.5 w-3.5" /> Redo
+              </Button>
+              <Button size="sm" variant="ghost" onClick={load}>
+                Refresh
+              </Button>
+            </div>
+            <div className="flex-1 overflow-y-auto">
+              {loading ? (
+                <p className="p-4 text-sm text-fg-muted">Loading…</p>
+              ) : edits.length === 0 ? (
+                <p className="p-4 text-sm text-fg-muted">No edits yet.</p>
+              ) : (
+                <ul className="divide-y divide-border">
+                  {edits.map((e) => (
+                    <li
+                      key={e.id}
+                      className={cn(
+                        'px-4 py-2.5',
+                        !e.is_active && 'opacity-50 line-through decoration-fg-subtle'
+                      )}
+                    >
+                      <div className="flex items-baseline justify-between gap-2">
+                        <p className="text-sm text-fg">{e.description ?? e.edit_type}</p>
+                        <span className="text-[10px] text-fg-subtle font-tabular whitespace-nowrap">
+                          #{e.edit_index}
+                        </span>
+                      </div>
+                      <p className="text-[11px] text-fg-muted font-tabular">
+                        {new Date(e.edited_at).toLocaleString()}
+                        {e.edited_by && ` · ${e.edited_by}`}
+                        {e.propagated_to_template && ' · template'}
+                      </p>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          </aside>
+        </>
+      )}
+    </>
+  )
+}

--- a/src/components/scheduler/StatusBar.tsx
+++ b/src/components/scheduler/StatusBar.tsx
@@ -1,0 +1,74 @@
+// Phase 4f-1 — bottom status bar with cycle summary + save indicator.
+import { Check, Loader2, AlertTriangle } from 'lucide-react'
+import { cn } from '../../lib/cn'
+
+export type SaveState = 'saved' | 'saving' | 'failed'
+
+interface Props {
+  cycleName: string
+  startDate: string
+  endDate: string
+  visitsPlaced: number
+  visitsTotal: number
+  utilizationPct: number | null
+  idleDays: number
+  optimizationScore: number | null
+  saveState: SaveState
+}
+
+export default function StatusBar({
+  cycleName,
+  startDate,
+  endDate,
+  visitsPlaced,
+  visitsTotal,
+  utilizationPct,
+  idleDays,
+  optimizationScore,
+  saveState,
+}: Props) {
+  return (
+    <div className="fixed bottom-0 left-0 right-0 z-20 border-t border-border bg-surface-elevated px-4 py-1.5 flex items-center gap-4 text-xs text-fg-muted">
+      <span className="text-fg font-medium">{cycleName}</span>
+      <span className="font-tabular text-fg-subtle">
+        {startDate} – {endDate}
+      </span>
+      <span>
+        <span className="font-tabular text-fg">{visitsPlaced}</span> / {visitsTotal} placed
+      </span>
+      {utilizationPct != null && (
+        <span>
+          Util: <span className="font-tabular text-fg">{utilizationPct}%</span>
+        </span>
+      )}
+      <span>
+        Idle days: <span className="font-tabular text-fg">{idleDays}</span>
+      </span>
+      {optimizationScore != null && (
+        <span>
+          Score: <span className="font-tabular text-fg">{optimizationScore}/100</span>
+        </span>
+      )}
+      <span className="ml-auto flex items-center gap-1.5">
+        {saveState === 'saved' && (
+          <>
+            <Check className="h-3 w-3 text-success" />
+            <span>All changes saved</span>
+          </>
+        )}
+        {saveState === 'saving' && (
+          <>
+            <Loader2 className="h-3 w-3 animate-spin" />
+            <span>Saving…</span>
+          </>
+        )}
+        {saveState === 'failed' && (
+          <>
+            <AlertTriangle className="h-3 w-3 text-danger" />
+            <span className="text-danger">Save failed</span>
+          </>
+        )}
+      </span>
+    </div>
+  )
+}

--- a/src/components/scheduler/ViewSwitcher.tsx
+++ b/src/components/scheduler/ViewSwitcher.tsx
@@ -1,0 +1,63 @@
+// Phase 4f-1 — view switcher tabs (Gantt / Calendar / List / Map).
+// Keyboard shortcuts: 1, 2, 3, 4.
+import { useEffect } from 'react'
+import { LayoutGrid, Calendar, List, Map as MapIcon } from 'lucide-react'
+import { cn } from '../../lib/cn'
+
+export type CycleViewKind = 'gantt' | 'calendar' | 'list' | 'map'
+
+const VIEWS: Array<{ key: CycleViewKind; label: string; icon: any; shortcut: string }> = [
+  { key: 'gantt', label: 'Gantt', icon: LayoutGrid, shortcut: '1' },
+  { key: 'calendar', label: 'Calendar', icon: Calendar, shortcut: '2' },
+  { key: 'list', label: 'List', icon: List, shortcut: '3' },
+  { key: 'map', label: 'Map', icon: MapIcon, shortcut: '4' },
+]
+
+interface Props {
+  value: CycleViewKind
+  onChange: (next: CycleViewKind) => void
+}
+
+export default function ViewSwitcher({ value, onChange }: Props) {
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement
+      if (target?.tagName === 'INPUT' || target?.tagName === 'TEXTAREA' || target?.isContentEditable) return
+      if (e.metaKey || e.ctrlKey || e.altKey) return
+      const v = VIEWS.find((v) => v.shortcut === e.key)
+      if (v) {
+        e.preventDefault()
+        onChange(v.key)
+      }
+    }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  }, [onChange])
+
+  return (
+    <div className="flex items-center gap-1 rounded-md border border-border bg-surface p-1">
+      {VIEWS.map((v) => {
+        const Icon = v.icon
+        const active = value === v.key
+        return (
+          <button
+            key={v.key}
+            type="button"
+            onClick={() => onChange(v.key)}
+            className={cn(
+              'flex items-center gap-1.5 rounded px-3 py-1.5 text-sm transition-colors',
+              active
+                ? 'bg-accent text-white shadow-sm'
+                : 'text-fg-muted hover:text-fg hover:bg-surface-subtle'
+            )}
+            title={`${v.label} (${v.shortcut})`}
+          >
+            <Icon className="h-3.5 w-3.5" />
+            {v.label}
+            <span className="ml-1 text-[10px] opacity-60 font-mono">{v.shortcut}</span>
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/pages/accounts/scheduler/CycleDetail.tsx
+++ b/src/pages/accounts/scheduler/CycleDetail.tsx
@@ -1,6 +1,6 @@
-// Phase 4d — Cycle instance detail.
-// Summary cards + list view of crew_day_routes + visits with edit affordances
-// (move/lock/mark-completed). Calendar grid + crew swimlanes deferred to 4f.
+// Phase 4f-1 — Cycle instance detail with view switcher (Gantt /
+// Calendar / List / Map), polished header summary, status bar, and
+// undo/redo history drawer. Drag-drop + multi-select ship in 4f-2.
 import { useState, useEffect, useCallback, useMemo } from 'react'
 import { useParams } from 'react-router-dom'
 import { Lock, Unlock, Check, MoveRight, Calendar } from 'lucide-react'
@@ -16,6 +16,11 @@ import {
 import {
   Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
 } from '../../../components/ui/Table'
+import ViewSwitcher, { type CycleViewKind } from '../../../components/scheduler/ViewSwitcher'
+import GanttView, { type UtilDay } from '../../../components/scheduler/GanttView'
+import CalendarView from '../../../components/scheduler/CalendarView'
+import HistoryDrawer from '../../../components/scheduler/HistoryDrawer'
+import StatusBar, { type SaveState } from '../../../components/scheduler/StatusBar'
 
 interface Cycle {
   id: string
@@ -66,23 +71,42 @@ export default function CycleDetailPage() {
   const [cycle, setCycle] = useState<Cycle | null>(null)
   const [visits, setVisits] = useState<Visit[]>([])
   const [crewDays, setCrewDays] = useState<CrewDay[]>([])
+  const [utilDays, setUtilDays] = useState<UtilDay[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [moveTarget, setMoveTarget] = useState<Visit | null>(null)
+  const [view, setView] = useState<CycleViewKind>('gantt')
+  const [saveState, setSaveState] = useState<SaveState>('saved')
+  const [optimizationScore, setOptimizationScore] = useState<number | null>(null)
 
   const load = useCallback(async () => {
     if (!cycleId) return
     setLoading(true)
     try {
       const token = await getToken()
-      const res = await fetch(`/api/scheduler/cycles/${cycleId}`, {
-        headers: { Authorization: `Bearer ${token}` },
-      })
-      if (!res.ok) throw new Error(`Load failed (${res.status})`)
-      const data = await res.json()
+      const [cycleRes, utilRes] = await Promise.all([
+        fetch(`/api/scheduler/cycles/${cycleId}`, { headers: { Authorization: `Bearer ${token}` } }),
+        fetch(`/api/scheduler/cycles/${cycleId}/crew-utilization`, { headers: { Authorization: `Bearer ${token}` } }),
+      ])
+      if (!cycleRes.ok) throw new Error(`Load failed (${cycleRes.status})`)
+      const data = await cycleRes.json()
       setCycle(data.cycle)
       setVisits(data.visits ?? [])
       setCrewDays(data.crew_days ?? [])
+      if (utilRes.ok) {
+        const u = await utilRes.json()
+        setUtilDays(u.days ?? [])
+      }
+      // Pull optimization score from the parent template for the status bar.
+      if (data.cycle?.template_id) {
+        const tplRes = await fetch(`/api/scheduler/templates/${data.cycle.template_id}`, {
+          headers: { Authorization: `Bearer ${token}` },
+        })
+        if (tplRes.ok) {
+          const tpl = await tplRes.json()
+          setOptimizationScore(tpl.template?.optimization_score ?? null)
+        }
+      }
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err))
     } finally {
@@ -108,6 +132,7 @@ export default function CycleDetailPage() {
   }, [crewDays])
 
   async function handleAction(visitId: string, path: string, body?: object) {
+    setSaveState('saving')
     try {
       const token = await getToken()
       const res = await fetch(`/api/scheduler/visits/${visitId}/${path}`, {
@@ -120,10 +145,26 @@ export default function CycleDetailPage() {
         throw new Error(errBody.error ?? `${path} failed (${res.status})`)
       }
       await load()
+      setSaveState('saved')
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err))
+      setSaveState('failed')
     }
   }
+
+  // Portfolio-level utilization stats, used by Gantt summary banner +
+  // bottom status bar.
+  const portfolioUtilization = useMemo(() => {
+    if (utilDays.length === 0) return null
+    const totalHours = utilDays.reduce((s, d) => s + d.work_hours_scheduled, 0)
+    const totalCapacity = utilDays.reduce((s, d) => s + d.work_hours_capacity, 0)
+    return totalCapacity > 0 ? Math.round((totalHours / totalCapacity) * 100) : 0
+  }, [utilDays])
+
+  const idleDayCount = useMemo(
+    () => utilDays.filter((d) => d.state.kind === 'idle' || d.state.kind === 'between_trips').length,
+    [utilDays]
+  )
 
   if (loading || !cycle) {
     return (
@@ -141,32 +182,97 @@ export default function CycleDetailPage() {
       { label: 'Routing templates', to: `/accounts/${accountId}/clients/${clientId}/scheduler/templates` },
       { label: `Cycle ${cycle.cycle_number}` },
     ]}>
-      <div className="mx-auto max-w-6xl px-6 py-10 space-y-6">
-        <header className="space-y-1">
-          <div className="flex items-center gap-2 flex-wrap">
-            <h1 className="text-2xl font-semibold tracking-tight text-fg">
-              Cycle {cycle.cycle_number}
-            </h1>
-            <Badge variant={cycle.status === 'completed' ? 'success' : cycle.status === 'in_progress' ? 'accent' : 'outline'}>
-              {cycle.status}
-            </Badge>
+      <div className="mx-auto max-w-7xl px-6 py-10 space-y-6 pb-12">
+        <header className="space-y-2">
+          <div className="flex items-start justify-between gap-4 flex-wrap">
+            <div>
+              <div className="flex items-center gap-2 flex-wrap">
+                <h1 className="text-2xl font-semibold tracking-tight text-fg">
+                  Cycle {cycle.cycle_number}
+                </h1>
+                <Badge variant={cycle.status === 'completed' ? 'success' : cycle.status === 'in_progress' ? 'accent' : 'outline'}>
+                  {cycle.status}
+                </Badge>
+              </div>
+              <p className="text-sm text-fg-muted font-tabular">
+                <Calendar className="inline h-3.5 w-3.5 mr-1" />
+                {cycle.start_date} — {cycle.end_date}
+              </p>
+            </div>
+            <ViewSwitcher value={view} onChange={setView} />
           </div>
-          <p className="text-sm text-fg-muted font-tabular">
-            <Calendar className="inline h-3.5 w-3.5 mr-1" />
-            {cycle.start_date} — {cycle.end_date}
-          </p>
         </header>
 
         {error && <p className="text-sm text-danger">{error}</p>}
 
-        {/* Summary cards */}
+        {/* Polished summary cards (4 across). Color-coded for at-a-
+            glance status. */}
         <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
-          <Stat label="Visits placed" value={`${placedVisits.length} / ${visits.length}`} sub={`${unplacedVisits.length} unplaced · ${completedVisits.length} completed`} />
-          <Stat label="Crew-days" value={String(crewDays.length)} />
-          <Stat label="Drive" value={`${formatMin(summary.driveMin)} · ${Math.round(summary.driveMiles)} mi`} />
-          <Stat label="Work" value={formatMin(summary.workMin)} />
+          <Stat
+            label="Visits placed"
+            value={`${placedVisits.length} / ${visits.length}`}
+            sub={`${unplacedVisits.length} unplaced · ${completedVisits.length} completed`}
+            tone={unplacedVisits.length > 0 ? 'warning' : 'success'}
+          />
+          <Stat
+            label="Total work hrs"
+            value={formatMin(summary.workMin)}
+            sub={`${formatMin(summary.driveMin)} drive · ${Math.round(summary.driveMiles)} mi`}
+          />
+          <Stat
+            label="Portfolio utilization"
+            value={portfolioUtilization != null ? `${portfolioUtilization}%` : '—'}
+            sub={`${idleDayCount} idle/between days`}
+            tone={
+              portfolioUtilization == null
+                ? 'default'
+                : portfolioUtilization >= 80
+                  ? 'success'
+                  : portfolioUtilization >= 60
+                    ? 'warning'
+                    : 'danger'
+            }
+          />
+          <Stat
+            label="Optimization score"
+            value={optimizationScore != null ? `${Math.round(optimizationScore)}/100` : '—'}
+            tone={optimizationScore != null && optimizationScore >= 80 ? 'success' : 'default'}
+          />
         </div>
 
+        {/* View switcher content */}
+        {view === 'gantt' && (
+          <div className="space-y-4">
+            <h2 className="text-base font-semibold tracking-tight text-fg">
+              Gantt — Crew × day utilization
+            </h2>
+            <p className="text-xs text-fg-muted">
+              Each cell is one crew on one workday. Click a cell to inspect the route. Drag-drop ships in 4f-2.
+            </p>
+            <GanttView days={utilDays} />
+          </div>
+        )}
+
+        {view === 'calendar' && (
+          <div className="space-y-4">
+            <h2 className="text-base font-semibold tracking-tight text-fg">Calendar</h2>
+            <p className="text-xs text-fg-muted">
+              Month grid showing per-day crew bars. Bar width ≈ utilization. Idle days highlighted yellow.
+            </p>
+            <CalendarView days={utilDays} />
+          </div>
+        )}
+
+        {view === 'map' && (
+          <div className="rounded-md border border-border bg-surface p-6 text-sm text-fg-muted">
+            Map view ships in 4f-3. Will plot all properties + branches on a Mapbox map with a
+            time scrubber to step through the cycle day-by-day.
+          </div>
+        )}
+
+        {/* List view: existing crew_days + visits tables */}
+        {view === 'list' && (
+        <>
         {/* Crew days */}
         <Card padding="none">
           <div className="border-b border-border px-4 py-3">
@@ -317,12 +423,28 @@ export default function CycleDetailPage() {
             </Table>
           )}
         </Card>
+        </>
+        )}
       </div>
 
       <MoveVisitDialog
         visit={moveTarget}
         onClose={() => setMoveTarget(null)}
         onMoved={() => { setMoveTarget(null); load() }}
+      />
+
+      <HistoryDrawer cycleId={cycleId!} onChange={load} />
+
+      <StatusBar
+        cycleName={`Cycle ${cycle.cycle_number}`}
+        startDate={cycle.start_date}
+        endDate={cycle.end_date}
+        visitsPlaced={placedVisits.length}
+        visitsTotal={visits.length}
+        utilizationPct={portfolioUtilization}
+        idleDays={idleDayCount}
+        optimizationScore={optimizationScore}
+        saveState={saveState}
       />
     </AppShell>
   )
@@ -415,7 +537,35 @@ function MoveVisitDialog({
   )
 }
 
-function Stat({ label, value, sub }: { label: string; value: string; sub?: string }) {
+function Stat({
+  label,
+  value,
+  sub,
+  tone = 'default',
+}: {
+  label: string
+  value: string
+  sub?: string
+  tone?: 'default' | 'success' | 'warning' | 'danger'
+}) {
+  const toneClass =
+    tone === 'success'
+      ? 'border-success/40 bg-success/5'
+      : tone === 'warning'
+        ? 'border-warning/40 bg-warning/5'
+        : tone === 'danger'
+          ? 'border-danger/40 bg-danger/5'
+          : 'border-border bg-surface'
+  return (
+    <div className={`rounded-md border ${toneClass} px-3 py-2`}>
+      <p className="text-[10px] uppercase tracking-wider text-fg-subtle">{label}</p>
+      <p className="font-mono text-base font-semibold tabular-nums text-fg leading-tight">{value}</p>
+      {sub && <p className="text-[11px] text-fg-muted font-tabular">{sub}</p>}
+    </div>
+  )
+}
+
+function StatLegacy({ label, value, sub }: { label: string; value: string; sub?: string }) {
   return (
     <div className="rounded-md border border-border bg-surface px-3 py-2">
       <p className="text-[10px] uppercase tracking-wider text-fg-subtle">{label}</p>

--- a/supabase/migrations/20260430132735_phase4f_cycle_edit_history.sql
+++ b/supabase/migrations/20260430132735_phase4f_cycle_edit_history.sql
@@ -1,0 +1,34 @@
+-- Phase 4f — cycle edit history (undo/redo stack).
+--
+-- Per-cycle ordered log of edits with both forward and reverse payloads.
+-- Cmd+Z reverses the most recent active edit by replaying its
+-- reverse_payload; Cmd+Shift+Z reapplies a previously-undone edit by
+-- replaying forward_payload. New edits invalidate the redo branch.
+
+CREATE TABLE IF NOT EXISTS public.cycle_edit_history (
+  id                       UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  cycle_instance_id        UUID NOT NULL REFERENCES public.cycle_instances(id) ON DELETE CASCADE,
+  edit_index               INT NOT NULL,
+  edit_type                TEXT NOT NULL CHECK (edit_type IN (
+    'move_visit', 'move_trip', 'reassign_cluster',
+    'add_visit', 'remove_visit', 'lock_visit', 'unlock_visit',
+    'lock_day', 'unlock_day', 'mark_complete', 'mark_cancelled',
+    'bulk_operation'
+  )),
+  forward_payload          JSONB NOT NULL,
+  reverse_payload          JSONB NOT NULL,
+  propagated_to_template   BOOLEAN NOT NULL DEFAULT FALSE,
+  template_change_payload  JSONB,
+  is_active                BOOLEAN NOT NULL DEFAULT TRUE,
+  undone_at                TIMESTAMPTZ,
+  edited_by                TEXT,
+  edited_at                TIMESTAMPTZ NOT NULL DEFAULT now(),
+  description              TEXT
+);
+
+CREATE INDEX IF NOT EXISTS ceh_cycle_idx
+  ON public.cycle_edit_history(cycle_instance_id, edit_index DESC);
+
+CREATE INDEX IF NOT EXISTS ceh_active_idx
+  ON public.cycle_edit_history(cycle_instance_id, is_active)
+  WHERE is_active = TRUE;


### PR DESCRIPTION
## Why
Phase 4f spec is too large for one PR — split into 3:
- **4f-1 (this PR):** foundations everything else builds on (crew utilization, undo stack, view scaffold, status bar, history drawer)
- **4f-2:** real drag-drop, multi-select, full keyboard shortcuts, Calendar drag-bars, polished List with bulk ops + CSV
- **4f-3:** Map view with time scrubber + animation + layer toggles, performance pass

This PR is the load-bearing pieces. UI shell is in place — Gantt and Calendar render data; Map and List use existing structures or placeholders.

## Crew utilization (Part 1)
\`api/_lib/scheduler/crew-utilization.ts\` is a pure function that classifies every (crew × workday) into one of 7 states:

- \`fully_utilized\` (≥90% capacity)
- \`partial\` (30–90%)
- \`idle\` (<30%)
- \`between_trips\` (idle, surrounded by trips within 3 days — second-pass derivation)
- \`travel_day\` / \`rest_day\` (from \`day_type\`)
- \`overnight_continuation\` (mid-stretch of a multi-day overnight trip)

\`GET /api/scheduler/cycles/[id]/crew-utilization\` returns the array. Optional \`?include_weekends=true\`.

## Undo stack (Part 2)
- New table \`cycle_edit_history\` — per-cycle ordered log with \`forward_payload\` + \`reverse_payload\` jsonb, \`is_active\` flag, descriptions
- \`api/_lib/scheduler/edit-history.ts\`: \`recordEdit()\`, \`applyForward()\`, \`applyReverse()\`, plus typed appliers for \`move\`/\`lock\`/\`status\`. Trims to last 50 active per cycle.
- \`POST /api/scheduler/cycles/[id]/undo\` reverses the most recent active edit
- \`POST /redo\` reapplies the most recently undone
- \`GET /edit-history\` returns last 50
- New edit invalidates the redo branch (deletes \`is_active=false\` rows)
- Recording wired into existing visit endpoints: **move**, **lock**, **unlock**, **mark-completed**. Each captures pre-edit state for the reverse payload.

## Cycle detail page (Parts 7, 9)
- **Polished header** with status badge + date subtitle
- **4 color-coded summary cards** — Visits placed, Total work hrs, Portfolio utilization, Optimization score. Tone (green/yellow/red) reflects health.
- **ViewSwitcher** tabs in the header — keyboard shortcuts \`1\`/\`2\`/\`3\`/\`4\`
- **GanttView (MVP)** — horizontal grid, crew rows × day columns, cells color-coded by state. Sticky crew column. Hover tooltips with utilization/trip. Per-crew summary chip ("83% · 5I 3P 1B"). Legend strip at bottom. Click is no-op for now.
- **CalendarView (MVP)** — month grid (Sun-start) with crew bars per day. Bar width ≈ utilization, color = crew. Idle days flagged with ⚠️ + yellow tint. Month nav arrows.
- **List view** — existing crew_days + visits tables stay as-is, rendered when view='list'
- **Map view** — placeholder card pointing at 4f-3
- **HistoryDrawer** — floating bottom-right button shows active edit count. Drawer lists last 50 with strikethrough on undone. Undo/Redo buttons + global \`Cmd+Z\` / \`Cmd+Shift+Z\` shortcuts. Press \`H\` to toggle.
- **StatusBar** — fixed to bottom, always visible: cycle name + dates, visits placed/total, utilization %, idle days, score, save indicator (✓ saved / ⏱ saving / ⚠ failed)

## Trade-offs / what's NOT in this PR
- **No drag-drop yet** — Gantt cells are click-no-op. 4f-2 wires drag-and-drop visit moves with the propagation modal.
- **No multi-select**, no \`Cmd+A\`/\`L\`/\`U\`/\`Delete\` shortcuts beyond Cmd+Z and H. Coming 4f-2.
- **Map view is a placeholder card.** Real Mapbox + scrubber lands in 4f-3.
- **Calendar isn't draggable.** 4f-2.
- **Undo of propagated edits** reverts only the cycle row, not the template's trips jsonb. Will tighten in 4f-2 alongside drag-drop.
- **History drawer doesn't gracefully handle obsolete entries** (where the underlying visit was deleted). Edge case for now.

## Test plan
- [ ] Open a cycle detail page → header shows polished card row + view tabs
- [ ] Press \`1\` / \`2\` / \`3\` / \`4\` → views switch
- [ ] Gantt: crew rows render, cells color-coded, hover tooltips show utilization
- [ ] Calendar: month grid, crew bars sized to utilization, idle days highlighted
- [ ] Move a visit → status bar shows "Saving…" → "All changes saved"
- [ ] Press \`H\` or click floating button → drawer opens, shows the move with description
- [ ] Press \`Cmd+Z\` → visit reverts, drawer entry shows strikethrough
- [ ] Press \`Cmd+Shift+Z\` → visit re-moves
- [ ] Make a new edit after an undo → drawer's strikethrough entry disappears (redo branch invalidated)
- [ ] Lock a visit → history entry "Locked X" appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)