### PR TITLE
feat: surface 'Edit client' link on Smart Analysis page

### DIFF
--- a/src/pages/accounts/AccountAnalysis.tsx
+++ b/src/pages/accounts/AccountAnalysis.tsx
@@ -8,6 +8,7 @@ import {
   LayoutDashboard,
   ListChecks,
   Map as MapIcon,
+  Pencil,
   Sparkles,
 } from 'lucide-react'
 import { useAuth } from '../../hooks/useAuth'
@@ -759,12 +760,25 @@ export default function AccountAnalysisPage() {
             the TopBar so we don't repeat it inline. */}
         <header className="flex items-start justify-between gap-6">
           <div className="space-y-2 min-w-0">
-            <h1 className="text-2xl font-semibold tracking-tight text-fg">
-              Smart Analysis
+            <h1 className="text-2xl font-semibold tracking-tight text-fg flex items-center gap-2 flex-wrap">
+              <span>
+                Smart Analysis
+                {client && (
+                  <span className="text-fg-muted font-normal">
+                    {' · '}{client.display_name ?? client.name}
+                  </span>
+                )}
+              </span>
               {client && (
-                <span className="text-fg-muted font-normal">
-                  {' · '}{client.display_name ?? client.name}
-                </span>
+                <Link
+                  to={`/clients/${client.id}`}
+                  title="Edit client (name, contact, status, brand color)"
+                  aria-label="Edit client"
+                  className="inline-flex items-center gap-1 text-xs font-normal text-fg-subtle hover:text-accent transition-colors border border-border rounded px-1.5 py-0.5"
+                >
+                  <Pencil className="h-3 w-3" />
+                  Edit client
+                </Link>
               )}
             </h1>
             <p className="text-sm text-fg-muted">


### PR DESCRIPTION
## What
The \`/clients/{id}\` page already has a full edit form (name, display_name, status, primary contact, notes, brand color) backed by an existing PATCH endpoint — but nothing in the account → client → analysis flow linked to it, so property managers couldn't reach client edit from the workflow they use daily.

Adds a small pencil-icon \"Edit client\" link next to the client name in the Smart Analysis header. Clicking it lands on the existing client detail page where the edit form already lives.

## Why this approach
No new endpoint, no new edit form. Just a missing link. Could later be promoted to an inline dialog if there's a strong reason to keep the user on the analysis page, but a link gets the immediate gap closed.

## Test plan
- [ ] Open Smart Analysis for any client → see \"Edit client\" pill next to the client name
- [ ] Click it → land on /clients/{id} with the edit form available
- [ ] Save changes → confirm they reflect when navigating back

🤖 Generated with [Claude Code](https://claude.com/claude-code)