### PR TITLE
feat(upload): idempotent commit + Retry button for partial-failure recovery

### DIFF
--- a/api/uploads/[batchId]/commit.ts
+++ b/api/uploads/[batchId]/commit.ts
@@ -27,7 +27,13 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
   if (fetchErr || !batch) return res.status(404).json({ error: 'Batch not found' })
 
-  if (batch.status !== 'completed') {
+  // Idempotent retry: 'completed' = staged but never committed; 'committed'
+  // = a prior run finished (possibly with failures or after a timeout).
+  // Either way, re-running this endpoint is safe — staged rows that
+  // already have service_location_id set are skipped below, and the
+  // dedupe_hash/unique-constraint paths recover cleanly if we hit a
+  // half-inserted row.
+  if (batch.status !== 'completed' && batch.status !== 'committed') {
     return res.status(400).json({ error: `Cannot commit a batch with status "${batch.status}"` })
   }
 
@@ -43,6 +49,18 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (!stagedRows?.length) {
     return res.status(400).json({ error: 'No committable rows found' })
   }
+
+  // Skip rows that were committed in a prior run (have service_location_id
+  // already populated). For partial-failure recovery the user just clicks
+  // "Retry commit" and we pick up where we left off.
+  let alreadyCommittedSkipped = 0
+  const rowsToProcess = stagedRows.filter((r: any) => {
+    if (r.service_location_id) {
+      alreadyCommittedSkipped += 1
+      return false
+    }
+    return true
+  })
 
   // Pre-fetch service offering names for display_name fallback
   const uniqueOfferingIds = [...new Set(
@@ -67,7 +85,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
   const dedupeCache = new Map<string, string>()
 
-  for (const row of stagedRows) {
+  for (const row of rowsToProcess) {
     const pd = row.property_data as Record<string, unknown>
     const sld = row.service_location_data as Record<string, unknown>
 
@@ -229,19 +247,28 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     }
   }
 
+  // For idempotent retries, ADD this run's counters to whatever the
+  // prior run(s) recorded. Failures are replaced (only the rows that
+  // failed on THIS attempt are still pending).
+  const prior = (batch.summary_stats as Record<string, any>) ?? {}
+  const sum = (k: string, v: number) => (Number(prior[k]) || 0) + v
   await db
     .from('upload_batches')
     .update({
       status: 'committed',
       committed_at: new Date().toISOString(),
       summary_stats: {
-        ...((batch.summary_stats as Record<string, unknown>) ?? {}),
-        committed_new_properties: newProperties,
-        committed_existing_properties: existingProperties,
-        committed_new_service_locations: newServiceLocations,
-        committed_updated_service_locations: updatedServiceLocations,
+        ...prior,
+        committed_new_properties: sum('committed_new_properties', newProperties),
+        committed_existing_properties: sum('committed_existing_properties', existingProperties),
+        committed_new_service_locations: sum('committed_new_service_locations', newServiceLocations),
+        committed_updated_service_locations: sum(
+          'committed_updated_service_locations',
+          updatedServiceLocations
+        ),
         commit_failure_count: failedRows.length,
         commit_failures: failedRows.slice(0, 50),
+        commit_already_committed_skipped: alreadyCommittedSkipped,
       },
     })
     .eq('upload_batch_id', batchId)

--- a/src/pages/UploadSummary.tsx
+++ b/src/pages/UploadSummary.tsx
@@ -19,6 +19,8 @@ export default function UploadSummaryPage() {
   const [data, setData] = useState<SummaryData | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const [retrying, setRetrying] = useState(false)
+  const [retryMsg, setRetryMsg] = useState<string | null>(null)
 
   useEffect(() => {
     if (!batchId) return
@@ -55,6 +57,37 @@ export default function UploadSummaryPage() {
     load()
     return () => { mounted = false }
   }, [batchId, getToken])
+
+  async function handleRetry() {
+    if (!batchId) return
+    setRetrying(true)
+    setRetryMsg(null)
+    setError(null)
+    try {
+      const token = await getToken()
+      const res = await fetch(`/api/uploads/${batchId}/commit`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      const j = await res.json()
+      if (!res.ok) throw new Error(j.error ?? `Retry failed: ${res.status}`)
+      setRetryMsg(
+        `Retry committed ${j.new_properties ?? 0} new properties + ${j.new_service_locations ?? 0} new service locations.`
+      )
+      // Reload status so the cards reflect the merged totals.
+      const statusRes = await fetch(`/api/uploads/${batchId}/status`, {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      if (statusRes.ok) {
+        const statusData = await statusRes.json()
+        setData((prev) => (prev ? { ...prev, summary_stats: statusData.summary_stats ?? prev.summary_stats } : prev))
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Retry failed')
+    } finally {
+      setRetrying(false)
+    }
+  }
 
   return (
     <AppShell breadcrumb={[{ label: 'Upload', to: '/upload' }, { label: 'Summary' }]}>
@@ -161,6 +194,56 @@ export default function UploadSummaryPage() {
                       </div>
                     </div>
                   )}
+                </div>
+              )}
+
+              {/* Commit failures / retry — surfaces when a prior commit
+                  errored out partway (Vercel timeout, transient DB error).
+                  The commit endpoint is now idempotent so re-running it
+                  picks up only the rows that didn't make it. */}
+              {((data.summary_stats?.commit_failure_count ?? 0) > 0 ||
+                data.status === 'completed') && (
+                <div className="rounded-xl border border-amber-200 bg-amber-50 p-4">
+                  <div className="flex items-start justify-between gap-4">
+                    <div className="space-y-1">
+                      <p className="text-sm font-semibold text-amber-900">
+                        {data.status === 'completed'
+                          ? 'Commit did not finish'
+                          : `${data.summary_stats?.commit_failure_count ?? 0} rows failed to commit`}
+                      </p>
+                      <p className="text-xs text-amber-800">
+                        Re-running the commit picks up only the rows that didn't get
+                        in last time. Already-committed rows are skipped automatically
+                        — you won't get duplicates.
+                      </p>
+                      {data.summary_stats?.commit_failures &&
+                        data.summary_stats.commit_failures.length > 0 && (
+                          <details className="mt-2 text-xs text-amber-900">
+                            <summary className="cursor-pointer">
+                              Show recent failure reasons
+                            </summary>
+                            <ul className="mt-1 list-disc pl-5 space-y-0.5">
+                              {data.summary_stats.commit_failures.slice(0, 10).map((f, i) => (
+                                <li key={i} className="font-mono break-all">
+                                  {f.reason}
+                                </li>
+                              ))}
+                            </ul>
+                          </details>
+                        )}
+                      {retryMsg && (
+                        <p className="text-xs text-green-700 font-medium mt-1">{retryMsg}</p>
+                      )}
+                    </div>
+                    <button
+                      type="button"
+                      onClick={handleRetry}
+                      disabled={retrying}
+                      className="shrink-0 px-3 py-1.5 text-sm font-medium text-white bg-amber-600 rounded-lg hover:bg-amber-700 disabled:opacity-50"
+                    >
+                      {retrying ? 'Retrying…' : 'Retry commit'}
+                    </button>
+                  </div>
                 </div>
               )}
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -128,6 +128,9 @@ export interface UploadSummaryStats {
   committed_existing_properties?: number
   committed_new_service_locations?: number
   committed_updated_service_locations?: number
+  commit_failure_count?: number
+  commit_failures?: Array<{ staged_row_id: string; reason: string }>
+  commit_already_committed_skipped?: number
 }
 
 export type ColumnMappingTarget =


### PR DESCRIPTION
## Real-world scenario
Uploaded 791 properties → 596 landed in the DB → commit returned a failure response → no way to finish the job. Re-uploading the same file would've gone through staging from scratch and the user had to know to bounce around the UI to recover.

## Fix
**API \`/api/uploads/{id}/commit\` is now idempotent:**
- Allows status \`completed\` (commit never ran) OR \`committed\` (a prior run finished/timed out partway).
- Skips staged rows that already have \`service_location_id\` set — those were committed in a prior attempt.
- Counters (\`committed_new_properties\` etc.) are SUMMED across runs, so the totals reflect all attempts.
- Adds \`commit_already_committed_skipped\` so the user can see how many rows the retry passed over.

**UI on \`/upload/{id}/summary\`:**
- Amber banner + \"Retry commit\" button surfaces when the prior commit didn't finish (status still \`completed\`) OR when \`commit_failure_count > 0\`.
- Expandable details show the recent failure reasons so the user can decide retry vs fix-and-reupload.

The existing dedupe + unique-constraint paths already handle the recovery case cleanly — properties match on \`address_hash\`, service_locations match on \`(property_id, service_offering_id, client_id)\` — so we don't get duplicates from a retry.

## Test plan
- [ ] Force a commit to time out partway → batch status stays \`completed\` → Retry banner appears → click → remaining rows insert
- [ ] Commit completes with some failed rows → Retry banner appears with failure reasons → click → failures reattempted
- [ ] Successful retry merges new counters into the existing summary cards (no overwrite)
- [ ] Retry on a fully-committed batch is a safe no-op (every row skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)