### PR TITLE
Show trip locations on Gantt + Calendar (not just colors)

### DIFF
--- a/src/components/scheduler/CalendarView.tsx
+++ b/src/components/scheduler/CalendarView.tsx
@@ -130,6 +130,13 @@ export default function CalendarView({ days, onDayClick, onCellDrop }: Props) {
           const cellDays = cellsByDate.get(c.date) ?? []
           const hasIdle = cellDays.some((d) => d.state.kind === 'idle')
           const isDragOver = dragOverDate === c.date
+          // Sort: working crews first, idle/between last (so the
+          // useful info reads top-down in the cell).
+          const sortedCellDays = [...cellDays].sort((a, b) => {
+            const order = (k: string) =>
+              k === 'idle' || k === 'between_trips' ? 1 : 0
+            return order(a.state.kind) - order(b.state.kind) || a.crew_index - b.crew_index
+          })
           return (
             <div
               key={c.date}
@@ -156,17 +163,19 @@ export default function CalendarView({ days, onDayClick, onCellDrop }: Props) {
               }}
               onClick={() => onDayClick?.(c.date!)}
               className={cn(
-                'border-r border-b border-border p-1.5 text-left flex flex-col gap-1 hover:bg-surface-subtle transition-colors cursor-pointer',
+                'border-r border-b border-border p-1.5 text-left flex flex-col gap-0.5 hover:bg-surface-subtle transition-colors cursor-pointer',
                 hasIdle && 'bg-warning/5',
                 isDragOver && 'ring-2 ring-warning ring-inset'
               )}
-              style={{ minHeight: 96 }}
+              style={{ minHeight: 110 }}
             >
               <p className="text-xs font-tabular text-fg-muted">{c.dom}</p>
-              {cellDays.map((d) => {
-                const pct = d.utilization_pct
+              {sortedCellDays.map((d) => {
                 const isIdle = d.state.kind === 'idle' || d.state.kind === 'between_trips'
                 const draggable = !isIdle
+                const label = isIdle
+                  ? d.state.kind === 'idle' ? 'idle' : 'between'
+                  : d.trip_label ?? '—'
                 return (
                   <div
                     key={d.crew_index}
@@ -183,18 +192,32 @@ export default function CalendarView({ days, onDayClick, onCellDrop }: Props) {
                       setDragOverDate(null)
                     }}
                     className={cn(
-                      'h-1.5 rounded-sm',
-                      isIdle ? 'bg-fg-subtle/30' : CREW_COLORS[d.crew_index % CREW_COLORS.length],
-                      d.state.kind === 'partial' && 'opacity-50',
+                      'flex items-center gap-1 text-[10px] leading-tight rounded px-1 py-0.5',
+                      isIdle
+                        ? 'bg-danger/10 text-danger'
+                        : 'bg-surface-subtle hover:bg-surface',
+                      d.state.kind === 'partial' && 'opacity-80',
                       draggable && 'cursor-grab'
                     )}
-                    style={{ width: `${Math.max(10, pct)}%` }}
                     title={`${d.crew_label}: ${d.work_hours_scheduled.toFixed(1)}h · ${d.state.kind}${draggable ? ' (drag to move)' : ''}`}
-                  />
+                  >
+                    <span
+                      className={cn(
+                        'h-2 w-2 rounded-full shrink-0',
+                        isIdle ? 'bg-danger/60' : CREW_COLORS[d.crew_index % CREW_COLORS.length]
+                      )}
+                    />
+                    <span className="truncate flex-1 font-medium text-fg">{label}</span>
+                    {!isIdle && (
+                      <span className="font-tabular text-fg-muted shrink-0">
+                        {d.work_hours_scheduled.toFixed(1)}h
+                      </span>
+                    )}
+                  </div>
                 )
               })}
               {hasIdle && (
-                <div className="text-[10px] text-danger flex items-center gap-1 mt-auto">
+                <div className="text-[9px] text-danger/70 flex items-center gap-1 mt-auto pt-0.5">
                   <AlertTriangle className="h-2.5 w-2.5" />
                   {cellDays.filter((d) => d.state.kind === 'idle').length} idle
                 </div>

--- a/src/components/scheduler/GanttView.tsx
+++ b/src/components/scheduler/GanttView.tsx
@@ -6,7 +6,7 @@
 // Each cell represents one (crew, day). Dragging a cell moves all
 // visits scheduled to that day to the target's date and crew. Per-
 // visit drag would need an expanded interaction; ships in 4f-3.
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { Fragment, useEffect, useMemo, useRef, useState } from 'react'
 import { stateClass, StateIcon, type CrewDayStateKind } from './CrewUtilizationChip'
 import { cn } from '../../lib/cn'
 
@@ -217,10 +217,30 @@ export default function GanttView({
           <tbody>
             {crews.map((crew, ci) => {
               const summary = crewSummaries[ci]
+              // Build a "trip ribbon" — consecutive same-trip days collapse
+              // into one cell so the user can read the location without
+              // hovering. Cells with no trip get their own narrow td.
+              const ribbon: Array<{ colSpan: number; label: string | null; trip_id: string | null }> = []
+              let k = 0
+              while (k < allDates.length) {
+                const c = crew.cells.get(allDates[k])
+                const tripId = c?.trip_id ?? null
+                if (!tripId) {
+                  ribbon.push({ colSpan: 1, label: null, trip_id: null })
+                  k++
+                  continue
+                }
+                let j = k
+                while (j < allDates.length && (crew.cells.get(allDates[j])?.trip_id ?? null) === tripId) j++
+                ribbon.push({ colSpan: j - k, label: c?.trip_label ?? tripId, trip_id: tripId })
+                k = j
+              }
               return (
-                <tr key={crew.index}>
+                <Fragment key={crew.index}>
+                <tr>
                   <th
-                    className="sticky left-0 z-10 bg-surface border-b border-r border-border px-3 py-2 text-left whitespace-nowrap"
+                    rowSpan={2}
+                    className="sticky left-0 z-10 bg-surface border-b border-r border-border px-3 py-2 text-left whitespace-nowrap align-top"
                     style={{ minWidth: 180 }}
                   >
                     <div className="flex items-center gap-2">
@@ -238,6 +258,22 @@ export default function GanttView({
                       </div>
                     </div>
                   </th>
+                  {ribbon.map((seg, si) => (
+                    <td
+                      key={si}
+                      colSpan={seg.colSpan}
+                      className={cn(
+                        'border-b border-border text-[11px] text-fg-muted px-1 py-0.5 truncate',
+                        seg.label && 'bg-surface-subtle font-medium text-fg'
+                      )}
+                      title={seg.label ?? ''}
+                      style={{ height: 18, minWidth: 28 }}
+                    >
+                      {seg.label ?? ''}
+                    </td>
+                  ))}
+                </tr>
+                <tr>
                   {allDates.map((d) => {
                     const cell = crew.cells.get(d)
                     if (!cell) {
@@ -317,6 +353,7 @@ export default function GanttView({
                     )
                   })}
                 </tr>
+                </Fragment>
               )
             })}
           </tbody>


### PR DESCRIPTION
## Why
User feedback: Gantt cells and Calendar day cells conveyed only the utilization color — no indication of *where* the crews are. "I can't tell what crew 1 is doing on May 5 unless I hover."

## Gantt — trip ribbon row
For each crew, render a "trip ribbon" row above the cell grid that groups consecutive same-trip days into one wide cell showing the trip label. The crew header now spans both rows via \`rowSpan={2}\`.

```
Crew 1 │ Frisco TX (local)              │ El Paso, TX – Visit 2  │ Frisco TX (local)
       │ █ █ █ █ █ █ █ █ █ █ █ █ █ █ █ │ █ █ █ █                │ █ █ █ █ █
```

Idle / between / no-cell days stay blank in the ribbon — only working trip days carry a label. Reads as a standard Gantt bar.

## Calendar — text-rich crew rows
Replaced the colored-bar-only rendering with one small line per crew per day: colored dot + trip label + hours. Idle/between rows are red-tinted and sorted to the bottom of the cell so the "what's actually happening" info reads top-down.

```
May 5 (Tue)
● Frisco TX (local)        7.5h
● El Paso, TX – Visit 2    8.0h
● Frisco TX (local)        6.2h
⚠ idle
```

Cell min-height bumped 96 → 110 to fit ~6 crews comfortably. Drag-drop semantics unchanged (drag a crew row to another day).

## Map
No change — user said it looks good as-is.

## Test plan
- [ ] Gantt: each crew row shows a trip ribbon above the colored cells, labeled with the trip name spanning the trip's days
- [ ] Long contiguous local trips (~30 days for a 0.5yr cluster) show one wide ribbon cell with the location
- [ ] Idle / between days in the ribbon stay blank
- [ ] Calendar: each day cell shows lines like "● Frisco TX (local) — 7.5h" instead of just colored bars
- [ ] Idle crews show with red dot + "idle" label, sorted to bottom of cell

🤖 Generated with [Claude Code](https://claude.com/claude-code)