### PR TITLE
fix: ignore stuck upload rows + always-visible enrichment status

### DIFF
--- a/api/uploads/[batchId]/ignore-failed.ts
+++ b/api/uploads/[batchId]/ignore-failed.ts
@@ -1,0 +1,74 @@
+// POST /api/uploads/[batchId]/ignore-failed
+// Marks the staged rows that failed to commit (or have never been
+// committed despite being eligible) as 'manually_ignored' so the batch
+// is no longer flagged as pending. The rows stay in the DB for audit
+// but won't be re-attempted by future retries and won't count toward
+// "valid_count" in the pending-uploads banner.
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { createAdminClient } from '../../_lib/supabase.js'
+import { authenticateRequest } from '../../_lib/auth.js'
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method === 'OPTIONS') return res.status(200).end()
+  if (req.method !== 'POST') return res.status(405).json({ error: 'Method not allowed' })
+
+  try {
+    await authenticateRequest(req)
+  } catch (err: any) {
+    return res.status(err.statusCode ?? 401).json({ error: err.message ?? 'Unauthorized' })
+  }
+
+  const batchId = req.query.batchId as string
+  if (!batchId) return res.status(400).json({ error: 'batchId required' })
+
+  const db = createAdminClient()
+
+  const { data: batch, error: bErr } = await db
+    .from('upload_batches')
+    .select('upload_batch_id, status, summary_stats')
+    .eq('upload_batch_id', batchId)
+    .single()
+  if (bErr || !batch) return res.status(404).json({ error: 'Batch not found' })
+
+  // Find staged rows that are still committable but have no
+  // service_location_id — those are the rows that failed to commit
+  // (or that the loop never reached). Mark them invalid so the
+  // pending-uploads banner stops counting them.
+  const { data: stuck, error: sErr } = await db
+    .from('upload_staged_rows')
+    .select('id')
+    .eq('upload_batch_id', batchId)
+    .in('outcome', ['valid', 'corrected', 'duplicate_existing'])
+    .is('service_location_id', null)
+  if (sErr) return res.status(500).json({ error: sErr.message })
+
+  const stuckIds = (stuck ?? []).map((r: any) => r.id as string)
+  if (stuckIds.length === 0) {
+    return res.status(200).json({ ignored: 0, message: 'Nothing to ignore' })
+  }
+
+  const { error: uErr } = await db
+    .from('upload_staged_rows')
+    .update({
+      outcome: 'invalid',
+      error_messages: ['Manually ignored by user'],
+    })
+    .in('id', stuckIds)
+  if (uErr) return res.status(500).json({ error: uErr.message })
+
+  // Stamp the batch summary so the UI reflects the action.
+  const prior = (batch.summary_stats as Record<string, any>) ?? {}
+  await db
+    .from('upload_batches')
+    .update({
+      summary_stats: {
+        ...prior,
+        manually_ignored_count: (Number(prior.manually_ignored_count) || 0) + stuckIds.length,
+        commit_failure_count: 0,
+        commit_failures: [],
+      },
+    })
+    .eq('upload_batch_id', batchId)
+
+  return res.status(200).json({ ignored: stuckIds.length })
+}

--- a/api/v1/clients/[id]/enrichment-status.ts
+++ b/api/v1/clients/[id]/enrichment-status.ts
@@ -29,16 +29,31 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   const db = createAdminClient()
 
   // Resolve the property ids under this client via service_locations.
-  const { data: slRows, error: slErr } = await db
-    .from('service_locations')
-    .select('property_id')
-    .eq('client_id', clientId)
-    .not('property_id', 'is', null)
-  if (slErr) return res.status(500).json({ error: slErr.message })
-
-  const propertyIds = Array.from(
-    new Set((slRows ?? []).map((r: any) => r.property_id).filter(Boolean))
-  ) as string[]
+  // PostgREST silently caps at ~1000 rows per response, so for clients
+  // with 1000+ SLs we MUST paginate or the enrichment banner under-
+  // counts and (when total ends up at the cap exactly) shows wrong
+  // numbers. Loop pages of 1000 until a short page comes back.
+  const SL_PAGE = 1000
+  const propIdSet = new Set<string>()
+  let slOffset = 0
+  const MAX_SL_PAGES = 100
+  for (let page = 0; page < MAX_SL_PAGES; page++) {
+    const { data: slRows, error: slErr } = await db
+      .from('service_locations')
+      .select('property_id')
+      .eq('client_id', clientId)
+      .not('property_id', 'is', null)
+      .range(slOffset, slOffset + SL_PAGE - 1)
+    if (slErr) return res.status(500).json({ error: slErr.message })
+    const batch = slRows ?? []
+    for (const r of batch) {
+      const id = (r as any).property_id
+      if (id) propIdSet.add(id)
+    }
+    if (batch.length < SL_PAGE) break
+    slOffset += SL_PAGE
+  }
+  const propertyIds = Array.from(propIdSet)
 
   if (req.method === 'GET') {
     if (propertyIds.length === 0) {
@@ -50,30 +65,37 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         no_coords: 0,
       })
     }
-    const { data: props, error } = await db
-      .from('properties')
-      .select('id, enrichment_status, latitude, longitude')
-      .in('id', propertyIds)
-    if (error) return res.status(500).json({ error: error.message })
-    const rows = (props ?? []) as Array<{
-      id: string
-      enrichment_status: string | null
-      latitude: number | null
-      longitude: number | null
-    }>
+    // Chunk the .in() to keep the PostgREST URL under its ~32KB limit.
+    const PROP_ID_CHUNK = 250
     let enriched = 0
     let pending = 0
     let failed = 0
     let noCoords = 0
-    for (const r of rows) {
-      const s = r.enrichment_status
-      if (s === 'enriched') enriched++
-      else if (s === 'failed') failed++
-      else pending++
-      if (r.latitude == null || r.longitude == null) noCoords++
+    let total = 0
+    for (let i = 0; i < propertyIds.length; i += PROP_ID_CHUNK) {
+      const chunk = propertyIds.slice(i, i + PROP_ID_CHUNK)
+      const { data: props, error } = await db
+        .from('properties')
+        .select('id, enrichment_status, latitude, longitude')
+        .in('id', chunk)
+      if (error) return res.status(500).json({ error: error.message })
+      const rows = (props ?? []) as Array<{
+        id: string
+        enrichment_status: string | null
+        latitude: number | null
+        longitude: number | null
+      }>
+      total += rows.length
+      for (const r of rows) {
+        const s = r.enrichment_status
+        if (s === 'enriched') enriched++
+        else if (s === 'failed') failed++
+        else pending++
+        if (r.latitude == null || r.longitude == null) noCoords++
+      }
     }
     return res.status(200).json({
-      total: rows.length,
+      total,
       enriched,
       pending,
       failed,
@@ -85,14 +107,24 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     if (propertyIds.length === 0) {
       return res.status(200).json({ message: 'No properties under this client', count: 0 })
     }
-    const { data: pendingRows, error } = await db
-      .from('properties')
-      .select('id')
-      .in('id', propertyIds)
-      .in('enrichment_status', ['pending', 'failed'])
-      .limit(ENRICH_BATCH_LIMIT)
-    if (error) return res.status(500).json({ error: error.message })
-    const targets = (pendingRows ?? []) as Array<{ id: string }>
+    // Chunk the .in() over property ids to keep the URL under
+    // PostgREST's ~32KB limit for clients with many properties.
+    const PROP_ID_CHUNK = 250
+    const targets: Array<{ id: string }> = []
+    for (let i = 0; i < propertyIds.length; i += PROP_ID_CHUNK) {
+      if (targets.length >= ENRICH_BATCH_LIMIT) break
+      const chunk = propertyIds.slice(i, i + PROP_ID_CHUNK)
+      const { data: pendingRows, error } = await db
+        .from('properties')
+        .select('id')
+        .in('id', chunk)
+        .in('enrichment_status', ['pending', 'failed'])
+      if (error) return res.status(500).json({ error: error.message })
+      for (const r of (pendingRows ?? []) as Array<{ id: string }>) {
+        targets.push(r)
+        if (targets.length >= ENRICH_BATCH_LIMIT) break
+      }
+    }
     if (targets.length === 0) {
       return res.status(200).json({ message: 'No pending properties', count: 0 })
     }

--- a/src/components/property/EnrichmentBanner.tsx
+++ b/src/components/property/EnrichmentBanner.tsx
@@ -2,7 +2,7 @@
 // every property under (account, client) is already enriched. Surfaces
 // pending+failed counts and lets the user kick off a scoped run.
 import { useCallback, useEffect, useState } from 'react'
-import { Loader2, MapPinOff, Sparkles, CheckCircle2 } from 'lucide-react'
+import { Loader2, MapPinOff, Sparkles, CheckCircle2, RefreshCw } from 'lucide-react'
 import { useAuth } from '../../hooks/useAuth'
 import Button from '../ui/Button'
 
@@ -90,15 +90,41 @@ export default function EnrichmentBanner({ clientId, onEnriched, refreshKey }: P
     }
   }
 
-  if (loading) return null
+  // Always render some state — silent null-returns hid bugs in the past
+  // (e.g. when an upstream fetch errored and the banner just disappeared
+  // with no signal to the user that enrichment was needed). Loading
+  // shows a small placeholder, error shows itself with a Refresh button,
+  // and total=0 shows a tiny "no properties yet" line.
+  if (loading) {
+    return (
+      <div className="flex items-center gap-2 rounded-md border border-border bg-surface-subtle px-4 py-2 text-xs text-fg-muted">
+        <Loader2 className="h-3.5 w-3.5 animate-spin" />
+        Checking enrichment status…
+      </div>
+    )
+  }
+  if (error && !stats) {
+    return (
+      <div className="flex items-center justify-between gap-3 rounded-md border border-danger/30 bg-danger/5 px-4 py-2 text-xs">
+        <span className="text-danger">Couldn't load enrichment status: {error}</span>
+        <Button size="sm" variant="ghost" onClick={fetchStats}>
+          <RefreshCw className="h-3.5 w-3.5 mr-1.5" />
+          Retry
+        </Button>
+      </div>
+    )
+  }
   if (!stats) return null
-  // Hide entirely when there's nothing to do AND nothing to report.
-  const everythingEnriched = stats.total > 0 && stats.pending === 0 && stats.failed === 0
 
   if (stats.total === 0) {
-    return null
+    return (
+      <div className="flex items-center gap-2 rounded-md border border-border bg-surface-subtle px-4 py-2 text-xs text-fg-muted">
+        No properties under this client yet.
+      </div>
+    )
   }
 
+  const everythingEnriched = stats.total > 0 && stats.pending === 0 && stats.failed === 0
   if (everythingEnriched && !message && !error) {
     return (
       <div className="flex items-center justify-between gap-3 rounded-md border border-success/30 bg-success/5 px-4 py-2.5 text-sm">
@@ -108,11 +134,19 @@ export default function EnrichmentBanner({ clientId, onEnriched, refreshKey }: P
             All <span className="font-tabular">{stats.enriched}</span> properties enriched.
           </span>
         </div>
-        {stats.no_coords > 0 && (
-          <span className="text-xs text-fg-muted">
-            {stats.no_coords} still missing coordinates
-          </span>
-        )}
+        <div className="flex items-center gap-3 text-xs text-fg-muted">
+          {stats.no_coords > 0 && (
+            <span>{stats.no_coords} still missing coordinates</span>
+          )}
+          <button
+            onClick={fetchStats}
+            className="text-fg-subtle hover:text-fg transition-colors inline-flex items-center gap-1"
+            aria-label="Refresh enrichment status"
+            title="Refresh enrichment status"
+          >
+            <RefreshCw className="h-3 w-3" />
+          </button>
+        </div>
       </div>
     )
   }

--- a/src/components/upload/PendingUploadsBanner.tsx
+++ b/src/components/upload/PendingUploadsBanner.tsx
@@ -3,7 +3,7 @@
 // its own "Retry commit" button; on success the row removes itself
 // from the list.
 import { useCallback, useEffect, useState } from 'react'
-import { Loader2, AlertTriangle, RotateCcw } from 'lucide-react'
+import { Loader2, AlertTriangle, RotateCcw, X } from 'lucide-react'
 import { useAuth } from '../../hooks/useAuth'
 import Button from '../ui/Button'
 
@@ -31,6 +31,7 @@ export default function PendingUploadsBanner({ clientId, onCommitted }: Props) {
   const [batches, setBatches] = useState<PendingBatch[]>([])
   const [loading, setLoading] = useState(true)
   const [retryingId, setRetryingId] = useState<string | null>(null)
+  const [ignoringId, setIgnoringId] = useState<string | null>(null)
   const [perBatchMessage, setPerBatchMessage] = useState<Record<string, string>>({})
   const [error, setError] = useState<string | null>(null)
 
@@ -54,6 +55,41 @@ export default function PendingUploadsBanner({ clientId, onCommitted }: Props) {
   useEffect(() => {
     fetchPending()
   }, [fetchPending])
+
+  const ignore = async (batch: PendingBatch) => {
+    if (
+      !window.confirm(
+        `Mark ${Math.max(0, batch.valid_count - batch.committed_count)} stuck row${
+          batch.valid_count - batch.committed_count === 1 ? '' : 's'
+        } in "${batch.source_filename ?? 'this batch'}" as ignored? They'll stay in the upload audit but won't be reattempted.`
+      )
+    ) {
+      return
+    }
+    setIgnoringId(batch.batch_id)
+    setError(null)
+    try {
+      const token = await getToken()
+      const res = await fetch(`/api/uploads/${batch.batch_id}/ignore-failed`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      const j = await res.json()
+      if (!res.ok) throw new Error(j.error ?? `Ignore failed: ${res.status}`)
+      setPerBatchMessage((prev) => ({
+        ...prev,
+        [batch.batch_id]: `Marked ${j.ignored ?? 0} row${j.ignored === 1 ? '' : 's'} as ignored.`,
+      }))
+      await fetchPending()
+    } catch (err) {
+      setPerBatchMessage((prev) => ({
+        ...prev,
+        [batch.batch_id]: err instanceof Error ? err.message : String(err),
+      }))
+    } finally {
+      setIgnoringId(null)
+    }
+  }
 
   const retry = async (batch: PendingBatch) => {
     setRetryingId(batch.batch_id)
@@ -146,24 +182,47 @@ export default function PendingUploadsBanner({ clientId, onCommitted }: Props) {
                   </p>
                 )}
               </div>
-              <Button
-                size="sm"
-                variant="secondary"
-                onClick={() => retry(b)}
-                disabled={isRetrying || retryingId != null}
-              >
-                {isRetrying ? (
-                  <>
-                    <Loader2 className="h-3.5 w-3.5 mr-1.5 animate-spin" />
-                    Retrying…
-                  </>
-                ) : (
-                  <>
-                    <RotateCcw className="h-3.5 w-3.5 mr-1.5" />
-                    Retry commit
-                  </>
+              <div className="flex items-center gap-2 shrink-0">
+                <Button
+                  size="sm"
+                  variant="secondary"
+                  onClick={() => retry(b)}
+                  disabled={isRetrying || retryingId != null || ignoringId != null}
+                >
+                  {isRetrying ? (
+                    <>
+                      <Loader2 className="h-3.5 w-3.5 mr-1.5 animate-spin" />
+                      Retrying…
+                    </>
+                  ) : (
+                    <>
+                      <RotateCcw className="h-3.5 w-3.5 mr-1.5" />
+                      Retry commit
+                    </>
+                  )}
+                </Button>
+                {(b.failure_count > 0 || b.committed_count < b.valid_count) && (
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    onClick={() => ignore(b)}
+                    disabled={ignoringId === b.batch_id || retryingId != null || ignoringId != null}
+                    title="Mark unfinishable rows as ignored so this batch stops being flagged."
+                  >
+                    {ignoringId === b.batch_id ? (
+                      <>
+                        <Loader2 className="h-3.5 w-3.5 mr-1.5 animate-spin" />
+                        Ignoring…
+                      </>
+                    ) : (
+                      <>
+                        <X className="h-3.5 w-3.5 mr-1.5" />
+                        Ignore stuck rows
+                      </>
+                    )}
+                  </Button>
                 )}
-              </Button>
+              </div>
             </li>
           )
         })}


### PR DESCRIPTION
## Three fixes for the partial-commit recovery flow

### 1. Ignore stuck rows
New \`POST /api/uploads/{id}/ignore-failed\` endpoint marks any staged rows that are still uncommitted (no \`service_location_id\`) as outcome=\`invalid\` so they stop counting toward the pending-uploads tally. PendingUploadsBanner now has an \"Ignore stuck rows\" button next to \"Retry commit\" for batches with failures or short commits — the user can either fix-and-retry, or walk away from the 2 stragglers.

### 2. Always-visible enrichment status
\`EnrichmentBanner\` used to silently return \`null\` on error or when \`total=0\`, which hid bugs like \"why isn't the enrich button showing?\":
- Loading: small placeholder.
- Error: red message + Retry button.
- total=0: \"No properties under this client yet.\"
- Green/amber states: refresh icon for on-demand re-poll.

### 3. PostgREST cap on enrichment-status
The client_id → property_id resolution had the same ~1000-row PostgREST cap that hit the map view. For clients with >1000 service_locations the enrichment counts were undercounting and in edge cases the banner showed \"everything enriched\" when the excess rows were actually pending. Loop SL pages of 1000 until a short page comes back, then chunk the \`.in('id', …)\` over property ids by 250 to stay under the ~32KB URL limit.

## Test plan
- [ ] After a successful Retry, the enrichment banner appears with the new pending count
- [ ] Click \"Ignore stuck rows\" on a batch with failures → confirm dialog → batch drops off the pending list (no remaining valid rows)
- [ ] Banner refresh icon re-fetches enrichment stats
- [ ] If the enrichment-status endpoint errors, the banner shows the error rather than silently disappearing
- [ ] Clients with > 1000 properties show accurate enrichment counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)