### PR TITLE
fix(upload): allow uploads without postal_code mapping

### DIFF
--- a/src/components/upload/ColumnMappingStep.tsx
+++ b/src/components/upload/ColumnMappingStep.tsx
@@ -44,7 +44,11 @@ function slugify(s: string): string {
 function isMappingValid(mappings: Record<string, string>): boolean {
   const targets = new Set(Object.values(mappings).filter((v) => v && v !== ''))
   if (!targets.has('address_line1') || !targets.has('city')) return false
-  return (targets.has('state') && targets.has('postal_code')) || targets.has('country')
+  // At least one of state / postal_code / country — that's enough for
+  // Google Address Validation to canonicalize the rest. We deliberately
+  // don't require postal_code because GAV fills in missing zips for
+  // US addresses given street + city + state.
+  return targets.has('state') || targets.has('postal_code') || targets.has('country')
 }
 
 interface NewFieldForm {
@@ -177,7 +181,7 @@ export default function ColumnMappingStep({
 
             {!valid && (
               <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-700">
-                Required: address_line1 + city + (state & postal_code, or country)
+                Required: address_line1 + city + at least one of (state, postal_code, country). Missing zips will be filled in by Google Address Validation during enrichment.
               </div>
             )}
 


### PR DESCRIPTION
## What was broken
The column-mapping step required \`(state AND postal_code) OR country\`, blocking uploads of address lists that had street + city + state but no zip column. Google Address Validation runs after upload and would have filled in the zip — but the user could never reach that step.

## Fix
- Frontend gate relaxed to \`address_line1 + city + at least one of (state, postal_code, country)\` — matches what the \`process-upload-batch\` Edge Function actually requires.
- Help banner updated to mention that missing zips are filled in by GAV during enrichment.

## Notes
After upload, Google Address Validation populates \`validated_postal_code\` on each property (separate column from \`postal_code\` so we preserve what the user uploaded). The original \`postal_code\` stays as uploaded — if you'd rather we overwrite it with the validated value, that's a follow-up.

## Test plan
- [ ] Upload a CSV with street + city + state columns (no zip) → mapping step now accepts it
- [ ] Upload completes; properties land in DB with empty \`postal_code\`
- [ ] Enrichment fills \`validated_postal_code\` per property; map view shows them at the right coordinates

🤖 Generated with [Claude Code](https://claude.com/claude-code)