### PR TITLE
Phase 3.8 — building-count crew math + size-class pairing

### DIFF
--- a/api/_lib/analysis/account-data.ts
+++ b/api/_lib/analysis/account-data.ts
@@ -26,6 +26,8 @@ export interface AccountServiceLocation {
   visits_per_year_override: number | null
   service_offering_id: string | null
   status: string
+  building_size_class_override?: 'small' | 'standard' | 'large' | 'multi_day' | null
+  building_size_override_reason?: string | null
 }
 
 // Pull every property whose service_locations belong to (account_id, client_id).
@@ -60,7 +62,7 @@ export async function loadAccountProperties(
   const { data: props, error: propErr } = await db
     .from('properties')
     .select(
-      'id, address_line1, address_line2, city, state, postal_code, latitude, longitude, geocode_confidence, address_validation_verdict, service_locations(id, property_id, client_id, display_name, serviceable_sqft, visits_per_year_override, service_offering_id, status)'
+      'id, address_line1, address_line2, city, state, postal_code, latitude, longitude, geocode_confidence, address_validation_verdict, service_locations(id, property_id, client_id, display_name, serviceable_sqft, visits_per_year_override, service_offering_id, status, building_size_class_override, building_size_override_reason)'
     )
     .in('id', propIds)
   if (propErr) throw new Error(`properties lookup failed: ${propErr.message}`)

--- a/api/_lib/analysis/building-size.ts
+++ b/api/_lib/analysis/building-size.ts
@@ -1,0 +1,42 @@
+// Phase 3.8 — building size classification.
+//
+// Crews can typically only do one building per day regardless of how
+// many hours that building takes (setup, breakdown, drive between, and
+// crew workflow constraints). Two small buildings can sometimes pair
+// in a single day, and very large buildings consume multiple days.
+
+export type BuildingSizeClass = 'small' | 'standard' | 'large' | 'multi_day'
+
+export function classifyBuildingSize(hoursPerVisit: number): BuildingSizeClass {
+  if (hoursPerVisit <= 4) return 'small'
+  if (hoursPerVisit <= 8) return 'standard'
+  if (hoursPerVisit <= 16) return 'large'
+  return 'multi_day'
+}
+
+export function effectiveSizeClass(serviceLocation: {
+  hours_per_visit: number
+  building_size_class_override?: BuildingSizeClass | null
+}): BuildingSizeClass {
+  return (
+    serviceLocation.building_size_class_override ??
+    classifyBuildingSize(serviceLocation.hours_per_visit)
+  )
+}
+
+export function crewDaysPerVisit(
+  sizeClass: BuildingSizeClass,
+  hoursPerVisit: number,
+  mode: 'conservative' | 'optimistic'
+): number {
+  switch (sizeClass) {
+    case 'small':
+      return mode === 'optimistic' ? 0.5 : 1.0
+    case 'standard':
+      return 1.0
+    case 'large':
+      return 1.0
+    case 'multi_day':
+      return Math.max(1, Math.ceil(hoursPerVisit / 8))
+  }
+}

--- a/api/_lib/analysis/crew-count.ts
+++ b/api/_lib/analysis/crew-count.ts
@@ -1,0 +1,115 @@
+// Phase 3.8 — building-count crew math.
+//
+// Replaces the hours-based crew count (annual hours / FTE hours) with
+// a building-day model: 1 building = 1 crew-day by default, with
+// pairing-aware optimistic and no-pairing conservative variants.
+import {
+  classifyBuildingSize,
+  crewDaysPerVisit,
+  effectiveSizeClass,
+  type BuildingSizeClass,
+} from './building-size.js'
+import { countWorkingDays, getDefaultHolidays } from './working-days.js'
+
+export interface CrewCountInput {
+  routed_visits: Array<{
+    service_location_id: string
+    hours_per_visit: number
+    building_size_class_override?: BuildingSizeClass | null
+  }>
+  cycle_length_days: number
+  cycle_start_date?: Date
+  cycles_per_year: number
+}
+
+export interface CrewCountModeResult {
+  total_crew_days_per_cycle: number
+  working_days_per_cycle: number
+  crews_needed: number
+  rationale: string
+}
+
+export interface CrewCountResult {
+  conservative: CrewCountModeResult
+  optimistic: CrewCountModeResult
+  size_class_breakdown: Record<BuildingSizeClass, number>
+  total_visits_per_cycle: number
+  cycles_per_year: number
+}
+
+export function computeCrewCount(input: CrewCountInput): CrewCountResult {
+  let conservativeCrewDays = 0
+  let optimisticCrewDays = 0
+  const sizeBreakdown: Record<BuildingSizeClass, number> = {
+    small: 0,
+    standard: 0,
+    large: 0,
+    multi_day: 0,
+  }
+
+  for (const visit of input.routed_visits) {
+    const sizeClass = effectiveSizeClass(visit)
+    sizeBreakdown[sizeClass]++
+    conservativeCrewDays += crewDaysPerVisit(
+      sizeClass,
+      visit.hours_per_visit,
+      'conservative'
+    )
+    optimisticCrewDays += crewDaysPerVisit(
+      sizeClass,
+      visit.hours_per_visit,
+      'optimistic'
+    )
+  }
+
+  const start = input.cycle_start_date ?? new Date()
+  const end = new Date(
+    Date.UTC(
+      start.getUTCFullYear(),
+      start.getUTCMonth(),
+      start.getUTCDate() + input.cycle_length_days
+    )
+  )
+  const workingDays = Math.max(
+    1,
+    countWorkingDays({
+      startDate: start,
+      endDate: end,
+      excludeWeekends: true,
+      holidays: getDefaultHolidays(start, end),
+    })
+  )
+
+  const conservativeCrews = Math.max(
+    1,
+    Math.ceil(conservativeCrewDays / workingDays)
+  )
+  const optimisticCrews = Math.max(
+    1,
+    Math.ceil(optimisticCrewDays / workingDays)
+  )
+
+  return {
+    conservative: {
+      total_crew_days_per_cycle: round1(conservativeCrewDays),
+      working_days_per_cycle: workingDays,
+      crews_needed: conservativeCrews,
+      rationale: `${round1(conservativeCrewDays)} building-days needed, ${workingDays} working days in cycle, no pairing assumed`,
+    },
+    optimistic: {
+      total_crew_days_per_cycle: round1(optimisticCrewDays),
+      working_days_per_cycle: workingDays,
+      crews_needed: optimisticCrews,
+      rationale: `${round1(optimisticCrewDays)} building-days needed (with small-property pairing), ${workingDays} working days in cycle`,
+    },
+    size_class_breakdown: sizeBreakdown,
+    total_visits_per_cycle: input.routed_visits.length,
+    cycles_per_year: input.cycles_per_year,
+  }
+}
+
+function round1(n: number): number {
+  return Math.round(n * 10) / 10
+}
+
+export { classifyBuildingSize }

--- a/api/_lib/analysis/edit-cascade.ts
+++ b/api/_lib/analysis/edit-cascade.ts
@@ -129,6 +129,14 @@ export function determineCascadingEffects(
         )
         continue
       }
+      if (c.field === 'building_size_class_override') {
+        addStale(
+          c.field,
+          ['crew_strategy', 'bid_pricing_structure'],
+          'Building-size override changes crew-day math + scheduler pairing.'
+        )
+        continue
+      }
       if (c.field === 'crew_size_override') {
         addStale(
           c.field,

--- a/api/_lib/analysis/working-days.ts
+++ b/api/_lib/analysis/working-days.ts
@@ -1,0 +1,104 @@
+// Phase 3.8 — working day counting (weekdays minus federal holidays).
+//
+// Crew count math divides building-days needed by working days in the
+// cycle, so we need an accurate working-day count, not a 5/7 estimate
+// that ignores holiday weeks.
+
+export interface WorkingDaysInput {
+  startDate: Date
+  endDate: Date
+  excludeWeekends?: boolean
+  holidays?: Date[]
+}
+
+export function countWorkingDays(input: WorkingDaysInput): number {
+  const exclWeekends = input.excludeWeekends ?? true
+  const holidayKeys = new Set(
+    (input.holidays ?? []).map((d) => toDateKey(d))
+  )
+  let count = 0
+  const cur = new Date(
+    Date.UTC(
+      input.startDate.getUTCFullYear(),
+      input.startDate.getUTCMonth(),
+      input.startDate.getUTCDate()
+    )
+  )
+  const end = new Date(
+    Date.UTC(
+      input.endDate.getUTCFullYear(),
+      input.endDate.getUTCMonth(),
+      input.endDate.getUTCDate()
+    )
+  )
+  while (cur <= end) {
+    const dow = cur.getUTCDay()
+    const isWeekend = dow === 0 || dow === 6
+    const key = toDateKey(cur)
+    if ((!exclWeekends || !isWeekend) && !holidayKeys.has(key)) count++
+    cur.setUTCDate(cur.getUTCDate() + 1)
+  }
+  return count
+}
+
+function toDateKey(d: Date): string {
+  return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}-${String(
+    d.getUTCDate()
+  ).padStart(2, '0')}`
+}
+
+// US federal holidays for the years a span overlaps. Hardcoded for
+// Phase 3.8; later phases can make this user-configurable per account.
+export function getDefaultHolidays(startDate: Date, endDate: Date): Date[] {
+  const startYear = startDate.getUTCFullYear()
+  const endYear = endDate.getUTCFullYear()
+  const out: Date[] = []
+  for (let y = startYear; y <= endYear; y++) {
+    out.push(...holidaysForYear(y))
+  }
+  return out
+}
+
+function holidaysForYear(year: number): Date[] {
+  return [
+    utc(year, 1, 1), // New Year's Day
+    nthWeekdayOfMonth(year, 1, 1, 3), // MLK Day — 3rd Monday Jan
+    nthWeekdayOfMonth(year, 2, 1, 3), // Presidents Day — 3rd Monday Feb
+    lastWeekdayOfMonth(year, 5, 1), // Memorial Day — last Monday May
+    utc(year, 6, 19), // Juneteenth
+    utc(year, 7, 4), // Independence Day
+    nthWeekdayOfMonth(year, 9, 1, 1), // Labor Day — 1st Monday Sept
+    nthWeekdayOfMonth(year, 10, 1, 2), // Columbus Day — 2nd Monday Oct
+    utc(year, 11, 11), // Veterans Day
+    nthWeekdayOfMonth(year, 11, 4, 4), // Thanksgiving — 4th Thursday Nov
+    addDaysUtc(nthWeekdayOfMonth(year, 11, 4, 4), 1), // Day after Thanksgiving
+    utc(year, 12, 24), // Christmas Eve
+    utc(year, 12, 25), // Christmas Day
+  ]
+}
+
+function utc(year: number, month: number, day: number): Date {
+  return new Date(Date.UTC(year, month - 1, day))
+}
+
+function nthWeekdayOfMonth(
+  year: number,
+  month: number,
+  weekday: number, // 0=Sun ... 6=Sat
+  n: number
+): Date {
+  const first = new Date(Date.UTC(year, month - 1, 1))
+  const offset = (weekday - first.getUTCDay() + 7) % 7
+  return new Date(Date.UTC(year, month - 1, 1 + offset + (n - 1) * 7))
+}
+
+function lastWeekdayOfMonth(year: number, month: number, weekday: number): Date {
+  // Walk back from the last day of the month.
+  const last = new Date(Date.UTC(year, month, 0))
+  const offset = (last.getUTCDay() - weekday + 7) % 7
+  return new Date(Date.UTC(year, month - 1, last.getUTCDate() - offset))
+}
+
+function addDaysUtc(d: Date, n: number): Date {
+  return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate() + n))
+}

--- a/api/_lib/scheduler/build-routing-template.ts
+++ b/api/_lib/scheduler/build-routing-template.ts
@@ -31,6 +31,9 @@ export interface PropertyForBuild {
   parent_visit_interval_years: number
   base_hours_per_visit: number
   constraints: StoredConstraint[]
+  // Phase 3.8 — per-SL building-size override (forwarded to routeDay so
+  // the in-day pairing rule respects manual reclassifications).
+  building_size_class_override?: 'small' | 'standard' | 'large' | 'multi_day' | null
   eligible_addons: Array<{
     cohort_assignment_id: string
     offering_id: string
@@ -94,6 +97,7 @@ interface VisitSpec {
   lng: number
   constraints: StoredConstraint[]
   address: string
+  building_size_class_override?: 'small' | 'standard' | 'large' | 'multi_day' | null
 }
 
 interface ClusterSpec {
@@ -210,6 +214,7 @@ export function buildRoutingTemplate(input: BuildTemplateInput): TemplateBuildRe
         lng: p.lng,
         constraints: p.constraints,
         address: p.address,
+        building_size_class_override: p.building_size_class_override ?? null,
       })
     }
   }
@@ -396,6 +401,7 @@ export function buildRoutingTemplate(input: BuildTemplateInput): TemplateBuildRe
             hours_per_visit: v.hours_per_visit,
             visits_per_year: 1,
             constraints: v.constraints,
+            building_size_class_override: v.building_size_class_override ?? null,
           }))
           const baseRoutingConfig = {
             crew_size: input.config.crew_size,

--- a/api/_lib/scheduler/route-day.ts
+++ b/api/_lib/scheduler/route-day.ts
@@ -13,6 +13,10 @@ import {
   type ConstraintEvaluation,
   type StoredConstraint,
 } from './constraint-evaluator.js'
+import {
+  effectiveSizeClass,
+  type BuildingSizeClass,
+} from '../analysis/building-size.js'
 
 export interface PropertyForRouting {
   id: string // service_location_id
@@ -23,6 +27,8 @@ export interface PropertyForRouting {
   hours_per_visit: number
   visits_per_year: number
   constraints: StoredConstraint[]
+  // Phase 3.8 — optional per-SL override of auto-computed size class.
+  building_size_class_override?: BuildingSizeClass | null
 }
 
 export interface DayRoutingInput {
@@ -37,6 +43,11 @@ export interface DayRoutingInput {
     buffer_minutes_per_stop: number
     drive_speed_mph: number
     return_to_branch: boolean
+    // Phase 3.8 — in-day pairing rule. Default cap of 2 buildings/day,
+    // and the second slot only opens when both buildings are 'small'
+    // size class and within the max drive minutes of each other.
+    in_day_pairing_max_drive_minutes?: number
+    in_day_pairing_max_buildings_per_day?: number
   }
   preferences: {
     objective: 'minimize_drive' | 'maximize_properties' | 'balanced'
@@ -152,7 +163,15 @@ export function routeDay(input: DayRoutingInput): DayRoutingResult {
   let currentMin = toMinutes(input.config.work_start_time)
   let sequence = 1
 
+  // Phase 3.8 — in-day pairing rule (max 2 buildings, both small + close
+  // for the second slot). Hardcap regardless of size keeps the operational
+  // reality (setup/breakdown overhead) honest.
+  const maxPerDay = input.config.in_day_pairing_max_buildings_per_day ?? 2
+  const maxPairDriveMin = input.config.in_day_pairing_max_drive_minutes ?? 30
+
   while (remaining.size > 0) {
+    if (route.length >= maxPerDay) break
+
     let bestId: string | null = null
     let bestScore = Infinity
     let bestMeta: {
@@ -182,6 +201,26 @@ export function routeDay(input: DayRoutingInput): DayRoutingResult {
           )
         : 0
       if (workEndMin + returnDriveMin > workEnd) continue
+
+      // Pairing rule: a second building only fits if both are 'small'
+      // class AND within the configured drive radius of each other.
+      if (route.length >= 1) {
+        const candidateClass = effectiveSizeClass({
+          hours_per_visit: p.hours_per_visit,
+          building_size_class_override: p.building_size_class_override,
+        })
+        if (candidateClass !== 'small') continue
+        const firstStop = route[0]
+        const firstProp = candidates.find((c) => c.id === firstStop.service_location_id)
+        if (firstProp) {
+          const firstClass = effectiveSizeClass({
+            hours_per_visit: firstProp.hours_per_visit,
+            building_size_class_override: firstProp.building_size_class_override,
+          })
+          if (firstClass !== 'small') continue
+        }
+        if (driveMin > maxPairDriveMin) continue
+      }
 
       // Soft-constraint penalty at this proposed schedule
       const ctx = {

--- a/api/analyses/account/[accountId]/clients/[clientId]/bid-pricing-structure.ts
+++ b/api/analyses/account/[accountId]/clients/[clientId]/bid-pricing-structure.ts
@@ -110,6 +110,22 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     const branchOpt = await fetchLatestCompletedAnalysis(db, accountId, clientId, 'branch_optimization')
     const workforce = await fetchLatestCompletedAnalysis(db, accountId, clientId, 'workforce_sizing')
 
+    // Phase 3.8 — when an active routing template exists for this client,
+    // the scheduler's actual numbers are the source of truth. Prefer them
+    // over Crew Strategy's pre-scheduler estimate.
+    const { data: schedulerTemplateRow } = await db
+      .from('routing_templates')
+      .select(
+        'id, name, crew_count, cycle_length_days, total_drive_miles_per_cycle, total_work_minutes_per_cycle, total_overnight_nights_per_cycle, total_estimated_cost_per_year'
+      )
+      .eq('account_id', accountId)
+      .eq('client_id', clientId)
+      .eq('status', 'active')
+      .order('updated_at', { ascending: false })
+      .limit(1)
+      .maybeSingle()
+    const schedulerTemplate = (schedulerTemplateRow as any) ?? null
+
     // Phase 3.7 — calculate overnight cost from selected branches + property
     // visit hours, then resolve final hotels value (override / calc / flat).
     const offerings = await loadAccountOfferings(db, accountId, clientId)
@@ -161,7 +177,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       crewStrategy?.outputs,
       branchOpt?.outputs,
       workforce?.outputs,
-      hotelsResolved
+      hotelsResolved,
+      schedulerTemplate
     )
 
     await completeAnalysisRecord(db, analysisId, {
@@ -177,18 +194,48 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   }
 }
 
+export type BidPricingSource =
+  | 'scheduler_template'
+  | 'crew_strategy_estimate'
+  | 'manual_override'
+
 export function computeBidPricing(
   properties: Awaited<ReturnType<typeof loadAccountProperties>>,
   inputs: BidInputs,
   crewStrategyOutputs: any,
   branchOptOutputs: any,
   workforceOutputs: any,
-  hotelsResolved?: ResolvedHotelsCost
+  hotelsResolved?: ResolvedHotelsCost,
+  schedulerTemplate?: {
+    id: string
+    name: string
+    crew_count: number
+    cycle_length_days: number
+    total_drive_miles_per_cycle: number | null
+    total_work_minutes_per_cycle: number | null
+    total_overnight_nights_per_cycle: number | null
+  } | null
 ) {
   let resolvedLabor = inputs.total_annual_labor_cost
   let resolvedVehicleFuel = inputs.total_annual_vehicle_cost
   let resolvedCrewCount = inputs.crew_count
   let recommendedOption: string | null = null
+  // Phase 3.8 — track where each number actually came from. Manual
+  // overrides win, then scheduler template, then crew_strategy estimate.
+  const manualOverride =
+    inputs.crew_count != null ||
+    inputs.total_annual_labor_cost != null ||
+    inputs.total_annual_vehicle_cost != null
+  let source: BidPricingSource = manualOverride
+    ? 'manual_override'
+    : schedulerTemplate
+      ? 'scheduler_template'
+      : 'crew_strategy_estimate'
+
+  // Scheduler template wins when present — it's the actual operational plan.
+  if (schedulerTemplate && !manualOverride) {
+    if (resolvedCrewCount == null) resolvedCrewCount = schedulerTemplate.crew_count
+  }
 
   if (crewStrategyOutputs) {
     recommendedOption = crewStrategyOutputs.recommended_option
@@ -274,7 +321,13 @@ export function computeBidPricing(
   summaryParts.push(
     `Monthly invoice estimate: $${Math.round(monthly_invoice_estimate).toLocaleString()}.`
   )
-  if (recommendedOption) {
+  if (source === 'scheduler_template' && schedulerTemplate) {
+    summaryParts.push(
+      `Crew count from active scheduler template "${schedulerTemplate.name}" (${resolvedCrewCount} crews).`
+    )
+  } else if (source === 'manual_override') {
+    summaryParts.push('Crew count + costs from manual override.')
+  } else if (recommendedOption) {
     summaryParts.push(`Labor pulled from Crew Strategy Option ${recommendedOption}.`)
   }
 
@@ -287,6 +340,10 @@ export function computeBidPricing(
         crew_count: resolvedCrewCount,
         branch_count: resolvedBranchCount,
         fte_count: fteCount,
+        source,
+        scheduler_template: schedulerTemplate
+          ? { id: schedulerTemplate.id, name: schedulerTemplate.name }
+          : null,
       },
       cost_buildup: {
         direct_labor: Math.round(direct_labor),

--- a/api/analyses/account/[accountId]/clients/[clientId]/crew-strategy.ts
+++ b/api/analyses/account/[accountId]/clients/[clientId]/crew-strategy.ts
@@ -33,6 +33,8 @@ import {
   type OvernightConfig,
   type OvernightResult,
 } from '../../../../../_lib/analysis/overnight-calculator.js'
+import { computeCrewCount } from '../../../../../_lib/analysis/crew-count.js'
+import type { BuildingSizeClass } from '../../../../../_lib/analysis/building-size.js'
 
 // Status enum for utilization band evaluation. Order matters for severity:
 // 'overcapacity' > 'underutilized' > 'acceptable' > 'ideal'.
@@ -239,6 +241,13 @@ export function computeCrewStrategy(
   }
 
   const perProperty: PropertyHours[] = []
+  // Phase 3.8 — per-visit list for building-count crew math.
+  const routedVisits: Array<{
+    service_location_id: string
+    hours_per_visit: number
+    building_size_class_override?: BuildingSizeClass | null
+    branch_idx: number
+  }> = []
   let totalAnnualHours = 0
   let totalProjectHours = 0
   let propertiesMissingCoords = 0
@@ -256,6 +265,12 @@ export function computeCrewStrategy(
     }
 
     let propAnnualHours = 0
+    const slHoursForProperty: Array<{
+      sl_id: string
+      hours_per_visit: number
+      visits: number
+      override: BuildingSizeClass | null
+    }> = []
     for (const sl of p.service_locations) {
       const offering = sl.service_offering_id ? offerings.get(sl.service_offering_id) : null
       const cls = offering ? classifyOffering(offering.name) : 'other'
@@ -279,6 +294,13 @@ export function computeCrewStrategy(
       hoursPerVisit = Math.max(hoursPerVisit, 1)
 
       propAnnualHours += hoursPerVisit * visits
+      slHoursForProperty.push({
+        sl_id: sl.id,
+        hours_per_visit: hoursPerVisit,
+        visits,
+        override:
+          (sl.building_size_class_override as BuildingSizeClass | null | undefined) ?? null,
+      })
     }
 
     // Find nearest branch (re-cluster against the chosen branch set so we can
@@ -298,6 +320,20 @@ export function computeCrewStrategy(
       propertiesMissingCoords += 1
     }
 
+    // Emit one routed_visit per (SL × visits/year) for the building-count
+    // math. branch_idx attribution lets us split into per-branch counts
+    // for Option B.
+    for (const sh of slHoursForProperty) {
+      for (let v = 0; v < sh.visits; v++) {
+        routedVisits.push({
+          service_location_id: sh.sl_id,
+          hours_per_visit: sh.hours_per_visit,
+          building_size_class_override: sh.override,
+          branch_idx: bestIdx,
+        })
+      }
+    }
+
     perProperty.push({ property: p, annual_hours: propAnnualHours, branch_idx: bestIdx })
     totalAnnualHours += propAnnualHours
     totalProjectHours += propAnnualHours
@@ -311,10 +347,37 @@ export function computeCrewStrategy(
     branchPropCount[ph.branch_idx] += 1
   }
 
+  // ── Phase 3.8 — Building-count crew math (replaces hours-based) ──────────
+  // 1 building = 1 crew-day (default), with small-property pairing as the
+  // optimistic ceiling. Uses actual working days, not 5/7 of calendar.
+  const crewCountAnalysis = computeCrewCount({
+    routed_visits: routedVisits,
+    cycle_length_days: 365,
+    cycles_per_year: 1,
+  })
+  // Per-branch slice for Option B (each branch's crews scale with its own
+  // building-day workload).
+  const crewCountPerBranch = branches.map((_, i) => {
+    const branchVisits = routedVisits.filter((v) => v.branch_idx === i)
+    if (branchVisits.length === 0) {
+      return { conservative: 1, optimistic: 1 }
+    }
+    const a = computeCrewCount({
+      routed_visits: branchVisits,
+      cycle_length_days: 365,
+      cycles_per_year: 1,
+    })
+    return {
+      conservative: a.conservative.crews_needed,
+      optimistic: a.optimistic.crews_needed,
+    }
+  })
+
   // ── Option A: Roving ──────────────────────────────────────────────────────
-  // Variable cost — paid only for hours worked. Right-size crew count so that
-  // crews × FTE-hours ≈ work-hours / target-utilization.
-  const optionA_crews = Math.max(1, Math.ceil(totalAnnualHours / (FTE_HOURS_PER_YEAR * 0.89)))
+  // Variable cost — paid only for hours worked. Crew count comes from the
+  // building-count math (conservative); cost is hours-based regardless.
+  const optionA_crews = crewCountAnalysis.conservative.crews_needed
+  const optionA_crews_optimistic = crewCountAnalysis.optimistic.crews_needed
   const optionA_labor =
     totalAnnualHours * inputs.hourly_loaded_labor_cost * inputs.crew_size
   const optionA_util_pct =
@@ -349,49 +412,19 @@ export function computeCrewStrategy(
     }
   })
 
-  // ── Option B: Dedicated — size each branch to fit the utilization band ───
-  // Algorithm per spec:
-  //   start = max(1, floor(work / FTE))
-  //   if util > soft_ceiling, try N+1 until in band or no improvement
-  //   if util < hard_floor, try N-1 (min 1) until in band or no improvement
-  // Status comes from classifyUtilization on the final crew count.
+  // ── Option B: Dedicated — size each branch from building-count math ──────
+  // Each branch gets ceil(branch_building_days / branch_working_days).
+  // The utilization band is no longer the primary driver — it survives
+  // below as informational annotation on the per-branch breakdown.
   const band = inputs.utilization_constraint
   const bandActive = band.enabled
-  const crewsPerBranch = new Array(branches.length).fill(1)
-  for (let i = 0; i < branches.length; i++) {
-    const work = branchHours[i]
-    if (work <= 0) {
-      crewsPerBranch[i] = 1
-      continue
-    }
-    let n = Math.max(1, Math.floor(work / FTE_HOURS_PER_YEAR))
-    if (bandActive) {
-      // Bump up while overcapacity
-      let util = (work / (n * FTE_HOURS_PER_YEAR)) * 100
-      while (util > band.soft_ceiling_pct && n < 10) {
-        n += 1
-        util = (work / (n * FTE_HOURS_PER_YEAR)) * 100
-      }
-      // Bump down while underutilized + still has slack
-      while (n > 1 && (work / ((n - 1) * FTE_HOURS_PER_YEAR)) * 100 <= band.soft_ceiling_pct) {
-        const newUtil = (work / ((n - 1) * FTE_HOURS_PER_YEAR)) * 100
-        if (newUtil < band.hard_floor_pct) break // would push below floor — stop
-        n -= 1
-      }
-    } else {
-      // Constraint disabled → fall back to legacy "largest branch gets +1"
-      n = 1
-    }
-    crewsPerBranch[i] = n
-  }
-  // Legacy "+1 to largest" fallback when band disabled
-  if (!bandActive && branches.length >= 1) {
-    const largestIdx = branches
-      .map((_, i) => i)
-      .sort((a, b) => branchHours[b] - branchHours[a])[0]
-    crewsPerBranch[largestIdx] = 2
-  }
+  const crewsPerBranch = crewCountPerBranch.map((c) => Math.max(1, c.conservative))
+  const crewsPerBranchOptimistic = crewCountPerBranch.map((c) => Math.max(1, c.optimistic))
   const optionB_crews = crewsPerBranch.reduce((a: number, b: number) => a + b, 0)
+  const optionB_crews_optimistic = crewsPerBranchOptimistic.reduce(
+    (a: number, b: number) => a + b,
+    0
+  )
 
   const optionB_labor =
     optionB_crews * FTE_HOURS_PER_YEAR * inputs.hourly_loaded_labor_cost * inputs.crew_size
@@ -404,6 +437,7 @@ export function computeCrewStrategy(
     city_state: string
     population: number | null
     crew_count: number
+    crew_count_optimistic: number
     work_hours: number
     available_hours: number
     utilization_pct: number
@@ -437,6 +471,7 @@ export function computeCrewStrategy(
       city_state: branchMeta[i].city_state,
       population: branchMeta[i].population,
       crew_count: crews,
+      crew_count_optimistic: crewsPerBranchOptimistic[i],
       work_hours: Math.round(branchHours[i]),
       available_hours: Math.round(available),
       utilization_pct: utilPct,
@@ -500,17 +535,22 @@ export function computeCrewStrategy(
 
   let recommended: 'A' | 'B' | 'C' = 'B'
   let recommendedRationale = ''
+  const buildingMath = `${routedVisits.length} building-days ÷ ${crewCountAnalysis.conservative.working_days_per_cycle} working days = ${crewCountAnalysis.conservative.crews_needed} crews (conservative)${
+    crewCountAnalysis.optimistic.crews_needed !== crewCountAnalysis.conservative.crews_needed
+      ? `, ${crewCountAnalysis.optimistic.crews_needed} with small-property pairing`
+      : ''
+  }.`
   if (properties.length > 400 && distinctStates > 5) {
     recommended = 'B'
-    recommendedRationale = `${properties.length} properties across ${distinctStates} states — Option B (Dedicated) is the most defensible choice for Year 1. Predictable operations, simple to staff, and easier to bid against. Consider Option A in Year 2-3 once dispatch is dialed in.`
+    recommendedRationale = `${properties.length} properties across ${distinctStates} states — Option B (Dedicated) is the most defensible choice for Year 1. ${buildingMath} Predictable operations, simple to staff, and easier to bid against. Consider Option A in Year 2-3 once dispatch is dialed in.`
   } else if (cVsBSavingsPct > 0.15) {
     recommended = 'C'
     recommendedRationale = `Option C saves ${Math.round(
       cVsBSavingsPct * 100
-    )}% in labor vs Option B. Strong candidate IF surge sourcing is reliable in this region — verify with regional ops before committing.`
+    )}% in labor vs Option B. ${buildingMath} Strong candidate IF surge sourcing is reliable in this region — verify with regional ops before committing.`
   } else {
     recommended = 'B'
-    recommendedRationale = `Option B (Dedicated) is the recommended baseline. Option C savings are below the 15% threshold needed to justify surge sourcing risk.`
+    recommendedRationale = `Option B (Dedicated) is the recommended baseline. ${buildingMath} Option C savings are below the 15% threshold needed to justify surge sourcing risk.`
   }
 
   // ── Per-region rollup for Option B ────────────────────────────────────────
@@ -677,6 +717,7 @@ export function computeCrewStrategy(
     A: {
       label: 'Roving Crews',
       crew_count: optionA_crews,
+      crew_count_optimistic: optionA_crews_optimistic,
       utilization_pct: optionA_util_pct,
       annual_labor_cost: Math.round(optionA_labor),
       annual_vehicle_cost: Math.round(optionA_vehicle),
@@ -699,6 +740,7 @@ export function computeCrewStrategy(
     B: {
       label: 'Dedicated Crews',
       crew_count: optionB_crews,
+      crew_count_optimistic: optionB_crews_optimistic,
       utilization_pct: optionB_util_pct,
       annual_labor_cost: Math.round(optionB_labor),
       annual_vehicle_cost: Math.round(optionB_vehicle),
@@ -775,6 +817,7 @@ export function computeCrewStrategy(
       property_count: properties.length,
       k_used: kUsed,
       total_project_hours_per_year: Math.round(totalProjectHours),
+      crew_count_analysis: crewCountAnalysis,
       branches: branches.map((b, i) => ({
         ...b,
         city_state: branchMeta[i].city_state,

--- a/api/analyses/account/[accountId]/clients/[clientId]/synthesize.ts
+++ b/api/analyses/account/[accountId]/clients/[clientId]/synthesize.ts
@@ -151,6 +151,11 @@ Format full_report_markdown with these sections (in order):
 ## Risks & Considerations
 ## Sensitivity Notes
 
+Phase 3.8 — building-count crew math:
+- Crew Strategy now reports BOTH a conservative crew count (1 building = 1 crew-day, no pairing) AND an optimistic count (small adjacent properties paired in a single day). The conservative number is what to size the bid around; the optimistic is how low you could go if scheduling consistently shows the work fits.
+- If both numbers exist and DIFFER, surface the range under "Risks & Considerations": e.g. "Crew sizing analysis shows X-Y crews depending on geographic packing efficiency. We recommend bidding at X crews to ensure capacity, with the option to scale down to Y if scheduling consistently shows the work fits." (replace X with the conservative count and Y with the optimistic count). This is typically a 6-figure-per-year swing — call it out.
+- If a routing template exists for this client, the Bid Pricing module pulls crew_count from the actual scheduler plan ("source": "scheduler_template"). Mention this is the authoritative number; the Crew Strategy estimate is the pre-scheduler ceiling. If there is a meaningful delta between the two (>= 1 crew), note it: e.g. "Crew Strategy estimates 4 crews; the scheduler optimization confirms 3 crews are sufficient with current geographic packing."
+
 Output strictly as JSON with two string keys: dashboard_summary, full_report_markdown.
 Do NOT wrap the JSON in markdown code fences.`
 

--- a/api/scheduler/templates/[templateId]/regenerate.ts
+++ b/api/scheduler/templates/[templateId]/regenerate.ts
@@ -85,7 +85,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   // Re-load offerings + property hours + cohorts
   const { data: slRows } = await db
     .from('service_locations')
-    .select('id, property_id, service_offering_id, serviceable_sqft, hours_per_visit_override, property:properties(id, address_line1, latitude, longitude)')
+    .select('id, property_id, service_offering_id, serviceable_sqft, hours_per_visit_override, building_size_class_override, property:properties(id, address_line1, latitude, longitude)')
     .in('id', slIds)
   const { data: offeringRows } = await db
     .from('service_offerings')
@@ -203,6 +203,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       parent_visit_interval_years: Number(r.offering.visit_interval_years ?? 0.5),
       base_hours_per_visit: baseHours,
       constraints: constraintsBySl.get(r.sl.id) ?? [],
+      building_size_class_override:
+        (r.sl as any).building_size_class_override ?? null,
       eligible_addons: eligibleAddons,
     }
   }).filter((p) => Number.isFinite(p.lat) && Number.isFinite(p.lng))

--- a/api/scheduler/templates/index.ts
+++ b/api/scheduler/templates/index.ts
@@ -75,7 +75,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     // Fetch SLs + properties + offerings
     const { data: slRows } = await db
       .from('service_locations')
-      .select('id, property_id, service_offering_id, serviceable_sqft, hours_per_visit_override, property:properties(id, address_line1, latitude, longitude)')
+      .select('id, property_id, service_offering_id, serviceable_sqft, hours_per_visit_override, building_size_class_override, property:properties(id, address_line1, latitude, longitude)')
       .in('id', slIds)
     const { data: offeringRows } = await db
       .from('service_offerings')
@@ -220,6 +220,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         parent_visit_interval_years: Number(r.offering.visit_interval_years ?? 0.5),
         base_hours_per_visit: baseHours,
         constraints: constraintsBySl.get(r.sl.id) ?? [],
+        building_size_class_override:
+          (r.sl as any).building_size_class_override ?? null,
         eligible_addons: eligibleAddons,
       }
     }).filter((p) => Number.isFinite(p.lat) && Number.isFinite(p.lng))

--- a/api/v1/service-locations/[id].ts
+++ b/api/v1/service-locations/[id].ts
@@ -55,8 +55,15 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     const rejected: string[] = []
     for (const [k, v] of Object.entries(body)) {
       if (k === 'edit_reason') continue
-      if (isEditableServiceLocationField(k)) updates[k] = v
-      else rejected.push(k)
+      if (isEditableServiceLocationField(k)) {
+        // Phase 3.8 — empty string on the size-class override means "use
+        // auto-computed", which the DB stores as NULL.
+        if (k === 'building_size_class_override' && v === '') {
+          updates[k] = null
+        } else {
+          updates[k] = v
+        }
+      } else rejected.push(k)
     }
 
     if (Object.keys(updates).length === 0) {

--- a/src/components/analysis/BidPricingChart.tsx
+++ b/src/components/analysis/BidPricingChart.tsx
@@ -24,6 +24,8 @@ interface BidOutputs {
     crew_count: number | null
     branch_count: number | null
     fte_count: number | null
+    source?: 'scheduler_template' | 'crew_strategy_estimate' | 'manual_override'
+    scheduler_template?: { id: string; name: string } | null
   }
   cost_buildup: {
     direct_labor: number
@@ -77,8 +79,51 @@ export default function BidPricingChart({ data }: { data: BidOutputs }) {
     { key: 'margin', value: data.margin.margin_amount },
   ].filter((r) => r.value > 0)
 
+  // Phase 3.8 — source-of-truth indicator for the headline bid number.
+  const source = data.sourced_from.source ?? null
+  const sourceLine = (() => {
+    if (source === 'scheduler_template') {
+      const name = data.sourced_from.scheduler_template?.name ?? 'active template'
+      return {
+        label: `Scheduler optimization (high confidence)`,
+        sub: `Crew count from active template "${name}".`,
+        tone: 'success' as const,
+      }
+    }
+    if (source === 'manual_override') {
+      return {
+        label: 'Manual override',
+        sub: 'Crew count + costs entered manually.',
+        tone: 'neutral' as const,
+      }
+    }
+    return {
+      label: 'Crew strategy estimate (run scheduler for actual numbers)',
+      sub: 'Pre-scheduler estimate from building-count math.',
+      tone: 'warn' as const,
+    }
+  })()
+
   return (
     <div className="space-y-6">
+      {/* Source-of-truth indicator */}
+      <div
+        className={
+          'rounded-md border px-3 py-2 text-xs ' +
+          (sourceLine.tone === 'success'
+            ? 'border-success/30 bg-success/5 text-success'
+            : sourceLine.tone === 'warn'
+              ? 'border-warning/30 bg-warning/5 text-warning'
+              : 'border-border bg-surface-subtle text-fg-muted')
+        }
+      >
+        <p className="font-semibold">
+          {sourceLine.tone === 'success' ? '✓ ' : sourceLine.tone === 'warn' ? '⚠ ' : ''}
+          Source: {sourceLine.label}
+        </p>
+        <p className="mt-0.5 text-fg-muted">{sourceLine.sub}</p>
+      </div>
+
       {/* Headline bid number — quiet 1px-bordered card per design rules
           (the legacy version used a green→teal gradient + 2px border which
           shouted; we let the typography do the work instead). */}

--- a/src/components/analysis/CrewStrategyChart.tsx
+++ b/src/components/analysis/CrewStrategyChart.tsx
@@ -42,6 +42,7 @@ interface BranchUtilRow {
 interface CrewOption {
   label: string
   crew_count: number
+  crew_count_optimistic?: number
   surge_crew_count?: number
   surge_weeks?: number
   utilization_pct: number
@@ -73,10 +74,34 @@ interface CrewOption {
   }
 }
 
+interface CrewCountAnalysis {
+  conservative: {
+    crews_needed: number
+    total_crew_days_per_cycle: number
+    working_days_per_cycle: number
+    rationale: string
+  }
+  optimistic: {
+    crews_needed: number
+    total_crew_days_per_cycle: number
+    working_days_per_cycle: number
+    rationale: string
+  }
+  size_class_breakdown: {
+    small: number
+    standard: number
+    large: number
+    multi_day: number
+  }
+  total_visits_per_cycle: number
+  cycles_per_year: number
+}
+
 interface CrewStrategyOutputs {
   property_count: number
   k_used: number
   total_project_hours_per_year: number
+  crew_count_analysis?: CrewCountAnalysis
   options: { A: CrewOption; B: CrewOption; C: CrewOption }
   recommended_option: 'A' | 'B' | 'C'
   recommended_rationale: string
@@ -148,6 +173,62 @@ export default function CrewStrategyChart({ data }: { data: CrewStrategyOutputs 
         <p className="mt-1 text-sm text-fg-muted">{data.recommended_rationale}</p>
       </div>
 
+      {/* Phase 3.8 — Building-count math summary */}
+      {data.crew_count_analysis && (
+        <Card padding="md">
+          <p className="text-[10px] font-semibold uppercase tracking-wider text-fg-subtle">
+            Building-count crew math
+          </p>
+          <p className="mt-1 text-sm text-fg">
+            <span className="font-tabular font-semibold">
+              {data.crew_count_analysis.conservative.crews_needed} crews
+            </span>{' '}
+            (conservative)
+            {data.crew_count_analysis.optimistic.crews_needed !==
+              data.crew_count_analysis.conservative.crews_needed && (
+              <>
+                {' — '}
+                <span className="font-tabular font-semibold">
+                  {data.crew_count_analysis.optimistic.crews_needed}
+                </span>{' '}
+                with small-property pairing (optimistic)
+              </>
+            )}
+          </p>
+          <p className="mt-1 text-xs text-fg-muted">
+            {data.crew_count_analysis.conservative.total_crew_days_per_cycle} building-days ÷{' '}
+            {data.crew_count_analysis.conservative.working_days_per_cycle} working days ={' '}
+            {(
+              data.crew_count_analysis.conservative.total_crew_days_per_cycle /
+              data.crew_count_analysis.conservative.working_days_per_cycle
+            ).toFixed(2)}{' '}
+            → {data.crew_count_analysis.conservative.crews_needed} crews.
+          </p>
+          <dl className="mt-3 grid grid-cols-2 sm:grid-cols-4 gap-3 text-xs">
+            <Stat label="Small (≤4 hr)">
+              <span className="font-tabular">
+                {data.crew_count_analysis.size_class_breakdown.small}
+              </span>
+            </Stat>
+            <Stat label="Standard (4–8 hr)">
+              <span className="font-tabular">
+                {data.crew_count_analysis.size_class_breakdown.standard}
+              </span>
+            </Stat>
+            <Stat label="Large (8–16 hr)">
+              <span className="font-tabular">
+                {data.crew_count_analysis.size_class_breakdown.large}
+              </span>
+            </Stat>
+            <Stat label="Multi-day (>16 hr)">
+              <span className="font-tabular">
+                {data.crew_count_analysis.size_class_breakdown.multi_day}
+              </span>
+            </Stat>
+          </dl>
+        </Card>
+      )}
+
       {/* Cost comparison bar chart */}
       <section className="space-y-2">
         <h4 className="text-[10px] font-semibold uppercase tracking-wider text-fg-subtle">
@@ -211,6 +292,13 @@ export default function CrewStrategyChart({ data }: { data: CrewStrategyOutputs 
             <dl className="my-3 grid grid-cols-2 gap-3 border-y border-border py-3 text-sm">
               <Stat label="Crews">
                 <span className="font-tabular">{o.crew_count}</span>
+                {o.crew_count_optimistic != null &&
+                  o.crew_count_optimistic !== o.crew_count && (
+                    <span className="text-fg-muted text-xs">
+                      {' '}
+                      (or <span className="font-tabular">{o.crew_count_optimistic}</span> w/ pairing)
+                    </span>
+                  )}
                 {o.surge_crew_count ? (
                   <span className="text-fg-muted">
                     {' + '}

--- a/src/lib/editable-fields.ts
+++ b/src/lib/editable-fields.ts
@@ -88,6 +88,26 @@ export const SERVICE_LOCATION_FIELDS: FieldSpec[] = [
     helper: 'Stales Crew Strategy + Bid Pricing.',
   },
   {
+    key: 'building_size_class_override',
+    label: 'Building size (override)',
+    kind: 'select',
+    options: [
+      { value: '', label: 'Auto (from hours/visit)' },
+      { value: 'small', label: 'Small (≤4 hr — pairs)' },
+      { value: 'standard', label: 'Standard (4–8 hr)' },
+      { value: 'large', label: 'Large (8–16 hr)' },
+      { value: 'multi_day', label: 'Multi-day (>16 hr)' },
+    ],
+    helper:
+      'Forces a size class regardless of hours/visit. Affects crew-day math + scheduler pairing.',
+  },
+  {
+    key: 'building_size_override_reason',
+    label: 'Override reason',
+    kind: 'text',
+    helper: 'Optional note explaining why this building was reclassified.',
+  },
+  {
     key: 'crew_size_override',
     label: 'Crew size (override)',
     kind: 'number',

--- a/src/pages/PropertyDetail.tsx
+++ b/src/pages/PropertyDetail.tsx
@@ -32,6 +32,13 @@ import type { ServiceLocation } from '../types'
 
 const PROPERTY_FIELD_BY_KEY = Object.fromEntries(PROPERTY_FIELDS.map((f) => [f.key, f]))
 
+const SIZE_CLASS_LABEL: Record<'small' | 'standard' | 'large' | 'multi_day', string> = {
+  small: 'Small',
+  standard: 'Standard',
+  large: 'Large',
+  multi_day: 'Multi-day',
+}
+
 // Extends Property with DB fields that aren't in the base type + joined tables
 interface PropertyDetail {
   property_id: string
@@ -481,6 +488,7 @@ export default function PropertyDetailPage() {
                       <TableHead>Name</TableHead>
                       <TableHead>Suite / floor</TableHead>
                       <TableHead className="text-right">Sqft</TableHead>
+                      <TableHead>Size class</TableHead>
                       <TableHead>Status</TableHead>
                       <TableHead className="w-8" />
                     </TableRow>
@@ -504,6 +512,16 @@ export default function PropertyDetailPage() {
                           {loc.serviceable_sqft
                             ? loc.serviceable_sqft.toLocaleString()
                             : '—'}
+                        </TableCell>
+                        <TableCell className="text-xs text-fg-muted">
+                          {loc.building_size_class_override ? (
+                            <span title={loc.building_size_override_reason ?? undefined}>
+                              {SIZE_CLASS_LABEL[loc.building_size_class_override]}
+                              <span className="text-fg-subtle"> · override</span>
+                            </span>
+                          ) : (
+                            <span className="text-fg-subtle">Auto</span>
+                          )}
                         </TableCell>
                         <TableCell>
                           <Badge variant={statusBadgeVariant(loc.status)}>

--- a/src/pages/accounts/scheduler/NewTemplate.tsx
+++ b/src/pages/accounts/scheduler/NewTemplate.tsx
@@ -46,8 +46,10 @@ export default function NewTemplatePage() {
   const [crewCount, setCrewCount] = useState(2)
   const [crewCountUserEdited, setCrewCountUserEdited] = useState(false)
   const [recommendedCrew, setRecommendedCrew] = useState<{
-    count: number
+    count: number // conservative — what to default to
+    optimistic: number | null
     option: string
+    source: 'building_count' | 'option_count'
   } | null>(null)
   const [cycleStartYear, setCycleStartYear] = useState(new Date().getUTCFullYear())
   const [planningMode, setPlanningMode] = useState<'auto' | 'hybrid' | 'manual'>('auto')
@@ -79,14 +81,35 @@ export default function NewTemplatePage() {
         const rows = await latestRes.json()
         const cs = (rows as any[]).find((r) => r.module_key === 'crew_strategy' && r.status === 'completed')
         if (cs?.outputs) {
+          // Phase 3.8 — prefer the new building-count math when present.
+          const cca = cs.outputs.crew_count_analysis as
+            | {
+                conservative: { crews_needed: number }
+                optimistic: { crews_needed: number }
+              }
+            | undefined
           const opt = cs.outputs.recommended_option as string | undefined
-          const count = opt
+          const optionCount = opt
             ? (cs.outputs.options?.[opt]?.crew_count as number | undefined)
             : undefined
-          if (count != null) {
-            setRecommendedCrew({ count, option: opt ?? '?' })
-            // Default to recommendation only if user hasn't manually edited.
-            if (!crewCountUserEdited) setCrewCount(count)
+          if (cca) {
+            const cons = cca.conservative.crews_needed
+            const optimi = cca.optimistic.crews_needed
+            setRecommendedCrew({
+              count: cons,
+              optimistic: optimi !== cons ? optimi : null,
+              option: opt ?? '?',
+              source: 'building_count',
+            })
+            if (!crewCountUserEdited) setCrewCount(cons)
+          } else if (optionCount != null) {
+            setRecommendedCrew({
+              count: optionCount,
+              optimistic: null,
+              option: opt ?? '?',
+              source: 'option_count',
+            })
+            if (!crewCountUserEdited) setCrewCount(optionCount)
           }
         }
       }
@@ -220,9 +243,13 @@ export default function NewTemplatePage() {
               label="Crew count"
               helper={
                 recommendedCrew
-                  ? crewCount === recommendedCrew.count
-                    ? `Recommended from Crew Strategy (Option ${recommendedCrew.option}).`
-                    : `Crew Strategy recommends ${recommendedCrew.count} (Option ${recommendedCrew.option}).`
+                  ? recommendedCrew.source === 'building_count'
+                    ? recommendedCrew.optimistic != null
+                      ? `Recommended: ${recommendedCrew.count} crews (conservative). ${recommendedCrew.optimistic} with small-property pairing.`
+                      : `Recommended: ${recommendedCrew.count} crews from building-count math.`
+                    : crewCount === recommendedCrew.count
+                      ? `Recommended from Crew Strategy (Option ${recommendedCrew.option}).`
+                      : `Crew Strategy recommends ${recommendedCrew.count} (Option ${recommendedCrew.option}).`
                   : 'Run Crew Strategy in Smart Analysis to get a recommendation.'
               }
             >

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -215,6 +215,9 @@ export interface ServiceLocation {
   display_name?: string | null
   suite_or_floor?: string | null
   serviceable_sqft?: number | null
+  hours_per_visit_override?: number | null
+  building_size_class_override?: 'small' | 'standard' | 'large' | 'multi_day' | null
+  building_size_override_reason?: string | null
   status: ServiceLocationStatus
   winteam_job_number?: string | null
   portfolio_ids?: string[] | null

--- a/supabase/migrations/20260430142405_phase_3_8_building_size_override.sql
+++ b/supabase/migrations/20260430142405_phase_3_8_building_size_override.sql
@@ -1,0 +1,22 @@
+-- Phase 3.8 — per-service-location override of auto-computed building
+-- size class. NULL means use the auto-computed class from
+-- hours_per_visit; a non-null value forces a specific class.
+
+ALTER TABLE public.service_locations
+  ADD COLUMN IF NOT EXISTS building_size_class_override text,
+  ADD COLUMN IF NOT EXISTS building_size_override_reason text;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'service_locations_building_size_class_override_check'
+  ) THEN
+    ALTER TABLE public.service_locations
+      ADD CONSTRAINT service_locations_building_size_class_override_check
+      CHECK (
+        building_size_class_override IS NULL OR
+        building_size_class_override IN ('small', 'standard', 'large', 'multi_day')
+      );
+  END IF;
+END $$;


### PR DESCRIPTION
## Summary
Replaces the hours-based crew count (annual hours ÷ FTE-hours) with a **building-day model**: 1 building = 1 crew-day by default, with small-property pairing as the optimistic ceiling and very large buildings consuming multiple days.

The bid is sized around a **conservative** count (no pairing) and the **optimistic** alternative (with pairing) is displayed alongside so the user can see the swing — typically a 6-figure-per-year delta on a JLL-sized portfolio.

## What changed

### New utilities (`api/_lib/analysis/`)
- `building-size.ts` — auto-classifies a building as `small / standard / large / multi_day` from hours-per-visit, with override support
- `working-days.ts` — counts weekdays minus US federal holidays in a date span
- `crew-count.ts` — `computeCrewCount({ routed_visits, cycle_length_days, ... })` returning conservative + optimistic + size-class breakdown

### Crew Strategy
- Each option (A/B/C) now reports both `crew_count` (conservative) and `crew_count_optimistic`
- New top-level `crew_count_analysis` output with conservative + optimistic + size-class breakdown
- Option B per-branch crew counts are derived from per-branch building-day totals (not utilization band)
- Utilization-band analysis preserved as informational annotations

### Bid Pricing
- Looks up the active routing template; prefers it as source of truth for crew count when present
- Emits a `source` field (`scheduler_template` / `crew_strategy_estimate` / `manual_override`)
- UI surfaces a visible source-of-truth indicator at the top of the bid card

### Scheduler
- `routeDay` now enforces an in-day pairing rule: max 2 buildings/day, second slot only opens if BOTH are 'small' AND drive between is ≤30 minutes (configurable via `in_day_pairing_max_buildings_per_day` and `in_day_pairing_max_drive_minutes`)
- Size-class override flows from `service_locations` → `PropertyForBuild` → `VisitSpec` → `PropertyForRouting` so the scheduler honors manual reclassifications
- `NewTemplate` form defaults `crew_count` to the conservative recommendation and surfaces the optimistic alternative

### Property detail
- New "Size class" column on the service-locations table (Auto vs override)
- Edit dialog gains a "Building size (override)" select (Auto / Small / Standard / Large / Multi-day) + free-form reason field
- Override stales Crew Strategy + Bid Pricing via the existing edit cascade

### Synthesizer prompt
- Tells the LLM to surface the conservative-vs-optimistic range in Risks when they differ
- Acknowledges the scheduler template as authoritative when present and to call out any delta vs Crew Strategy

### DB migration
- `service_locations.building_size_class_override` (nullable text, CHECK constraint enforces enum)
- `service_locations.building_size_override_reason` (nullable text)
- Already pushed to the linked Supabase project (`efpjlesawuymmafwgkrm`)

## Notes
- Existing routing templates + cycles will keep their old crew counts; regenerate to pick up the new pairing-aware scheduling.
- The 2-building/day cap is a real behavior change — the scheduler will pack many more days for the same workload, which is the whole point of the math correction.

## Test plan
- [ ] Re-run Crew Strategy on JLL Property Reserve → crew count drops from ~6 to 3-4; size-class breakdown visible; conservative + optimistic both shown
- [ ] Re-run Bid Pricing without an active template → source shows `crew_strategy_estimate`, warning indicator
- [ ] Make a routing template active for the client, re-run Bid Pricing → source flips to `scheduler_template`, success indicator
- [ ] Override a service location to `small` → Crew Strategy + Bid Pricing go stale; re-run; the building shows up under "small" in the breakdown
- [ ] Regenerate a routing template → verify pairing rule (no day has 3+ buildings; second-stop days are both small and close)
- [ ] Synthesis includes the conservative/optimistic range in Risks when they differ

🤖 Generated with [Claude Code](https://claude.com/claude-code)