### PR TITLE
feat: per-client enrichment UI on Account pages

### DIFF
--- a/api/v1/clients/[id]/enrichment-status.ts
+++ b/api/v1/clients/[id]/enrichment-status.ts
@@ -1,0 +1,131 @@
+// GET  /api/v1/clients/[id]/enrichment-status
+//   → per-client counts: enriched / pending / failed / total / no_coords
+// POST /api/v1/clients/[id]/enrichment-status
+//   → kicks off enrichment for every pending+failed property under this
+//     client. Same logic as the global /api/admin/enrich-pending but
+//     scoped to (client_id) via service_locations join.
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { createAdminClient } from '../../../_lib/supabase.js'
+import { authenticateRequest } from '../../../_lib/auth.js'
+
+// 5-min timeout; ~2 min to do 1000 properties at 10 concurrency.
+export const config = { maxDuration: 300 }
+
+const ENRICH_CONCURRENCY = 10
+const ENRICH_BATCH_LIMIT = 2000
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method === 'OPTIONS') return res.status(200).end()
+
+  try {
+    await authenticateRequest(req)
+  } catch (err: any) {
+    return res.status(err.statusCode ?? 401).json({ error: err.message ?? 'Unauthorized' })
+  }
+
+  const clientId = req.query.id as string
+  if (!clientId) return res.status(400).json({ error: 'client id required' })
+
+  const db = createAdminClient()
+
+  // Resolve the property ids under this client via service_locations.
+  const { data: slRows, error: slErr } = await db
+    .from('service_locations')
+    .select('property_id')
+    .eq('client_id', clientId)
+    .not('property_id', 'is', null)
+  if (slErr) return res.status(500).json({ error: slErr.message })
+
+  const propertyIds = Array.from(
+    new Set((slRows ?? []).map((r: any) => r.property_id).filter(Boolean))
+  ) as string[]
+
+  if (req.method === 'GET') {
+    if (propertyIds.length === 0) {
+      return res.status(200).json({
+        total: 0,
+        enriched: 0,
+        pending: 0,
+        failed: 0,
+        no_coords: 0,
+      })
+    }
+    const { data: props, error } = await db
+      .from('properties')
+      .select('id, enrichment_status, latitude, longitude')
+      .in('id', propertyIds)
+    if (error) return res.status(500).json({ error: error.message })
+    const rows = (props ?? []) as Array<{
+      id: string
+      enrichment_status: string | null
+      latitude: number | null
+      longitude: number | null
+    }>
+    let enriched = 0
+    let pending = 0
+    let failed = 0
+    let noCoords = 0
+    for (const r of rows) {
+      const s = r.enrichment_status
+      if (s === 'enriched') enriched++
+      else if (s === 'failed') failed++
+      else pending++
+      if (r.latitude == null || r.longitude == null) noCoords++
+    }
+    return res.status(200).json({
+      total: rows.length,
+      enriched,
+      pending,
+      failed,
+      no_coords: noCoords,
+    })
+  }
+
+  if (req.method === 'POST') {
+    if (propertyIds.length === 0) {
+      return res.status(200).json({ message: 'No properties under this client', count: 0 })
+    }
+    const { data: pendingRows, error } = await db
+      .from('properties')
+      .select('id')
+      .in('id', propertyIds)
+      .in('enrichment_status', ['pending', 'failed'])
+      .limit(ENRICH_BATCH_LIMIT)
+    if (error) return res.status(500).json({ error: error.message })
+    const targets = (pendingRows ?? []) as Array<{ id: string }>
+    if (targets.length === 0) {
+      return res.status(200).json({ message: 'No pending properties', count: 0 })
+    }
+
+    const baseUrl = process.env.VITE_APP_URL || `https://${req.headers.host}`
+    let succeeded = 0
+    let failedCount = 0
+
+    for (let i = 0; i < targets.length; i += ENRICH_CONCURRENCY) {
+      const chunk = targets.slice(i, i + ENRICH_CONCURRENCY)
+      const results = await Promise.allSettled(
+        chunk.map((p) =>
+          fetch(`${baseUrl}/api/properties/${p.id}/enrich`, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              'X-RBM-Service-Key': process.env.SERVICE_API_KEY ?? '',
+            },
+          })
+        )
+      )
+      for (const r of results) {
+        if (r.status === 'fulfilled' && r.value.ok) succeeded++
+        else failedCount++
+      }
+    }
+
+    return res.status(200).json({
+      total: targets.length,
+      succeeded,
+      failed: failedCount,
+    })
+  }
+
+  return res.status(405).json({ error: 'Method not allowed' })
+}

--- a/src/components/property/EnrichmentBanner.tsx
+++ b/src/components/property/EnrichmentBanner.tsx
@@ -1,0 +1,157 @@
+// Per-client enrichment status + run button. Renders nothing when
+// every property under (account, client) is already enriched. Surfaces
+// pending+failed counts and lets the user kick off a scoped run.
+import { useCallback, useEffect, useState } from 'react'
+import { Loader2, MapPinOff, Sparkles, CheckCircle2 } from 'lucide-react'
+import { useAuth } from '../../hooks/useAuth'
+import Button from '../ui/Button'
+
+interface Stats {
+  total: number
+  enriched: number
+  pending: number
+  failed: number
+  no_coords: number
+}
+
+interface Props {
+  clientId: string
+  // Optional callback when an enrichment run completes (e.g. so a parent
+  // page can re-fetch property lists).
+  onEnriched?: () => void
+}
+
+export default function EnrichmentBanner({ clientId, onEnriched }: Props) {
+  const { getToken } = useAuth()
+  const [stats, setStats] = useState<Stats | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [running, setRunning] = useState(false)
+  const [message, setMessage] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  const fetchStats = useCallback(async () => {
+    if (!clientId) return
+    try {
+      const token = await getToken()
+      const res = await fetch(`/api/v1/clients/${clientId}/enrichment-status`, {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      if (!res.ok) throw new Error(`Status fetch failed: ${res.status}`)
+      const data = (await res.json()) as Stats
+      setStats(data)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setLoading(false)
+    }
+  }, [clientId, getToken])
+
+  useEffect(() => {
+    fetchStats()
+  }, [fetchStats])
+
+  const runEnrichment = async () => {
+    setRunning(true)
+    setMessage(null)
+    setError(null)
+    try {
+      const token = await getToken()
+      const res = await fetch(`/api/v1/clients/${clientId}/enrichment-status`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      const data = await res.json()
+      if (!res.ok) {
+        throw new Error(data.error ?? `Enrichment failed: ${res.status}`)
+      }
+      if (data.message) {
+        setMessage(data.message)
+      } else {
+        setMessage(
+          `Enriched ${data.succeeded ?? 0}/${data.total ?? 0} properties.${
+            data.failed ? ` ${data.failed} failed.` : ''
+          }`
+        )
+      }
+      await fetchStats()
+      onEnriched?.()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setRunning(false)
+    }
+  }
+
+  if (loading) return null
+  if (!stats) return null
+  // Hide entirely when there's nothing to do AND nothing to report.
+  const everythingEnriched = stats.total > 0 && stats.pending === 0 && stats.failed === 0
+
+  if (stats.total === 0) {
+    return null
+  }
+
+  if (everythingEnriched && !message && !error) {
+    return (
+      <div className="flex items-center justify-between gap-3 rounded-md border border-success/30 bg-success/5 px-4 py-2.5 text-sm">
+        <div className="flex items-center gap-2 text-success">
+          <CheckCircle2 className="h-4 w-4" />
+          <span>
+            All <span className="font-tabular">{stats.enriched}</span> properties enriched.
+          </span>
+        </div>
+        {stats.no_coords > 0 && (
+          <span className="text-xs text-fg-muted">
+            {stats.no_coords} still missing coordinates
+          </span>
+        )}
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-3 rounded-md border border-warning/30 bg-warning/5 px-4 py-3">
+      <div className="flex items-start gap-3 min-w-0">
+        <MapPinOff className="h-4 w-4 text-warning shrink-0 mt-0.5" />
+        <div className="space-y-0.5 min-w-0">
+          <p className="text-sm font-medium text-fg">
+            <span className="font-tabular">{stats.pending + stats.failed}</span>{' '}
+            {stats.pending + stats.failed === 1 ? 'property needs' : 'properties need'} enrichment
+          </p>
+          <p className="text-xs text-fg-muted">
+            Validates each address with Google + geocodes lat/lng so they show on the map and feed analyses.{' '}
+            {stats.failed > 0 && (
+              <>
+                <span className="text-danger">{stats.failed} previously failed</span> — re-running may succeed if data was fixed.{' '}
+              </>
+            )}
+            {stats.enriched > 0 && (
+              <>
+                ({stats.enriched}/{stats.total} already enriched.)
+              </>
+            )}
+          </p>
+          {message && <p className="text-xs text-success mt-1">{message}</p>}
+          {error && <p className="text-xs text-danger mt-1">{error}</p>}
+        </div>
+      </div>
+      <Button
+        size="sm"
+        onClick={runEnrichment}
+        disabled={running || stats.pending + stats.failed === 0}
+      >
+        {running ? (
+          <>
+            <Loader2 className="h-3.5 w-3.5 mr-1.5 animate-spin" />
+            Enriching…
+          </>
+        ) : (
+          <>
+            <Sparkles className="h-3.5 w-3.5 mr-1.5" />
+            Enrich {stats.pending + stats.failed} pending
+          </>
+        )}
+      </Button>
+    </div>
+  )
+}

--- a/src/pages/accounts/AccountAnalysis.tsx
+++ b/src/pages/accounts/AccountAnalysis.tsx
@@ -13,6 +13,7 @@ import {
 import { useAuth } from '../../hooks/useAuth'
 import Button from '../../components/ui/Button'
 import AppShell from '../../components/layout/AppShell'
+import EnrichmentBanner from '../../components/property/EnrichmentBanner'
 import {
   Sidebar,
   SidebarItem,
@@ -749,6 +750,11 @@ export default function AccountAnalysisPage() {
       }
     >
       <div className="mx-auto max-w-6xl px-6 py-10 space-y-10">
+        {/* Enrichment status — surfaces pending/failed counts and lets
+            the user kick off a scoped run. Hides itself when everything's
+            already enriched. */}
+        {clientId && <EnrichmentBanner clientId={clientId} />}
+
         {/* Header — title + metadata row + run-all CTA. Breadcrumb is in
             the TopBar so we don't repeat it inline. */}
         <header className="flex items-start justify-between gap-6">

--- a/src/pages/accounts/PropertiesAdmin.tsx
+++ b/src/pages/accounts/PropertiesAdmin.tsx
@@ -9,6 +9,7 @@ import { useParams, Link } from 'react-router-dom'
 import { Search, Tag, Trash2, FileText } from 'lucide-react'
 import { useAuth } from '../../hooks/useAuth'
 import AppShell from '../../components/layout/AppShell'
+import EnrichmentBanner from '../../components/property/EnrichmentBanner'
 import Button from '../../components/ui/Button'
 import { Badge } from '../../components/ui/Badge'
 import { Card, CardTitle } from '../../components/ui/Card'
@@ -174,6 +175,12 @@ export default function PropertiesAdminPage() {
             />
           </div>
         </header>
+
+        {/* Enrichment status — shows pending count + run button, or
+            "all enriched" when complete. Reloads property list on success. */}
+        {clientId && (
+          <EnrichmentBanner clientId={clientId} onEnriched={load} />
+        )}
 
         {/* Action bar */}
         {selected.size > 0 && (


### PR DESCRIPTION
## What this adds
A banner on the **Smart Analysis** page and the **per-client Properties admin** page showing enrichment status (\`X of Y enriched, Z pending, F failed\`) with a one-click \"Enrich N pending\" button. Hides itself when nothing's pending.

The backing endpoint \`GET/POST /api/v1/clients/{id}/enrichment-status\` counts and runs enrichment scoped to that client's properties via the \`service_locations\` join, at the same 10-concurrency rate as the existing admin-wide \`/api/admin/enrich-pending\`.

## Why
The codebase already documented this exact need (commit.ts:251):

> // Fire-and-forget enrichment for newly-created properties.
> // Note: Vercel Node functions may not reliably execute async work after res.send().
> // If this proves unreliable, use the manual \"Enrich Pending Properties\" button on /admin.

Reality: it's been unreliable. Users uploading a fresh client end up with properties that never got geocoded, never appear on the map, and have to know to bounce out to \`/admin\` to recover. This puts the same recovery action right where the user's already looking.

## Test plan
- [ ] Upload a new client's properties; banner appears on /analysis and /admin/properties showing pending count
- [ ] Click \"Enrich N pending\" → banner shows \"Enriching…\" then refreshes to show enriched/total counts
- [ ] Properties now have lat/lng + validated_postal_code + appear on the map
- [ ] When all properties are enriched, banner shows the green \"all enriched\" state
- [ ] Failed-state properties can be retried (rerun is idempotent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)