### PR TITLE
fix(map): paginate SL filter + harden empty-id handling

### DIFF
--- a/api/v1/properties/index.ts
+++ b/api/v1/properties/index.ts
@@ -59,28 +59,57 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     const hasPortfolioFilter = portfolio_id && String(portfolio_id).trim().length > 0
 
     if (hasClientFilter || hasStatusFilter || hasPortfolioFilter) {
-      let slQuery = db.from('service_locations').select('property_id')
+      // Strip empty/whitespace-only ids — Postgres uuid type rejects ''
+      // with a 22P02 error which would surface as a 500 here.
+      const cleanIds = (csv: string) =>
+        csv.split(',').map((s) => s.trim()).filter((s) => s.length > 0)
 
-      if (hasClientFilter) {
-        slQuery = slQuery.in('client_id', String(client_id).split(','))
+      // PostgREST silently caps responses at ~1000 rows; for accounts
+      // with thousands of service_locations we MUST paginate, otherwise
+      // the property-id slice we feed into the next query is incomplete
+      // (the "all clients = 0 pins" bug). Loop pages until we get a
+      // short page back.
+      const SL_PAGE = 1000
+      const propIdSet = new Set<string>()
+      let slOffset = 0
+      // Hard ceiling — 100 pages × 1000 rows = 100k SLs, more than any
+      // legitimate portfolio. Beyond that something is wrong upstream.
+      const MAX_SL_PAGES = 100
+      for (let page = 0; page < MAX_SL_PAGES; page++) {
+        let slQuery = db
+          .from('service_locations')
+          .select('property_id')
+          .range(slOffset, slOffset + SL_PAGE - 1)
+        if (hasClientFilter) {
+          const ids = cleanIds(String(client_id))
+          if (ids.length === 0) break
+          slQuery = slQuery.in('client_id', ids)
+        }
+        if (hasStatusFilter) {
+          const statuses = cleanIds(String(status))
+          if (statuses.length === 0) break
+          slQuery = slQuery.in('status', statuses)
+        }
+        if (hasPortfolioFilter) {
+          const portfolioIds = cleanIds(String(portfolio_id))
+          if (portfolioIds.length === 0) break
+          slQuery = slQuery.overlaps('portfolio_ids', portfolioIds)
+        }
+        const { data: sls, error: slError } = await slQuery
+        if (slError) {
+          return res
+            .status(500)
+            .json({ error: `Service location query failed: ${slError.message}` })
+        }
+        const batch = sls ?? []
+        for (const r of batch) {
+          const id = (r as any).property_id
+          if (id) propIdSet.add(id)
+        }
+        if (batch.length < SL_PAGE) break
+        slOffset += SL_PAGE
       }
-      if (hasStatusFilter) {
-        slQuery = slQuery.in('status', String(status).split(','))
-      }
-      if (hasPortfolioFilter) {
-        // portfolio_ids is an array field, use containedBy or overlaps
-        const portfolioIds = String(portfolio_id).split(',')
-        slQuery = slQuery.overlaps('portfolio_ids', portfolioIds)
-      }
-
-      const { data: sls, error: slError } = await slQuery
-
-      // Return error if service_locations query fails
-      if (slError) {
-        return res.status(500).json({ error: `Service location query failed: ${slError.message}` })
-      }
-
-      propIdsFromServiceLocations = [...new Set((sls ?? []).map((r: any) => r.property_id).filter((id: any) => id != null))]
+      propIdsFromServiceLocations = Array.from(propIdSet)
 
       if (propIdsFromServiceLocations.length === 0) {
         return res.status(200).json({ properties: [], total_count: 0, has_more: false })

--- a/src/pages/Map.tsx
+++ b/src/pages/Map.tsx
@@ -33,6 +33,7 @@ export default function MapPage() {
   const { clients, selectedClientId } = useClient()
   const [propertiesWithLocations, setPropertiesWithLocations] = useState<PropertyWithLocations[]>([])
   const [loading, setLoading] = useState(true)
+  const [fetchError, setFetchError] = useState<string | null>(null)
   const [filter, setFilter] = useState<MapFilter>(DEFAULT_FILTER)
   const [selectedProperty, setSelectedProperty] = useState<PropertyWithLocations | null>(null)
   const [panelOpen, setPanelOpen] = useState(false)
@@ -55,19 +56,29 @@ export default function MapPage() {
     let cancelled = false
     async function load() {
       setLoading(true)
+      setFetchError(null)
       try {
         const token = await getToken()
         const buildParams = (offset: number) => {
           const params = new URLSearchParams()
           // Apply nav-level client switcher as a filter baseline
-          const effectiveClients = filter.clients.length
-            ? filter.clients
+          const filterClientsClean = filter.clients.filter(
+            (id) => typeof id === 'string' && id.trim().length > 0
+          )
+          const effectiveClients = filterClientsClean.length
+            ? filterClientsClean
             : selectedClientId
             ? [selectedClientId]
             : []
           if (effectiveClients.length) params.set('client_id', effectiveClients.join(','))
-          if (filter.statuses.length) params.set('status', filter.statuses.join(','))
-          if (filter.portfolios.length) params.set('portfolio_id', filter.portfolios.join(','))
+          const statusesClean = filter.statuses.filter(
+            (s) => typeof s === 'string' && s.trim().length > 0
+          )
+          if (statusesClean.length) params.set('status', statusesClean.join(','))
+          const portfoliosClean = filter.portfolios.filter(
+            (p) => typeof p === 'string' && p.trim().length > 0
+          )
+          if (portfoliosClean.length) params.set('portfolio_id', portfoliosClean.join(','))
           if (filter.cityState) params.set('city_state', filter.cityState)
           params.set('limit', '2000')
           params.set('offset', String(offset))
@@ -88,7 +99,13 @@ export default function MapPage() {
           const res = await fetch(`/api/v1/properties?${buildParams(offset)}`, {
             headers: { Authorization: `Bearer ${token}` },
           })
-          if (!res.ok) break
+          if (!res.ok) {
+            const body = await res.json().catch(() => ({}))
+            const msg =
+              (body as { error?: string }).error ?? `Request failed: ${res.status}`
+            if (!cancelled) setFetchError(msg)
+            break
+          }
           const data = await res.json()
           const batch: PropertyWithLocations[] = data.properties ?? []
           all.push(...batch)
@@ -96,6 +113,10 @@ export default function MapPage() {
           offset += batch.length
         }
         if (!cancelled) setPropertiesWithLocations(all)
+      } catch (err) {
+        if (!cancelled) {
+          setFetchError(err instanceof Error ? err.message : String(err))
+        }
       } finally {
         if (!cancelled) setLoading(false)
       }
@@ -198,6 +219,11 @@ export default function MapPage() {
         <FilterSidebar filter={filter} onChange={setFilter} />
 
         <div className="flex-1 relative">
+          {fetchError && !loading && (
+            <div className="absolute top-2 left-1/2 -translate-x-1/2 z-30 max-w-lg rounded-md border border-danger/30 bg-danger/5 px-3 py-2 text-sm text-danger shadow">
+              <span className="font-medium">Map data error:</span> {fetchError}
+            </div>
+          )}
           {loading && (
             <div
               role="status"


### PR DESCRIPTION
## What was broken
After PR #117, the map paginated the property fetch but two upstream issues still bit:

1. **\`/api/v1/properties\` SL subquery wasn't paginated.** When ANY filter is set (client/status/portfolio), the endpoint first runs a service_locations query to derive the property-id slice, then \`.in('id', ...)\` on properties. PostgREST silently caps that SL query at ~1000 rows. With thousands of SLs across many clients, the property-id slice came out short (or empty). This explains \"all clients checkboxes = 0 pins\".
2. **Empty/whitespace ids in the comma-separated query params** were being passed straight to \`.in('client_id', [''])\`, which Postgres rejects with 22P02 (\"invalid uuid input\") → 500 → map fetch breaks → empty map. Easy to introduce silently; hard to spot in the logs.

## Fix
- API: loop SL pages of 1000 until a short page comes back; \`cleanIds()\` strips empty entries before \`.in()\`.
- Map.tsx: also strips empty ids before joining; surfaces fetch errors as a red banner so future regressions are visible instead of \"why is the map empty\".

## Test plan
- [ ] Map with no filter → shows all properties across all clients
- [ ] Map filtered to single 600+ property client → shows all 600+
- [ ] Map with EVERY client checkbox checked → shows everything (was 0)
- [ ] If something fails (e.g. 5xx), the error banner appears instead of an empty map

🤖 Generated with [Claude Code](https://claude.com/claude-code)