### PR TITLE
Phase 4f-3: Map view, Calendar drag, drag-with-template-propagation

### DIFF
--- a/api/scheduler/cycles/[cycleId]/index.ts
+++ b/api/scheduler/cycles/[cycleId]/index.ts
@@ -15,7 +15,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     if (!cycle) return res.status(404).json({ error: 'Cycle not found' })
     const { data: visits } = await db
       .from('scheduled_visits')
-      .select('*, service_locations(id, display_name, property:properties(id, address_line1))')
+      .select('*, service_locations(id, display_name, property:properties(id, address_line1, latitude, longitude))')
       .eq('cycle_instance_id', id)
       .order('scheduled_date', { ascending: true })
     const { data: crewDays } = await db

--- a/api/scheduler/visits/bulk-action.ts
+++ b/api/scheduler/visits/bulk-action.ts
@@ -12,6 +12,7 @@ import {
   applyVisitStatus,
   recordEdit,
 } from '../../_lib/scheduler/edit-history.js'
+import { moveVisit } from '../../_lib/scheduler/edit-propagation.js'
 
 export const config = { maxDuration: 60 }
 
@@ -72,7 +73,19 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       if (action === 'move') {
         const newDate = body.payload?.to_date as string | undefined
         if (!newDate) continue
-        await applyVisitMove(db, { visit_id: id, to_date: newDate })
+        const propagate = body.payload?.propagate_to_template === true
+        if (propagate) {
+          // Use the propagation helper so template.trips is also updated.
+          // moveVisit handles per-row propagation under the hood.
+          await moveVisit(db, {
+            visitId: id,
+            newScheduledDate: newDate,
+            propagateToTemplate: true,
+            editedBy: userId,
+          })
+        } else {
+          await applyVisitMove(db, { visit_id: id, to_date: newDate })
+        }
         forward.push({ visit_id: id, to_date: newDate })
         reverse.push({ visit_id: id, to_date: cur.scheduled_date, to_sequence: cur.sequence_in_day })
       } else if (action === 'lock') {
@@ -104,6 +117,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         reverse_payload: { action: reverseAction(action), items: reverse },
         description: bulkDescription(action, forward.length),
         edited_by: userId,
+        propagated_to_template: action === 'move' && body.payload?.propagate_to_template === true,
       })
     } catch (err) {
       console.error('[bulk-action] history record failed:', err)

--- a/src/components/scheduler/CalendarView.tsx
+++ b/src/components/scheduler/CalendarView.tsx
@@ -1,8 +1,8 @@
-// Phase 4f-1 MVP Calendar view — month grid with crew bars per day.
-// Drag-drop ships in 4f-2.
-import { useMemo } from 'react'
+// Phase 4f-3 Calendar view — month grid with crew bars per day +
+// drag-drop on individual crew bars. Drag a bar from one day to another
+// to move that crew's visits.
+import { useMemo, useRef, useState } from 'react'
 import { ChevronLeft, ChevronRight, AlertTriangle } from 'lucide-react'
-import { useState } from 'react'
 import Button from '../ui/Button'
 import { cn } from '../../lib/cn'
 import type { UtilDay } from './GanttView'
@@ -25,9 +25,17 @@ const MONTH_NAMES = [
 interface Props {
   days: UtilDay[]
   onDayClick?: (date: string) => void
+  // Drag-drop a crew bar on day A onto day B → move that crew's visits.
+  // Same shape as Gantt's onCellDrop.
+  onCellDrop?: (drop: {
+    source: { crew_index: number; date: string }
+    target: { crew_index: number; date: string }
+  }) => void
 }
 
-export default function CalendarView({ days, onDayClick }: Props) {
+export default function CalendarView({ days, onDayClick, onCellDrop }: Props) {
+  const dragSource = useRef<{ crew_index: number; date: string } | null>(null)
+  const [dragOverDate, setDragOverDate] = useState<string | null>(null)
   const dates = useMemo(() => {
     const set = new Set(days.map((d) => d.scheduled_date))
     return Array.from(set).sort()
@@ -121,14 +129,36 @@ export default function CalendarView({ days, onDayClick }: Props) {
           }
           const cellDays = cellsByDate.get(c.date) ?? []
           const hasIdle = cellDays.some((d) => d.state.kind === 'idle')
+          const isDragOver = dragOverDate === c.date
           return (
-            <button
+            <div
               key={c.date}
-              type="button"
+              onDragOver={(e) => {
+                if (dragSource.current && dragSource.current.date !== c.date) {
+                  e.preventDefault()
+                  e.dataTransfer.dropEffect = 'move'
+                  setDragOverDate(c.date)
+                }
+              }}
+              onDragLeave={() => {
+                if (dragOverDate === c.date) setDragOverDate(null)
+              }}
+              onDrop={(e) => {
+                e.preventDefault()
+                const src = dragSource.current
+                dragSource.current = null
+                setDragOverDate(null)
+                if (!src || !c.date || src.date === c.date) return
+                onCellDrop?.({
+                  source: src,
+                  target: { crew_index: src.crew_index, date: c.date },
+                })
+              }}
               onClick={() => onDayClick?.(c.date!)}
               className={cn(
-                'border-r border-b border-border p-1.5 text-left flex flex-col gap-1 hover:bg-surface-subtle transition-colors',
-                hasIdle && 'bg-warning/5'
+                'border-r border-b border-border p-1.5 text-left flex flex-col gap-1 hover:bg-surface-subtle transition-colors cursor-pointer',
+                hasIdle && 'bg-warning/5',
+                isDragOver && 'ring-2 ring-warning ring-inset'
               )}
               style={{ minHeight: 96 }}
             >
@@ -136,16 +166,30 @@ export default function CalendarView({ days, onDayClick }: Props) {
               {cellDays.map((d) => {
                 const pct = d.utilization_pct
                 const isIdle = d.state.kind === 'idle' || d.state.kind === 'between_trips'
+                const draggable = !isIdle
                 return (
                   <div
                     key={d.crew_index}
+                    draggable={draggable}
+                    onDragStart={(e) => {
+                      if (!draggable) return
+                      e.stopPropagation()
+                      dragSource.current = { crew_index: d.crew_index, date: d.scheduled_date }
+                      e.dataTransfer.effectAllowed = 'move'
+                      e.dataTransfer.setData('text/plain', `${d.crew_index}|${d.scheduled_date}`)
+                    }}
+                    onDragEnd={() => {
+                      dragSource.current = null
+                      setDragOverDate(null)
+                    }}
                     className={cn(
                       'h-1.5 rounded-sm',
                       isIdle ? 'bg-fg-subtle/30' : CREW_COLORS[d.crew_index % CREW_COLORS.length],
-                      d.state.kind === 'partial' && 'opacity-50'
+                      d.state.kind === 'partial' && 'opacity-50',
+                      draggable && 'cursor-grab'
                     )}
                     style={{ width: `${Math.max(10, pct)}%` }}
-                    title={`${d.crew_label}: ${d.work_hours_scheduled.toFixed(1)}h · ${d.state.kind}`}
+                    title={`${d.crew_label}: ${d.work_hours_scheduled.toFixed(1)}h · ${d.state.kind}${draggable ? ' (drag to move)' : ''}`}
                   />
                 )
               })}
@@ -155,7 +199,7 @@ export default function CalendarView({ days, onDayClick }: Props) {
                   {cellDays.filter((d) => d.state.kind === 'idle').length} idle
                 </div>
               )}
-            </button>
+            </div>
           )
         })}
       </div>

--- a/src/components/scheduler/CycleMapView.tsx
+++ b/src/components/scheduler/CycleMapView.tsx
@@ -1,0 +1,402 @@
+// Phase 4f-3 — Cycle map view.
+//
+// Spatial reasoning. Full-bleed Mapbox map showing branches + properties
+// + the routes for the day under the time scrubber. Right-side panel
+// summarizes per-crew status for the current date. Drag scrubber to
+// step through the cycle; play-animation + layer toggles deferred.
+import { useEffect, useMemo, useRef, useState } from 'react'
+import mapboxgl from 'mapbox-gl'
+import 'mapbox-gl/dist/mapbox-gl.css'
+import { stateClass, type CrewDayStateKind } from './CrewUtilizationChip'
+import { cn } from '../../lib/cn'
+
+mapboxgl.accessToken = import.meta.env.VITE_MAPBOX_ACCESS_TOKEN ?? ''
+
+const CREW_COLORS = [
+  '#6366f1', // indigo
+  '#14b8a6', // teal
+  '#f59e0b', // amber
+  '#f43f5e', // rose
+  '#10b981', // emerald
+  '#8b5cf6', // violet
+  '#64748b', // slate
+]
+
+interface Visit {
+  id: string
+  service_location_id: string
+  scheduled_date: string | null
+  arrival_time: string | null
+  departure_time: string | null
+  hours_per_visit_total: number | null
+  status: string
+  crew_day_route_id: string | null
+  service_locations?: {
+    display_name: string | null
+    property: { address_line1: string; latitude: number | null; longitude: number | null } | null
+  } | null
+}
+
+interface CrewDay {
+  id: string
+  trip_id: string
+  trip_label: string | null
+  crew_index: number
+  scheduled_date: string
+  day_type: string
+  start_location: { type?: string; name?: string; lat?: number; lng?: number } | null
+  total_drive_minutes: number | null
+  total_work_minutes: number | null
+  total_drive_miles: number | null
+}
+
+interface UtilDay {
+  crew_index: number
+  crew_label: string
+  scheduled_date: string
+  state: { kind: CrewDayStateKind; work_hours: number; unused_hours: number }
+  utilization_pct: number
+}
+
+interface Branch { name: string; lat: number; lng: number }
+
+interface Props {
+  visits: Visit[]
+  crewDays: CrewDay[]
+  utilDays: UtilDay[]
+  branches: Branch[]
+  cycleStart: string
+  cycleEnd: string
+  height?: number
+}
+
+export default function CycleMapView({
+  visits,
+  crewDays,
+  utilDays,
+  branches,
+  cycleStart,
+  cycleEnd,
+  height = 600,
+}: Props) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const mapRef = useRef<mapboxgl.Map | null>(null)
+  const markersRef = useRef<mapboxgl.Marker[]>([])
+  const [mapLoaded, setMapLoaded] = useState(false)
+
+  // All distinct dates in the cycle (workdays only).
+  const dates = useMemo(() => {
+    const set = new Set<string>()
+    for (const u of utilDays) set.add(u.scheduled_date)
+    return Array.from(set).sort()
+  }, [utilDays])
+
+  const [scrubIdx, setScrubIdx] = useState(0)
+  // Reset scrub if dates list shortens past the current index.
+  useEffect(() => {
+    if (scrubIdx >= dates.length) setScrubIdx(Math.max(0, dates.length - 1))
+  }, [dates, scrubIdx])
+
+  const currentDate = dates[scrubIdx] ?? cycleStart
+
+  // Crew-day routes for the current date, indexed by crew_index.
+  const dayCrewDays = useMemo(() => {
+    const out = new Map<number, CrewDay>()
+    for (const cd of crewDays) {
+      if (cd.scheduled_date === currentDate) out.set(cd.crew_index, cd)
+    }
+    return out
+  }, [crewDays, currentDate])
+
+  // Visits for the current date, grouped by crew_index.
+  const dayVisitsByCrewIndex = useMemo(() => {
+    const crewByRoute = new Map<string, number>()
+    for (const cd of crewDays) crewByRoute.set(cd.id, cd.crew_index)
+    const out = new Map<number, Visit[]>()
+    for (const v of visits) {
+      if (v.scheduled_date !== currentDate) continue
+      if (!v.crew_day_route_id) continue
+      const ci = crewByRoute.get(v.crew_day_route_id)
+      if (ci == null) continue
+      const arr = out.get(ci) ?? []
+      arr.push(v)
+      out.set(ci, arr)
+    }
+    for (const arr of out.values()) {
+      arr.sort((a, b) => (a.arrival_time ?? '').localeCompare(b.arrival_time ?? ''))
+    }
+    return out
+  }, [visits, crewDays, currentDate])
+
+  // Utilization snapshot per crew for the current day, indexed by crew_index.
+  const dayUtilByCrewIndex = useMemo(() => {
+    const out = new Map<number, UtilDay>()
+    for (const u of utilDays) {
+      if (u.scheduled_date === currentDate) out.set(u.crew_index, u)
+    }
+    return out
+  }, [utilDays, currentDate])
+
+  // Map init + cleanup.
+  useEffect(() => {
+    if (!containerRef.current || !mapboxgl.accessToken) return
+    if (mapRef.current) return
+    // Center on the centroid of branches if present, else US center.
+    let centerLng = -98.5
+    let centerLat = 39.8
+    if (branches.length > 0) {
+      centerLng = branches.reduce((s, b) => s + b.lng, 0) / branches.length
+      centerLat = branches.reduce((s, b) => s + b.lat, 0) / branches.length
+    }
+    const m = new mapboxgl.Map({
+      container: containerRef.current,
+      style: 'mapbox://styles/mapbox/light-v11',
+      center: [centerLng, centerLat],
+      zoom: 5,
+    })
+    mapRef.current = m
+    m.on('load', () => setMapLoaded(true))
+    return () => {
+      markersRef.current.forEach((mk) => mk.remove())
+      markersRef.current = []
+      m.remove()
+      mapRef.current = null
+      setMapLoaded(false)
+    }
+  }, [branches])
+
+  // Render branches once.
+  useEffect(() => {
+    if (!mapLoaded || !mapRef.current) return
+    const m = mapRef.current
+    const branchEls: mapboxgl.Marker[] = []
+    for (const b of branches) {
+      const el = document.createElement('div')
+      el.className =
+        'flex h-7 w-7 items-center justify-center rounded-full text-[11px] font-bold text-white shadow-md'
+      el.style.backgroundColor = '#0f172a'
+      el.style.border = '2px solid #fff'
+      el.textContent = '★'
+      el.title = b.name
+      branchEls.push(
+        new mapboxgl.Marker({ element: el })
+          .setLngLat([b.lng, b.lat])
+          .setPopup(new mapboxgl.Popup({ offset: 18 }).setHTML(`<strong>${b.name}</strong><br/>Branch`))
+          .addTo(m)
+      )
+    }
+    return () => {
+      branchEls.forEach((mk) => mk.remove())
+    }
+  }, [mapLoaded, branches])
+
+  // Render visit markers + route polylines for the current scrub date.
+  // Re-runs whenever currentDate or visit data changes.
+  useEffect(() => {
+    if (!mapLoaded || !mapRef.current) return
+    const m = mapRef.current
+
+    // Clear previous markers
+    markersRef.current.forEach((mk) => mk.remove())
+    markersRef.current = []
+
+    const allCoords: [number, number][] = branches.map((b) => [b.lng, b.lat])
+
+    for (const [crewIdx, crewVisits] of dayVisitsByCrewIndex) {
+      const color = CREW_COLORS[crewIdx % CREW_COLORS.length]
+      const stops: [number, number][] = []
+      for (const v of crewVisits) {
+        const lat = v.service_locations?.property?.latitude
+        const lng = v.service_locations?.property?.longitude
+        if (lat == null || lng == null) continue
+        const el = document.createElement('div')
+        el.className =
+          'flex h-5 w-5 items-center justify-center rounded-full text-[10px] font-bold text-white shadow'
+        el.style.backgroundColor = color
+        el.style.border = '2px solid #fff'
+        el.textContent = String(crewVisits.indexOf(v) + 1)
+        markersRef.current.push(
+          new mapboxgl.Marker({ element: el })
+            .setLngLat([lng, lat])
+            .setPopup(
+              new mapboxgl.Popup({ offset: 14 }).setHTML(
+                `<strong>Stop ${crewVisits.indexOf(v) + 1}</strong><br/>${
+                  v.service_locations?.property?.address_line1 ?? ''
+                }<br/>${v.arrival_time ?? ''}–${v.departure_time ?? ''}`
+              )
+            )
+            .addTo(m)
+        )
+        stops.push([lng, lat])
+        allCoords.push([lng, lat])
+      }
+
+      // Route polyline: branch (or trip start) → stops → branch.
+      const cd = dayCrewDays.get(crewIdx)
+      const startBranch = branches.find((b) => b.name === cd?.start_location?.name)
+      const startCoord: [number, number] | null = startBranch
+        ? [startBranch.lng, startBranch.lat]
+        : cd?.start_location?.lat != null && cd?.start_location?.lng != null
+          ? [cd.start_location.lng, cd.start_location.lat]
+          : null
+      const lineCoords: [number, number][] = []
+      if (startCoord) lineCoords.push(startCoord)
+      lineCoords.push(...stops)
+      if (startCoord && cd?.day_type !== 'overnight') lineCoords.push(startCoord)
+
+      const sourceId = `route-${crewIdx}`
+      if (m.getLayer(sourceId)) m.removeLayer(sourceId)
+      if (m.getSource(sourceId)) m.removeSource(sourceId)
+      if (lineCoords.length >= 2) {
+        m.addSource(sourceId, {
+          type: 'geojson',
+          data: { type: 'Feature', properties: {}, geometry: { type: 'LineString', coordinates: lineCoords } },
+        })
+        m.addLayer({
+          id: sourceId,
+          type: 'line',
+          source: sourceId,
+          paint: {
+            'line-color': color,
+            'line-width': 3,
+            'line-opacity': 0.7,
+            'line-dasharray': cd?.day_type === 'travel' ? [2, 2] : [1, 0],
+          },
+        })
+      }
+    }
+
+    // Fit bounds when day data changes — but only if there are actual coords.
+    if (allCoords.length > 1) {
+      const bounds = allCoords.reduce(
+        (b, c) => b.extend(c),
+        new mapboxgl.LngLatBounds(allCoords[0], allCoords[0])
+      )
+      m.fitBounds(bounds, { padding: 40, maxZoom: 11, duration: 300 })
+    }
+
+    // Cleanup polylines on unmount of this effect — clear all crew route layers.
+    return () => {
+      for (const [crewIdx] of dayVisitsByCrewIndex) {
+        const sourceId = `route-${crewIdx}`
+        if (m.getLayer(sourceId)) m.removeLayer(sourceId)
+        if (m.getSource(sourceId)) m.removeSource(sourceId)
+      }
+    }
+  }, [mapLoaded, branches, dayVisitsByCrewIndex, dayCrewDays])
+
+  if (dates.length === 0) {
+    return (
+      <div className="rounded-md border border-border bg-surface p-6 text-sm text-fg-muted">
+        No scheduled days yet. Generate a cycle first.
+      </div>
+    )
+  }
+  if (!mapboxgl.accessToken) {
+    return (
+      <div className="rounded-md border border-warning/40 bg-warning/5 p-6 text-sm text-fg">
+        VITE_MAPBOX_ACCESS_TOKEN not set — Map view requires a Mapbox token.
+      </div>
+    )
+  }
+
+  const currentDateObj = new Date(currentDate + 'T00:00:00Z')
+  const dayLabel = currentDateObj.toLocaleDateString(undefined, {
+    weekday: 'long',
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    timeZone: 'UTC',
+  })
+
+  return (
+    <div className="rounded-md border border-border bg-surface overflow-hidden flex flex-col">
+      <div className="grid grid-cols-1 lg:grid-cols-[1fr_300px]" style={{ height }}>
+        <div ref={containerRef} className="bg-surface-subtle" />
+
+        {/* Right-side crew status panel */}
+        <aside className="border-l border-border bg-surface overflow-y-auto">
+          <header className="px-3 py-2 border-b border-border bg-surface-subtle">
+            <p className="text-sm font-semibold text-fg">{dayLabel}</p>
+            <p className="text-[11px] text-fg-muted font-tabular">
+              Day {scrubIdx + 1} of {dates.length}
+            </p>
+          </header>
+          <ul className="divide-y divide-border">
+            {Array.from(dayUtilByCrewIndex.entries())
+              .sort(([a], [b]) => a - b)
+              .map(([crewIdx, util]) => {
+                const cd = dayCrewDays.get(crewIdx)
+                const stops = (dayVisitsByCrewIndex.get(crewIdx) ?? []).length
+                return (
+                  <li key={crewIdx} className="px-3 py-2 text-xs">
+                    <div className="flex items-center gap-2">
+                      <span
+                        className="h-2.5 w-2.5 rounded-full shrink-0"
+                        style={{ backgroundColor: CREW_COLORS[crewIdx % CREW_COLORS.length] }}
+                      />
+                      <span className="font-medium text-fg">{util.crew_label}</span>
+                      <span
+                        className={cn(
+                          'ml-auto rounded border px-1.5 py-0.5 font-mono text-[10px]',
+                          stateClass(util.state.kind)
+                        )}
+                      >
+                        {util.state.kind}
+                      </span>
+                    </div>
+                    <p className="mt-1 text-fg-muted font-tabular">
+                      {util.state.kind === 'idle' || util.state.kind === 'between_trips' ? (
+                        <span className="text-danger">No work scheduled</span>
+                      ) : (
+                        <>
+                          {stops} stop{stops === 1 ? '' : 's'} · {util.state.work_hours.toFixed(1)}h
+                          {cd?.total_drive_miles != null && (
+                            <> · {Math.round(Number(cd.total_drive_miles))} mi</>
+                          )}
+                        </>
+                      )}
+                    </p>
+                    {cd?.trip_label && (
+                      <p className="text-[10px] text-fg-subtle">{cd.trip_label}</p>
+                    )}
+                  </li>
+                )
+              })}
+          </ul>
+        </aside>
+      </div>
+
+      {/* Time scrubber */}
+      <div className="border-t border-border bg-surface-subtle px-4 py-3 flex items-center gap-3">
+        <button
+          type="button"
+          onClick={() => setScrubIdx((i) => Math.max(0, i - 1))}
+          disabled={scrubIdx === 0}
+          className="rounded border border-border bg-surface px-2 py-1 text-xs disabled:opacity-50"
+        >
+          ←
+        </button>
+        <input
+          type="range"
+          min={0}
+          max={Math.max(0, dates.length - 1)}
+          value={scrubIdx}
+          onChange={(e) => setScrubIdx(Number(e.target.value))}
+          className="flex-1 accent-accent"
+        />
+        <button
+          type="button"
+          onClick={() => setScrubIdx((i) => Math.min(dates.length - 1, i + 1))}
+          disabled={scrubIdx === dates.length - 1}
+          className="rounded border border-border bg-surface px-2 py-1 text-xs disabled:opacity-50"
+        >
+          →
+        </button>
+        <span className="text-xs text-fg-muted font-tabular whitespace-nowrap min-w-[120px] text-right">
+          {currentDate}
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/accounts/scheduler/CycleDetail.tsx
+++ b/src/pages/accounts/scheduler/CycleDetail.tsx
@@ -19,6 +19,7 @@ import {
 import ViewSwitcher, { type CycleViewKind } from '../../../components/scheduler/ViewSwitcher'
 import GanttView, { type UtilDay } from '../../../components/scheduler/GanttView'
 import CalendarView from '../../../components/scheduler/CalendarView'
+import CycleMapView from '../../../components/scheduler/CycleMapView'
 import HistoryDrawer from '../../../components/scheduler/HistoryDrawer'
 import StatusBar, { type SaveState } from '../../../components/scheduler/StatusBar'
 
@@ -79,6 +80,7 @@ export default function CycleDetailPage() {
   const [view, setView] = useState<CycleViewKind>('gantt')
   const [saveState, setSaveState] = useState<SaveState>('saved')
   const [optimizationScore, setOptimizationScore] = useState<number | null>(null)
+  const [branches, setBranches] = useState<Array<{ name: string; lat: number; lng: number }>>([])
   const [selectedVisitIds, setSelectedVisitIds] = useState<Set<string>>(new Set())
 
   const load = useCallback(async () => {
@@ -99,7 +101,7 @@ export default function CycleDetailPage() {
         const u = await utilRes.json()
         setUtilDays(u.days ?? [])
       }
-      // Pull optimization score from the parent template for the status bar.
+      // Pull optimization score + branches from the parent template.
       if (data.cycle?.template_id) {
         const tplRes = await fetch(`/api/scheduler/templates/${data.cycle.template_id}`, {
           headers: { Authorization: `Bearer ${token}` },
@@ -107,6 +109,13 @@ export default function CycleDetailPage() {
         if (tplRes.ok) {
           const tpl = await tplRes.json()
           setOptimizationScore(tpl.template?.optimization_score ?? null)
+          setBranches(
+            (tpl.template?.branches ?? []).map((b: any) => ({
+              name: b.name,
+              lat: Number(b.lat),
+              lng: Number(b.lng),
+            }))
+          )
         }
       }
     } catch (err) {
@@ -374,15 +383,27 @@ export default function CycleDetailPage() {
             <h2 className="text-base font-semibold tracking-tight text-fg">Calendar</h2>
             <p className="text-xs text-fg-muted">
               Month grid showing per-day crew bars. Bar width ≈ utilization. Idle days highlighted yellow.
+              Drag a crew bar to a different day to move that crew's visits.
             </p>
-            <CalendarView days={utilDays} />
+            <CalendarView days={utilDays} onCellDrop={handleCellDrop} />
           </div>
         )}
 
         {view === 'map' && (
-          <div className="rounded-md border border-border bg-surface p-6 text-sm text-fg-muted">
-            Map view ships in 4f-3. Will plot all properties + branches on a Mapbox map with a
-            time scrubber to step through the cycle day-by-day.
+          <div className="space-y-2">
+            <h2 className="text-base font-semibold tracking-tight text-fg">Map</h2>
+            <p className="text-xs text-fg-muted">
+              Properties + branches plotted spatially. Drag the scrubber to step through each
+              workday in the cycle. Right panel shows per-crew status for the selected date.
+            </p>
+            <CycleMapView
+              visits={visits as any}
+              crewDays={crewDays as any}
+              utilDays={utilDays}
+              branches={branches}
+              cycleStart={cycle.start_date}
+              cycleEnd={cycle.end_date}
+            />
           </div>
         )}
 
@@ -605,9 +626,12 @@ export default function CycleDetailPage() {
       <BulkMoveConfirmDialog
         pending={pendingDrop}
         onClose={() => setPendingDrop(null)}
-        onConfirm={async () => {
+        onConfirm={async (propagate) => {
           if (!pendingDrop) return
-          await handleBulkAction('move', pendingDrop.sourceVisitIds, { to_date: pendingDrop.targetDate })
+          await handleBulkAction('move', pendingDrop.sourceVisitIds, {
+            to_date: pendingDrop.targetDate,
+            propagate_to_template: propagate,
+          })
           setPendingDrop(null)
         }}
       />
@@ -768,8 +792,10 @@ function BulkMoveConfirmDialog({
 }: {
   pending: { sourceVisitIds: string[]; targetDate: string; description: string } | null
   onClose: () => void
-  onConfirm: () => void
+  onConfirm: (propagate: boolean) => void
 }) {
+  const [propagate, setPropagate] = useState(true)
+  useEffect(() => { if (pending) setPropagate(true) }, [pending])
   if (!pending) return null
   return (
     <Dialog open onOpenChange={(o) => { if (!o) onClose() }}>
@@ -777,16 +803,41 @@ function BulkMoveConfirmDialog({
         <DialogHeader>
           <DialogTitle>Confirm move</DialogTitle>
         </DialogHeader>
-        <div className="space-y-2 text-sm">
+        <div className="space-y-3 text-sm">
           <p>{pending.description}.</p>
-          <p className="text-xs text-fg-muted">
-            This applies to the cycle only — template propagation arrives in 4f-3.
-            Cmd+Z to undo.
-          </p>
+          <FormField label="Apply this change to:">
+            <div className="space-y-1">
+              <label className="flex items-start gap-2 text-xs">
+                <input
+                  type="radio"
+                  checked={propagate}
+                  onChange={() => setPropagate(true)}
+                  className="mt-0.5 border-border accent-accent"
+                />
+                <span>
+                  <span className="font-medium">This cycle and the template</span> — change repeats in future cycles (default)
+                </span>
+              </label>
+              <label className="flex items-start gap-2 text-xs">
+                <input
+                  type="radio"
+                  checked={!propagate}
+                  onChange={() => setPropagate(false)}
+                  className="mt-0.5 border-border accent-accent"
+                />
+                <span>
+                  <span className="font-medium">This cycle only</span> — one-time exception
+                </span>
+              </label>
+            </div>
+          </FormField>
+          <p className="text-xs text-fg-subtle">Cmd+Z to undo.</p>
         </div>
         <DialogFooter>
           <Button variant="ghost" onClick={onClose}>Cancel</Button>
-          <Button onClick={onConfirm}>Move {pending.sourceVisitIds.length}</Button>
+          <Button onClick={() => onConfirm(propagate)}>
+            Move {pending.sourceVisitIds.length}
+          </Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>


### PR DESCRIPTION
## What ships in 4f-3
The fourth view (Map), Calendar drag-bar interactions, and the template-propagation prompt on the drag-drop dialog. This rounds out Phase 4f's user-facing surface.

## Map view
\`src/components/scheduler/CycleMapView.tsx\`. Replaces the placeholder card.

- Mapbox base. Branches render as ★ markers. Property dots are numbered, crew-colored.
- Time scrubber (HTML range slider) at the bottom; ←/→ buttons; current date label
- Right-side crew status panel: per-crew badge with state, stops + hours + miles, trip label; idle/between-trips clearly flagged
- Route polylines per crew for the selected day — solid for work days, dashed for travel days
- Fits bounds whenever day data changes
- Falls back to a friendly "VITE_MAPBOX_ACCESS_TOKEN not set" notice when the token is missing

Cycle endpoint extended: visits now include nested \`property.latitude/longitude\` so the map can plot without an extra fetch.

## Drag dialog: template propagation prompt
The \`BulkMoveConfirmDialog\` now asks scope:

```
Apply this change to:
◉ This cycle and the template — change repeats in future cycles (default)
○ This cycle only — one-time exception
```

Backend: \`POST /visits/bulk-action\` accepts \`payload.propagate_to_template\`. When true, calls the existing \`moveVisit()\` helper per row (mutates \`template.trips\` jsonb). When false, uses the bare per-row state-write path (cycle only). The bulk_operation history entry carries \`propagated_to_template\` so the drawer / audit log can show "template" badge.

## Calendar drag
Mirrors Gantt's pattern:
- Crew bars are now draggable. Day cells are drop targets.
- Drop opens the same propagation prompt as Gantt
- Day cell switched from \`<button>\` to \`<div>\` to handle nested drag correctly while still keeping click → day-detail behavior

## Trade-offs / what's explicitly NOT in this PR
Things mentioned in the original 4f spec that I'm parking until real-feedback says they're needed:

- **Play-animation** on map (auto-step the scrubber). Manual scrub is in.
- **Layer toggles** (properties / branches / routes / overnight stays). All four are always-on.
- **"Show all idle days" map filter** — would jump scrubber through idle-only days.
- **Mapbox clustering** for >500 properties when zoomed out.
- **Trip-block drag** on Gantt (multi-day overnight blocks as a unit).
- **Per-visit drag** inside a day cell (would need a richer day drawer).
- **Cluster reassign UI** (move whole geographic cluster between crews).

## Test plan
- [ ] Open cycle Map view → Mapbox renders with branches as ★ + property pins for current day
- [ ] Drag the time scrubber → markers update, polylines redraw
- [ ] Use ← / → arrow buttons to step day by day
- [ ] Right panel shows per-crew status + idle flags for current date
- [ ] Drag a Gantt cell → propagation modal appears with "this cycle + template" default
- [ ] Pick "this cycle only" → moves but template untouched (verify via Generate Cycle 2 still uses original template structure)
- [ ] Drag a crew bar in Calendar view → same modal flow
- [ ] Cmd+Z works on the bulk move (whether propagated or not)
- [ ] If \`VITE_MAPBOX_ACCESS_TOKEN\` env var is missing, Map view shows the friendly notice instead of a blank map

🤖 Generated with [Claude Code](https://claude.com/claude-code)