### PR TITLE
fix(upload): true commit counts + auto-refresh enrichment after retry

### DIFF
--- a/api/v1/clients/[id]/pending-uploads.ts
+++ b/api/v1/clients/[id]/pending-uploads.ts
@@ -44,18 +44,54 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     created_at: string
     committed_at: string | null
   }>
+  if (rows.length === 0) {
+    return res.status(200).json({ batches: [] })
+  }
+
+  // Per-batch true committed/valid counts from staged_rows. summary_stats
+  // can lag (Vercel timeout cuts the function before the final write),
+  // so we count staged_rows.service_location_id IS NOT NULL as the
+  // source of truth for "committed". Valid rows are anything with an
+  // outcome that's eligible for commit.
+  const batchIds = rows.map((r) => r.upload_batch_id)
+  const trueCounts = new Map<string, { valid: number; committed: number }>()
+  // Total valid (eligible) rows per batch.
+  {
+    const { data, error: cErr } = await db
+      .from('upload_staged_rows')
+      .select('upload_batch_id', { count: undefined })
+      .in('upload_batch_id', batchIds)
+      .in('outcome', ['valid', 'corrected', 'duplicate_existing'])
+    if (cErr) return res.status(500).json({ error: cErr.message })
+    for (const r of (data ?? []) as Array<{ upload_batch_id: string }>) {
+      const cur = trueCounts.get(r.upload_batch_id) ?? { valid: 0, committed: 0 }
+      cur.valid += 1
+      trueCounts.set(r.upload_batch_id, cur)
+    }
+  }
+  // Already-committed rows per batch (have service_location_id set).
+  {
+    const { data, error: cErr } = await db
+      .from('upload_staged_rows')
+      .select('upload_batch_id')
+      .in('upload_batch_id', batchIds)
+      .in('outcome', ['valid', 'corrected', 'duplicate_existing'])
+      .not('service_location_id', 'is', null)
+    if (cErr) return res.status(500).json({ error: cErr.message })
+    for (const r of (data ?? []) as Array<{ upload_batch_id: string }>) {
+      const cur = trueCounts.get(r.upload_batch_id) ?? { valid: 0, committed: 0 }
+      cur.committed += 1
+      trueCounts.set(r.upload_batch_id, cur)
+    }
+  }
 
   const pending = rows
     .map((b) => {
       const stats = b.summary_stats ?? {}
       const failureCount = Number(stats.commit_failure_count ?? 0)
-      const validCount =
-        Number(stats.valid ?? 0) +
-        Number(stats.corrected ?? 0) +
-        Number(stats.duplicate_existing ?? 0)
-      const committedNew = Number(stats.committed_new_properties ?? 0)
-      const committedExisting = Number(stats.committed_existing_properties ?? 0)
-      const committedTotal = committedNew + committedExisting
+      const counts = trueCounts.get(b.upload_batch_id) ?? { valid: 0, committed: 0 }
+      const validCount = counts.valid
+      const committedTotal = counts.committed
       const isCompletedNeverCommitted = b.status === 'completed' && validCount > 0
       const isCommittedWithFailures = b.status === 'committed' && failureCount > 0
       const isCommittedShortOfValid =

--- a/src/components/property/EnrichmentBanner.tsx
+++ b/src/components/property/EnrichmentBanner.tsx
@@ -19,9 +19,14 @@ interface Props {
   // Optional callback when an enrichment run completes (e.g. so a parent
   // page can re-fetch property lists).
   onEnriched?: () => void
+  // Optional bump to force a stats refetch — change the value (e.g.
+  // increment a counter) when something happens elsewhere on the page
+  // that would change the pending count, like a Retry commit landing
+  // new properties in 'pending' state.
+  refreshKey?: number | string
 }
 
-export default function EnrichmentBanner({ clientId, onEnriched }: Props) {
+export default function EnrichmentBanner({ clientId, onEnriched, refreshKey }: Props) {
   const { getToken } = useAuth()
   const [stats, setStats] = useState<Stats | null>(null)
   const [loading, setLoading] = useState(true)
@@ -48,7 +53,10 @@ export default function EnrichmentBanner({ clientId, onEnriched }: Props) {
 
   useEffect(() => {
     fetchStats()
-  }, [fetchStats])
+    // refreshKey is intentionally listed so callers can bump it to
+    // force a re-fetch (e.g. after a Retry commit).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [fetchStats, refreshKey])
 
   const runEnrichment = async () => {
     setRunning(true)

--- a/src/pages/accounts/AccountAnalysis.tsx
+++ b/src/pages/accounts/AccountAnalysis.tsx
@@ -160,6 +160,10 @@ export default function AccountAnalysisPage() {
   const [account, setAccount] = useState<AccountInfo | null>(null)
   const [client, setClient] = useState<ClientInfo | null>(null)
   const [editClientOpen, setEditClientOpen] = useState(false)
+  // Bumped whenever a Retry commit lands new properties — kicks the
+  // EnrichmentBanner to re-fetch its stats so the new pending rows
+  // surface immediately.
+  const [enrichRefreshKey, setEnrichRefreshKey] = useState(0)
   const [latestByModule, setLatestByModule] = useState<Record<string, AnalysisRow | null>>({})
   const [running, setRunning] = useState<Record<string, boolean>>({})
   const [pollIds, setPollIds] = useState<Record<string, string>>({})
@@ -766,13 +770,10 @@ export default function AccountAnalysisPage() {
         {clientId && (
           <PendingUploadsBanner
             clientId={clientId}
-            onCommitted={() => {
-              // Newly-committed properties show up as "pending enrichment"
-              // — kick the enrichment banner to refresh too.
-            }}
+            onCommitted={() => setEnrichRefreshKey((k) => k + 1)}
           />
         )}
-        {clientId && <EnrichmentBanner clientId={clientId} />}
+        {clientId && <EnrichmentBanner clientId={clientId} refreshKey={enrichRefreshKey} />}
 
         {/* Header — title + metadata row + run-all CTA. Breadcrumb is in
             the TopBar so we don't repeat it inline. */}


### PR DESCRIPTION
## What was still broken after #126
1. **Pending-uploads banner kept saying \"597 still need to be committed\"** even after retry succeeded with 194 new + the 597 pre-flight-patched. The counts came from \`upload_batches.summary_stats\`, which a Vercel timeout can leave stale (function dies before the final summary write). The 597 from the original run were in the DB but never recorded in summary_stats.

2. **Enrichment banner didn't refresh** so the newly-committed properties had no obvious path to enrichment.

## Fix
**1. Count from staged_rows, not summary_stats**
\`pending-uploads\` now derives \`valid_count\` and \`committed_count\` per batch with two staged_rows queries:
- \`valid_count\` = rows with eligible outcome (\`valid\`/\`corrected\`/\`duplicate_existing\`).
- \`committed_count\` = those rows with \`service_location_id IS NOT NULL\`.

This is the actual source of truth — both the pre-flight patches (#126) and the per-row updates write to staged_rows, so the count is consistent regardless of whether \`summary_stats\` got its final write.

**2. Refreshable enrichment banner**
\`EnrichmentBanner\` now takes an optional \`refreshKey\` prop. AccountAnalysis bumps it from \`PendingUploadsBanner.onCommitted\`, so the moment a retry lands properties the enrichment banner re-fetches and shows the new \"Enrich N pending\" count.

## Test plan
- [ ] Click Retry on a partially-committed batch → after success, banner shows full committed count and the row drops off (or shows 0 remaining)
- [ ] Same retry → enrichment banner pops up with the new pending properties
- [ ] Click Enrich N pending → properties enrich and appear on the map

🤖 Generated with [Claude Code](https://claude.com/claude-code)