### PR TITLE
fix(properties): has_more should compare actual returned length, not requested limit

### DIFF
--- a/api/v1/properties/index.ts
+++ b/api/v1/properties/index.ts
@@ -176,10 +176,17 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     }))
 
     const total_count = count ?? 0
+    // has_more must compare against the *actual* returned length, not
+    // the *requested* limit. PostgREST silently caps responses at ~1000
+    // rows even when limit=2000 is requested, so using the requested
+    // limit causes early termination of paginated callers when total
+    // is between cap and limit (e.g. 1000–2000 properties → only the
+    // first page would be returned).
+    const has_more = offset + properties.length < total_count
     return res.status(200).json({
       properties,
       total_count,
-      has_more: offset + limit < total_count,
+      has_more,
     })
   }
 


### PR DESCRIPTION
## Root cause of the \"map maxes at 1000\" bug
The \`/api/v1/properties\` endpoint computed \`has_more\` as \`offset + limit < total_count\` where \`limit\` is the **requested** page size (Map.tsx asks for 2000). PostgREST silently caps responses at ~1000 rows, so for portfolios with 1000–2000 total properties:

- Page 1 request: offset=0, limit=2000, total=1500
- has_more math: \`2000 < 1500\` → \`false\`
- But only 1000 rows actually returned.
- Map's paginated loop sees \`has_more=false\`, terminates after one page → 1000 visible.

The map header literally read \"1,000 properties\" no matter what, which is what tipped this off.

## Fix
Compare against \`properties.length\` (the actual returned page size) instead of the requested \`limit\`:

\`\`\`ts
const has_more = offset + properties.length < total_count
\`\`\`

Now callers correctly keep paginating until the response actually empties out. With a 1500-property portfolio, page 2 (offset=1000, returns 500) will set \`has_more=false\` correctly.

## Test plan
- [ ] Map shows the actual property count for portfolios > 1000 (was always 1000)
- [ ] Map shows the actual property count for portfolios > 2000 (multi-page works)
- [ ] No regression for portfolios < 1000

🤖 Generated with [Claude Code](https://claude.com/claude-code)