### PR TITLE
Branch-prefixed crew labels (e.g. Frisco TX Crew 1)

### DIFF
--- a/api/_lib/scheduler/build-routing-template.ts
+++ b/api/_lib/scheduler/build-routing-template.ts
@@ -286,6 +286,38 @@ export function buildRoutingTemplate(input: BuildTemplateInput): TemplateBuildRe
     target.total_drive_hours += cluster.estimated_drive_hours
   }
 
+  // Branch-prefixed crew labels: pick each crew's dominant branch
+  // (most work hours among assigned clusters) and number per-branch so
+  // labels read "Frisco TX Crew 1", "Frisco TX Crew 2", "Sugarland Crew 1".
+  if (input.branches.length > 0) {
+    const branchCounters = new Map<number, number>()
+    for (const crew of crews) {
+      const workByBranch = new Map<number, number>()
+      for (const clusterId of crew.cluster_ids) {
+        const cluster = clusters.find((c) => c.cluster_id === clusterId)
+        if (!cluster) continue
+        workByBranch.set(
+          cluster.base_branch_index,
+          (workByBranch.get(cluster.base_branch_index) ?? 0) + cluster.total_work_hours
+        )
+      }
+      let dominantBranchIdx = -1
+      let dominantHours = -1
+      for (const [idx, hours] of workByBranch) {
+        if (hours > dominantHours) {
+          dominantHours = hours
+          dominantBranchIdx = idx
+        }
+      }
+      if (dominantBranchIdx >= 0) {
+        const branchName = input.branches[dominantBranchIdx]?.name ?? `Branch ${dominantBranchIdx + 1}`
+        const counter = (branchCounters.get(dominantBranchIdx) ?? 0) + 1
+        branchCounters.set(dominantBranchIdx, counter)
+        crew.label = `${branchName} Crew ${counter}`
+      }
+    }
+  }
+
   // ── 5. Sequence trips on cycle calendar ───────────────────────────
   const trips: any[] = []
   const unplaced: any[] = []

--- a/api/_lib/scheduler/generate-cycle-instance.ts
+++ b/api/_lib/scheduler/generate-cycle-instance.ts
@@ -130,6 +130,16 @@ export async function generateCycleInstance(
   const scheduledVisits: any[] = []
   let addonsDropped = 0
 
+  // Look up branch-prefixed crew labels (e.g. "Frisco TX Crew 1") from
+  // the template; fall back to generic "Crew N" for older templates that
+  // pre-date the labeling pass.
+  const crewLabelByIndex = new Map<number, string>()
+  for (const ca of (template.crew_assignments ?? []) as any[]) {
+    if (typeof ca?.crew_index === 'number' && typeof ca?.crew_label === 'string') {
+      crewLabelByIndex.set(ca.crew_index, ca.crew_label)
+    }
+  }
+
   for (const trip of trips) {
     for (const day of trip.days ?? []) {
       const dayOffset = (trip.relative_start_day ?? 0) + ((day.trip_day_number ?? 1) - 1)
@@ -144,7 +154,7 @@ export async function generateCycleInstance(
         trip_id: trip.trip_id,
         trip_label: trip.trip_label ?? trip.trip_id,
         crew_index: trip.crew_index ?? 0,
-        crew_label: `Crew ${(trip.crew_index ?? 0) + 1}`,
+        crew_label: crewLabelByIndex.get(trip.crew_index ?? 0) ?? `Crew ${(trip.crew_index ?? 0) + 1}`,
         scheduled_date: scheduledDate,
         day_type: trip.trip_type === 'overnight' ? 'overnight' : 'local',
         start_location: trip.start_location ?? {},


### PR DESCRIPTION
## Summary
- Renames crews from generic `Crew 1, 2, 3` to branch-prefixed `Frisco TX Crew 1`, `Frisco TX Crew 2`, `Sugarland Crew 1`, etc.
- Each crew's dominant branch is picked by summing `total_work_hours` across the clusters it was assigned, then numbered per-branch with a counter.
- `generate-cycle-instance` reads the new label out of `template.crew_assignments` and falls back to the old `Crew N` form for templates built before this change.

## Notes
- **Existing templates + cycles will keep their old "Crew N" labels** — to see the new labels you'll need to regenerate the template and the cycle instance.
- Falls back to `Crew N` if no branches were provided to the builder.

## Test plan
- [ ] Regenerate the JLL template — confirm `crew_assignments[].crew_label` shows branch-prefixed names
- [ ] Regenerate a cycle from that template — confirm `crew_day_routes.crew_label` matches
- [ ] Gantt + Calendar + List + Map views show the new labels in crew headers / pills
- [ ] Pre-existing cycles still render `Crew 1, 2, 3` (backwards-compat fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)