### PR TITLE
Phase 4e — recurring cycles with auto-generation, preflight checks, and side-by-side comparison

### DIFF
--- a/api/_lib/scheduler/auto-generation.ts
+++ b/api/_lib/scheduler/auto-generation.ts
@@ -1,0 +1,129 @@
+// Phase 4e — auto-generation trigger.
+//
+// For an in-progress cycle: if completion ≥ template threshold AND we
+// have at least lead_days runway before cycle.end_date AND no next
+// cycle exists yet AND auto-generate is enabled on the template, then
+// generate the next cycle, run preflight on it, and link the cycles.
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { calculateCycleCompletion } from './cycle-completion.js'
+import { generateCycleInstance } from './generate-cycle-instance.js'
+import { runPreflightChecks, persistPreflightResults } from './preflight-checks.js'
+
+export interface AutoGenerationOutcome {
+  action: 'triggered' | 'deferred' | 'skipped' | 'blocked'
+  reason?: string
+  new_cycle_id?: string
+  preflight_summary?: {
+    blocking: number
+    warning: number
+    info: number
+  }
+}
+
+function addDaysIso(dateStr: string, n: number): string {
+  const [y, m, d] = dateStr.split('-').map(Number)
+  const dt = new Date(Date.UTC(y, m - 1, d))
+  dt.setUTCDate(dt.getUTCDate() + n)
+  return dt.toISOString().slice(0, 10)
+}
+
+function daysBetween(a: string, b: string): number {
+  const ad = new Date(`${a}T00:00:00Z`).getTime()
+  const bd = new Date(`${b}T00:00:00Z`).getTime()
+  return Math.round((bd - ad) / 86400000)
+}
+
+export async function checkAndTriggerAutoGeneration(
+  db: SupabaseClient,
+  cycleId: string,
+  options: { force?: boolean } = {}
+): Promise<AutoGenerationOutcome> {
+  const { data: cycle, error: cErr } = await db
+    .from('cycle_instances')
+    .select('id, template_id, cycle_number, status, end_date, next_cycle_id')
+    .eq('id', cycleId)
+    .single()
+  if (cErr || !cycle) return { action: 'skipped', reason: 'cycle_not_found' }
+  const c = cycle as any
+
+  if (c.next_cycle_id) {
+    return { action: 'skipped', reason: 'next_cycle_already_exists' }
+  }
+  if (!options.force && c.status !== 'in_progress') {
+    return { action: 'skipped', reason: `cycle_status_${c.status}` }
+  }
+
+  const { data: tpl, error: tErr } = await db
+    .from('routing_templates')
+    .select(
+      'id, cycle_length_days, auto_generate_enabled, auto_generate_at_completion_pct, auto_generate_lead_days'
+    )
+    .eq('id', c.template_id)
+    .single()
+  if (tErr || !tpl) return { action: 'skipped', reason: 'template_not_found' }
+  const t = tpl as any
+
+  if (!options.force && t.auto_generate_enabled === false) {
+    return { action: 'skipped', reason: 'auto_generate_disabled_on_template' }
+  }
+
+  // Completion threshold check (skipped on force).
+  if (!options.force) {
+    const stats = await calculateCycleCompletion(db, cycleId)
+    const threshold = Number(t.auto_generate_at_completion_pct ?? 80)
+    if (stats.completion_pct < threshold) {
+      return {
+        action: 'skipped',
+        reason: `below_completion_threshold (${stats.completion_pct}% < ${threshold}%)`,
+      }
+    }
+  }
+
+  // Lead-time check.
+  const today = new Date().toISOString().slice(0, 10)
+  const daysUntilEnd = daysBetween(today, c.end_date)
+  const leadDays = Number(t.auto_generate_lead_days ?? 14)
+  if (!options.force && daysUntilEnd < leadDays) {
+    return {
+      action: 'deferred',
+      reason: `insufficient_lead_time (${daysUntilEnd} days, need ${leadDays})`,
+    }
+  }
+
+  // Compute next cycle date range.
+  const nextStart = addDaysIso(c.end_date, 1)
+  const nextCycleNumber = Number(c.cycle_number) + 1
+
+  // Generate the new cycle (uses Phase 4d's generator; applies latest
+  // template since the template may have been edited since cycle 1).
+  const result = await generateCycleInstance(
+    db,
+    c.template_id,
+    nextStart,
+    nextCycleNumber,
+    { applyTemplateChanges: true }
+  )
+
+  // Run preflight on the freshly-generated cycle and persist results.
+  const preflight = await runPreflightChecks(db, result.cycle_instance_id)
+  await persistPreflightResults(db, result.cycle_instance_id, c.template_id, preflight)
+
+  // Link cycles.
+  await db
+    .from('cycle_instances')
+    .update({
+      next_cycle_id: result.cycle_instance_id,
+      auto_generation_triggered_at: new Date().toISOString(),
+    })
+    .eq('id', cycleId)
+
+  return {
+    action: 'triggered',
+    new_cycle_id: result.cycle_instance_id,
+    preflight_summary: {
+      blocking: preflight.blocking.length,
+      warning: preflight.warnings.length,
+      info: preflight.info.length,
+    },
+  }
+}

--- a/api/_lib/scheduler/cycle-comparison.ts
+++ b/api/_lib/scheduler/cycle-comparison.ts
@@ -1,0 +1,246 @@
+// Phase 4e — side-by-side cycle comparison.
+//
+// Loads both cycles' summary metrics + visit/crew detail and computes
+// deltas. Both cycles must belong to the same template (else throws).
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+interface CycleSummary {
+  id: string
+  template_id: string
+  cycle_number: number
+  start_date: string
+  end_date: string
+  status: string
+  crew_count: number
+  total_visits: number
+  visits_completed: number
+  visits_cancelled: number
+  visits_unplaced: number
+  total_drive_miles: number
+  total_work_hours: number
+  total_overnight_nights: number
+  total_estimated_cost: number
+  hard_constraint_violations: number
+  soft_constraint_violations: number
+  visit_counts_by_status: Record<string, number>
+  crews_used: number
+}
+
+interface CompareSide {
+  cycle: CycleSummary
+}
+
+export interface ComparisonResult {
+  left: CompareSide
+  right: CompareSide
+  deltas: {
+    total_visits: Delta
+    total_drive_miles: Delta
+    total_work_hours: Delta
+    total_overnight_nights: Delta
+    total_estimated_cost: Delta
+    crews_used: Delta
+    hard_constraint_violations: Delta
+    soft_constraint_violations: Delta
+    properties_added: string[]
+    properties_removed: string[]
+    properties_with_changed_crew: Array<{
+      property_id: string
+      left_crew: number | null
+      right_crew: number | null
+    }>
+    properties_with_changed_date: Array<{
+      property_id: string
+      left_date: string | null
+      right_date: string | null
+    }>
+  }
+}
+
+interface Delta {
+  left: number
+  right: number
+  delta: number
+  pct_change: number
+}
+
+function delta(left: number, right: number): Delta {
+  const d = right - left
+  return {
+    left,
+    right,
+    delta: d,
+    pct_change: left === 0 ? (right === 0 ? 0 : 100) : Math.round((d / left) * 1000) / 10,
+  }
+}
+
+async function loadOneCycle(
+  db: SupabaseClient,
+  cycleId: string
+): Promise<{
+  summary: CycleSummary
+  visits: Array<{
+    property_id: string | null
+    scheduled_date: string | null
+    crew_day_route_id: string | null
+    status: string
+  }>
+  crewDays: Array<{ id: string; crew_index: number }>
+}> {
+  const { data: cycle, error: cErr } = await db
+    .from('cycle_instances')
+    .select(
+      'id, template_id, cycle_number, start_date, end_date, status, ' +
+        'total_visits, total_drive_miles, total_work_minutes, total_overnight_nights, ' +
+        'total_estimated_cost, hard_constraint_violations, soft_constraint_violations'
+    )
+    .eq('id', cycleId)
+    .single()
+  if (cErr || !cycle) throw new Error(`Cycle ${cycleId} not found: ${cErr?.message}`)
+  const c = cycle as any
+
+  const { data: tpl } = await db
+    .from('routing_templates')
+    .select('crew_count')
+    .eq('id', c.template_id)
+    .single()
+  const crewCount = Number((tpl as any)?.crew_count ?? 0)
+
+  const { data: visits } = await db
+    .from('scheduled_visits')
+    .select('property_id, scheduled_date, crew_day_route_id, status')
+    .eq('cycle_instance_id', cycleId)
+  const v = (visits ?? []) as any[]
+
+  const { data: crewDays } = await db
+    .from('crew_day_routes')
+    .select('id, crew_index')
+    .eq('cycle_instance_id', cycleId)
+  const cd = (crewDays ?? []) as any[]
+
+  const counts: Record<string, number> = {}
+  let completed = 0
+  let cancelled = 0
+  let unplaced = 0
+  for (const x of v) {
+    counts[x.status] = (counts[x.status] ?? 0) + 1
+    if (x.status === 'completed') completed++
+    else if (x.status === 'cancelled') cancelled++
+    else if (x.status === 'unplaced') unplaced++
+  }
+  const crewsUsed = new Set(cd.map((x) => x.crew_index)).size
+
+  const summary: CycleSummary = {
+    id: c.id,
+    template_id: c.template_id,
+    cycle_number: c.cycle_number,
+    start_date: c.start_date,
+    end_date: c.end_date,
+    status: c.status,
+    crew_count: crewCount,
+    total_visits: Number(c.total_visits ?? v.length),
+    visits_completed: completed,
+    visits_cancelled: cancelled,
+    visits_unplaced: unplaced,
+    total_drive_miles: Number(c.total_drive_miles ?? 0),
+    total_work_hours: Math.round((Number(c.total_work_minutes ?? 0) / 60) * 10) / 10,
+    total_overnight_nights: Number(c.total_overnight_nights ?? 0),
+    total_estimated_cost: Number(c.total_estimated_cost ?? 0),
+    hard_constraint_violations: Number(c.hard_constraint_violations ?? 0),
+    soft_constraint_violations: Number(c.soft_constraint_violations ?? 0),
+    visit_counts_by_status: counts,
+    crews_used: crewsUsed,
+  }
+  return { summary, visits: v, crewDays: cd }
+}
+
+export async function compareCycles(
+  db: SupabaseClient,
+  leftId: string,
+  rightId: string
+): Promise<ComparisonResult> {
+  const [left, right] = await Promise.all([loadOneCycle(db, leftId), loadOneCycle(db, rightId)])
+  if (left.summary.template_id !== right.summary.template_id) {
+    throw new Error('Cycles must belong to the same template')
+  }
+
+  // Build crew_index lookup per cycle for visits.
+  const leftCrewByRoute = new Map<string, number>()
+  for (const cd of left.crewDays) leftCrewByRoute.set(cd.id, cd.crew_index)
+  const rightCrewByRoute = new Map<string, number>()
+  for (const cd of right.crewDays) rightCrewByRoute.set(cd.id, cd.crew_index)
+
+  const leftVisitByProp = new Map<
+    string,
+    { date: string | null; crew: number | null }
+  >()
+  for (const v of left.visits) {
+    if (!v.property_id) continue
+    leftVisitByProp.set(v.property_id, {
+      date: v.scheduled_date,
+      crew: v.crew_day_route_id ? leftCrewByRoute.get(v.crew_day_route_id) ?? null : null,
+    })
+  }
+  const rightVisitByProp = new Map<
+    string,
+    { date: string | null; crew: number | null }
+  >()
+  for (const v of right.visits) {
+    if (!v.property_id) continue
+    rightVisitByProp.set(v.property_id, {
+      date: v.scheduled_date,
+      crew: v.crew_day_route_id ? rightCrewByRoute.get(v.crew_day_route_id) ?? null : null,
+    })
+  }
+
+  const leftPropIds = new Set(leftVisitByProp.keys())
+  const rightPropIds = new Set(rightVisitByProp.keys())
+  const propertiesAdded: string[] = []
+  const propertiesRemoved: string[] = []
+  for (const id of rightPropIds) if (!leftPropIds.has(id)) propertiesAdded.push(id)
+  for (const id of leftPropIds) if (!rightPropIds.has(id)) propertiesRemoved.push(id)
+
+  const propertiesWithChangedCrew: ComparisonResult['deltas']['properties_with_changed_crew'] = []
+  const propertiesWithChangedDate: ComparisonResult['deltas']['properties_with_changed_date'] = []
+  for (const [pid, lv] of leftVisitByProp) {
+    const rv = rightVisitByProp.get(pid)
+    if (!rv) continue
+    if (lv.crew !== rv.crew) {
+      propertiesWithChangedCrew.push({ property_id: pid, left_crew: lv.crew, right_crew: rv.crew })
+    }
+    if (lv.date !== rv.date) {
+      propertiesWithChangedDate.push({ property_id: pid, left_date: lv.date, right_date: rv.date })
+    }
+  }
+
+  return {
+    left: { cycle: left.summary },
+    right: { cycle: right.summary },
+    deltas: {
+      total_visits: delta(left.summary.total_visits, right.summary.total_visits),
+      total_drive_miles: delta(left.summary.total_drive_miles, right.summary.total_drive_miles),
+      total_work_hours: delta(left.summary.total_work_hours, right.summary.total_work_hours),
+      total_overnight_nights: delta(
+        left.summary.total_overnight_nights,
+        right.summary.total_overnight_nights
+      ),
+      total_estimated_cost: delta(
+        left.summary.total_estimated_cost,
+        right.summary.total_estimated_cost
+      ),
+      crews_used: delta(left.summary.crews_used, right.summary.crews_used),
+      hard_constraint_violations: delta(
+        left.summary.hard_constraint_violations,
+        right.summary.hard_constraint_violations
+      ),
+      soft_constraint_violations: delta(
+        left.summary.soft_constraint_violations,
+        right.summary.soft_constraint_violations
+      ),
+      properties_added: propertiesAdded,
+      properties_removed: propertiesRemoved,
+      properties_with_changed_crew: propertiesWithChangedCrew,
+      properties_with_changed_date: propertiesWithChangedDate,
+    },
+  }
+}

--- a/api/_lib/scheduler/cycle-completion.ts
+++ b/api/_lib/scheduler/cycle-completion.ts
@@ -1,0 +1,89 @@
+// Phase 4e — cycle completion tracking.
+//
+// "Completion" treats both completed AND cancelled visits as "done with"
+// the cycle (the work is no longer pending), so a cycle that's been
+// fully cancelled reads as 100% complete. Unplaced visits never had a
+// date; they're tracked separately and excluded from the denominator
+// to avoid pinning completion below 100% when work just couldn't be
+// scheduled.
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+export interface CompletionResult {
+  visits_total: number
+  visits_completed: number
+  visits_cancelled: number
+  visits_unplaced: number
+  completion_pct: number
+  status_summary: string
+}
+
+export async function calculateCycleCompletion(
+  db: SupabaseClient,
+  cycleInstanceId: string
+): Promise<CompletionResult> {
+  const { data, error } = await db
+    .from('scheduled_visits')
+    .select('status')
+    .eq('cycle_instance_id', cycleInstanceId)
+  if (error) throw new Error(`scheduled_visits read failed: ${error.message}`)
+
+  let completed = 0
+  let cancelled = 0
+  let unplaced = 0
+  let other = 0
+  for (const r of (data ?? []) as Array<{ status: string }>) {
+    if (r.status === 'completed') completed++
+    else if (r.status === 'cancelled') cancelled++
+    else if (r.status === 'unplaced') unplaced++
+    else other++
+  }
+  const total = completed + cancelled + other // exclude unplaced
+  // 0 placed visits = vacuously complete (nothing to do).
+  const completion_pct = total === 0 ? 100 : Math.round(((completed + cancelled) / total) * 1000) / 10
+
+  return {
+    visits_total: total,
+    visits_completed: completed,
+    visits_cancelled: cancelled,
+    visits_unplaced: unplaced,
+    completion_pct,
+    status_summary: `${completed} completed · ${cancelled} cancelled · ${other} placed · ${unplaced} unplaced`,
+  }
+}
+
+// Recompute completion + persist on the cycle_instances row. Also
+// transitions cycle.status if appropriate (planned → in_progress on
+// first completion; in_progress → completed at 100%). Returns the
+// updated stats so the caller can short-circuit on no change.
+export async function refreshCycleCompletion(
+  db: SupabaseClient,
+  cycleInstanceId: string
+): Promise<{ stats: CompletionResult; status_changed_to: string | null }> {
+  const stats = await calculateCycleCompletion(db, cycleInstanceId)
+
+  // Read current cycle status to decide if we should transition.
+  const { data: cycle } = await db
+    .from('cycle_instances')
+    .select('id, status, start_date')
+    .eq('id', cycleInstanceId)
+    .single()
+  const currentStatus = (cycle as any)?.status as string | undefined
+  let nextStatus: string | null = null
+  if (currentStatus === 'planned' && (stats.visits_completed > 0 || stats.visits_cancelled > 0)) {
+    nextStatus = 'in_progress'
+  } else if (currentStatus === 'in_progress' && stats.completion_pct >= 100) {
+    nextStatus = 'completed'
+  }
+
+  const update: Record<string, unknown> = {
+    completion_pct: stats.completion_pct,
+    visits_completed_count: stats.visits_completed,
+    visits_total_count: stats.visits_total,
+    completion_last_calculated_at: new Date().toISOString(),
+  }
+  if (nextStatus) update.status = nextStatus
+
+  await db.from('cycle_instances').update(update).eq('id', cycleInstanceId)
+
+  return { stats, status_changed_to: nextStatus }
+}

--- a/api/_lib/scheduler/preflight-checks.ts
+++ b/api/_lib/scheduler/preflight-checks.ts
@@ -1,0 +1,533 @@
+// Phase 4e — preflight checks against an auto-generated (or recently
+// re-generated) cycle. Runs 10 lightweight queries that surface known
+// issues so the operator reviews before the cycle goes live.
+//
+// All checks read from the DB (cycle's scheduled_visits + the template
+// + the client's current property set) and return 0-N issues each.
+// The aggregator runs them in parallel and persists results to
+// cycle_preflight_checks.
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { getDefaultHolidays } from '../analysis/working-days.js'
+import { computeCrewCount } from '../analysis/crew-count.js'
+import { evaluateConstraint, type StoredConstraint } from './constraint-evaluator.js'
+
+export type CheckType =
+  | 'holiday_in_work_week'
+  | 'blackout_date_conflict'
+  | 'seasonal_window_violation'
+  | 'property_added_since_template'
+  | 'property_removed_since_template'
+  | 'capacity_overflow'
+  | 'cohort_year_transition'
+  | 'cohort_unassigned'
+  | 'extended_idle_period'
+  | 'cycle_starts_during_holiday'
+
+export type Severity = 'blocking' | 'warning' | 'info'
+
+export interface PreflightIssue {
+  check_type: CheckType
+  severity: Severity
+  affected_count?: number
+  affected_entity_type?: string
+  affected_entity_ids?: string[]
+  description: string
+  suggested_action?: string
+}
+
+export interface PreflightResult {
+  has_blocking_issues: boolean
+  blocking: PreflightIssue[]
+  warnings: PreflightIssue[]
+  info: PreflightIssue[]
+}
+
+interface CycleContext {
+  cycle: {
+    id: string
+    template_id: string
+    cycle_number: number
+    start_date: string
+    end_date: string
+  }
+  template: {
+    id: string
+    client_id: string
+    crew_count: number
+    cycle_length_days: number
+    routed_service_location_ids: string[]
+  }
+  visits: Array<{
+    id: string
+    service_location_id: string | null
+    property_id: string | null
+    scheduled_date: string | null
+    crew_day_route_id: string | null
+    status: string
+    hours_per_visit_total: number | null
+    attached_addons: any[] | null
+  }>
+  crewDays: Array<{
+    id: string
+    crew_index: number
+    crew_label: string | null
+    scheduled_date: string
+    day_type: string
+  }>
+  // Per-SL constraints, keyed by service_location_id.
+  constraints: Map<string, StoredConstraint[]>
+}
+
+async function loadCycleContext(
+  db: SupabaseClient,
+  cycleId: string
+): Promise<CycleContext> {
+  const { data: cycle, error: cErr } = await db
+    .from('cycle_instances')
+    .select('id, template_id, cycle_number, start_date, end_date')
+    .eq('id', cycleId)
+    .single()
+  if (cErr || !cycle) throw new Error(`Cycle not found: ${cErr?.message}`)
+  const c = cycle as any
+
+  const { data: template, error: tErr } = await db
+    .from('routing_templates')
+    .select('id, client_id, crew_count, cycle_length_days, routed_service_location_ids')
+    .eq('id', c.template_id)
+    .single()
+  if (tErr || !template) throw new Error(`Template not found: ${tErr?.message}`)
+  const t = template as any
+
+  const { data: visits } = await db
+    .from('scheduled_visits')
+    .select('id, service_location_id, property_id, scheduled_date, crew_day_route_id, status, hours_per_visit_total, attached_addons')
+    .eq('cycle_instance_id', cycleId)
+  const v = (visits ?? []) as any[]
+
+  const { data: crewDays } = await db
+    .from('crew_day_routes')
+    .select('id, crew_index, crew_label, scheduled_date, day_type')
+    .eq('cycle_instance_id', cycleId)
+  const cd = (crewDays ?? []) as any[]
+
+  // Pull per-SL constraints (date-driven only — what preflight actually
+  // checks). Skip if no SLs are referenced.
+  const slIds = Array.from(
+    new Set(v.map((x) => x.service_location_id).filter(Boolean) as string[])
+  )
+  const constraints = new Map<string, StoredConstraint[]>()
+  if (slIds.length > 0) {
+    // Chunk in case of many SLs.
+    const CHUNK = 250
+    for (let i = 0; i < slIds.length; i += CHUNK) {
+      const chunk = slIds.slice(i, i + CHUNK)
+      const { data: cons } = await db
+        .from('service_location_constraints')
+        .select('id, service_location_id, constraint_type, enforcement, config, notes')
+        .in('service_location_id', chunk)
+      for (const row of (cons ?? []) as any[]) {
+        const arr = constraints.get(row.service_location_id) ?? []
+        arr.push({
+          id: row.id,
+          service_location_id: row.service_location_id,
+          constraint_type: row.constraint_type,
+          enforcement: row.enforcement,
+          config: row.config ?? {},
+          notes: row.notes ?? null,
+        })
+        constraints.set(row.service_location_id, arr)
+      }
+    }
+  }
+
+  return { cycle: c, template: t, visits: v, crewDays: cd, constraints }
+}
+
+// ── Individual checks ────────────────────────────────────────────────
+
+function checkHolidaysInWorkWeeks(ctx: CycleContext): PreflightIssue[] {
+  const start = new Date(`${ctx.cycle.start_date}T00:00:00Z`)
+  const end = new Date(`${ctx.cycle.end_date}T23:59:59Z`)
+  const holidays = getDefaultHolidays(start, end).filter((h) => h >= start && h <= end)
+  const issues: PreflightIssue[] = []
+  for (const holiday of holidays) {
+    const weekStart = new Date(holiday)
+    weekStart.setUTCDate(holiday.getUTCDate() - holiday.getUTCDay()) // Sun
+    const weekEnd = new Date(weekStart)
+    weekEnd.setUTCDate(weekStart.getUTCDate() + 6)
+    const weekVisits = ctx.visits.filter((v) => {
+      if (!v.scheduled_date) return false
+      const d = new Date(`${v.scheduled_date}T00:00:00Z`)
+      return d >= weekStart && d <= weekEnd
+    })
+    if (weekVisits.length > 0) {
+      issues.push({
+        check_type: 'holiday_in_work_week',
+        severity: 'warning',
+        affected_count: weekVisits.length,
+        affected_entity_type: 'visit',
+        affected_entity_ids: weekVisits.map((v) => v.id),
+        description: `${weekVisits.length} visits planned in the week of a federal holiday (${holiday.toISOString().slice(0, 10)})`,
+        suggested_action: 'Review visits in this week; consider rescheduling around the holiday',
+      })
+    }
+  }
+  return issues
+}
+
+function checkBlackoutDateConflicts(ctx: CycleContext): PreflightIssue[] {
+  const offenders: Array<{ id: string; description: string }> = []
+  for (const v of ctx.visits) {
+    if (!v.service_location_id || !v.scheduled_date) continue
+    const cs = ctx.constraints.get(v.service_location_id) ?? []
+    for (const c of cs) {
+      if (c.constraint_type !== 'blackout_dates') continue
+      const ev = evaluateConstraint(c, {
+        scheduled_date: v.scheduled_date,
+        arrival_time: '08:00',
+        work_start_time: '08:00',
+        work_end_time: '17:00',
+        crew_size: 1,
+      })
+      if (!ev.satisfied && ev.severity === 'hard') {
+        offenders.push({ id: v.id, description: ev.description })
+      }
+    }
+  }
+  if (offenders.length === 0) return []
+  return [
+    {
+      check_type: 'blackout_date_conflict',
+      severity: 'blocking',
+      affected_count: offenders.length,
+      affected_entity_type: 'visit',
+      affected_entity_ids: offenders.map((o) => o.id),
+      description: `${offenders.length} visits land on blackout dates`,
+      suggested_action: 'Move these visits to a different day before the cycle goes live',
+    },
+  ]
+}
+
+function checkSeasonalWindowViolations(ctx: CycleContext): PreflightIssue[] {
+  const offenders: string[] = []
+  for (const v of ctx.visits) {
+    if (!v.service_location_id || !v.scheduled_date) continue
+    const cs = ctx.constraints.get(v.service_location_id) ?? []
+    for (const c of cs) {
+      if (c.constraint_type !== 'seasonal_window') continue
+      const ev = evaluateConstraint(c, {
+        scheduled_date: v.scheduled_date,
+        arrival_time: '08:00',
+        work_start_time: '08:00',
+        work_end_time: '17:00',
+        crew_size: 1,
+      })
+      if (!ev.satisfied && ev.severity === 'hard') offenders.push(v.id)
+    }
+  }
+  if (offenders.length === 0) return []
+  return [
+    {
+      check_type: 'seasonal_window_violation',
+      severity: 'blocking',
+      affected_count: offenders.length,
+      affected_entity_type: 'visit',
+      affected_entity_ids: offenders,
+      description: `${offenders.length} visits fall outside their seasonal window`,
+      suggested_action: 'Reschedule these visits within the allowed seasonal range',
+    },
+  ]
+}
+
+async function checkPropertiesAddedSinceTemplate(
+  db: SupabaseClient,
+  ctx: CycleContext
+): Promise<PreflightIssue[]> {
+  // Routed SLs in the client today. Compare to the template's snapshot.
+  const { data: sls } = await db
+    .from('service_locations')
+    .select('id')
+    .eq('client_id', ctx.template.client_id)
+  const currentIds = new Set((sls ?? []).map((r: any) => r.id as string))
+  const templateIds = new Set(ctx.template.routed_service_location_ids ?? [])
+  const added: string[] = []
+  for (const id of currentIds) if (!templateIds.has(id)) added.push(id)
+  if (added.length === 0) return []
+  return [
+    {
+      check_type: 'property_added_since_template',
+      severity: 'warning',
+      affected_count: added.length,
+      affected_entity_type: 'service_location',
+      affected_entity_ids: added,
+      description: `${added.length} new service locations exist on the client but aren't in this template`,
+      suggested_action: 'Re-optimize the template to include the new properties before next cycle',
+    },
+  ]
+}
+
+async function checkPropertiesRemovedSinceTemplate(
+  db: SupabaseClient,
+  ctx: CycleContext
+): Promise<PreflightIssue[]> {
+  if (!ctx.template.routed_service_location_ids?.length) return []
+  const { data: sls } = await db
+    .from('service_locations')
+    .select('id')
+    .in('id', ctx.template.routed_service_location_ids)
+  const stillExisting = new Set((sls ?? []).map((r: any) => r.id as string))
+  const removed = ctx.template.routed_service_location_ids.filter(
+    (id) => !stillExisting.has(id)
+  )
+  if (removed.length === 0) return []
+  return [
+    {
+      check_type: 'property_removed_since_template',
+      severity: 'warning',
+      affected_count: removed.length,
+      affected_entity_type: 'service_location',
+      affected_entity_ids: removed,
+      description: `${removed.length} service locations in the template no longer exist`,
+      suggested_action: 'Re-optimize the template to drop the removed properties',
+    },
+  ]
+}
+
+function checkCapacityOverflow(ctx: CycleContext): PreflightIssue[] {
+  const placedVisits = ctx.visits.filter((v) => v.status !== 'unplaced')
+  if (placedVisits.length === 0) return []
+  const result = computeCrewCount({
+    routed_visits: placedVisits.map((v) => ({
+      service_location_id: v.service_location_id ?? '',
+      hours_per_visit: Number(v.hours_per_visit_total ?? 1),
+    })),
+    cycle_length_days: ctx.template.cycle_length_days,
+    cycle_start_date: new Date(`${ctx.cycle.start_date}T00:00:00Z`),
+    cycles_per_year: 1,
+  })
+  if (result.conservative.crews_needed <= ctx.template.crew_count) return []
+  return [
+    {
+      check_type: 'capacity_overflow',
+      severity: 'warning',
+      affected_count: result.conservative.crews_needed,
+      description: `Building-count math estimates ${result.conservative.crews_needed} crews are needed, but the template assumes ${ctx.template.crew_count}`,
+      suggested_action: 'Bump crew count on the template, or rebalance branch assignments',
+    },
+  ]
+}
+
+function checkCohortYearTransition(ctx: CycleContext): PreflightIssue[] {
+  const startYear = Number(ctx.cycle.start_date.slice(0, 4))
+  const endYear = Number(ctx.cycle.end_date.slice(0, 4))
+  if (startYear === endYear) return []
+  // Count visits with attached addons (those carry cohort_year info).
+  const visitsWithAddons = ctx.visits.filter(
+    (v) => Array.isArray(v.attached_addons) && v.attached_addons.length > 0
+  )
+  return [
+    {
+      check_type: 'cohort_year_transition',
+      severity: 'info',
+      affected_count: visitsWithAddons.length,
+      description: `Cycle spans year boundary (${startYear} → ${endYear}). ${visitsWithAddons.length} visits with addon cohorts may have year-dependent rotations.`,
+      suggested_action: 'Spot-check cohort_year on attached addons near the transition date',
+    },
+  ]
+}
+
+async function checkCohortUnassigned(
+  db: SupabaseClient,
+  ctx: CycleContext
+): Promise<PreflightIssue[]> {
+  // Properties using addon offerings without cohort assignments.
+  const slIds = ctx.template.routed_service_location_ids ?? []
+  if (slIds.length === 0) return []
+  // Find SLs that have at least one addon-eligible service offering attached.
+  const { data: addonOfferings } = await db
+    .from('service_offerings')
+    .select('id, attaches_to_offering_ids')
+    .not('attaches_to_offering_ids', 'is', null)
+  const addonOfferingIds = (addonOfferings ?? [])
+    .map((o: any) => o.id as string)
+    .filter(Boolean)
+  if (addonOfferingIds.length === 0) return []
+  // Get cohort assignments for SLs in this template using these addons.
+  const { data: assignments } = await db
+    .from('addon_cohort_assignments')
+    .select('service_location_id, service_offering_id, cohort_index')
+    .in('service_offering_id', addonOfferingIds)
+  const assignmentSet = new Set(
+    (assignments ?? []).map((a: any) => `${a.service_location_id}::${a.service_offering_id}`)
+  )
+  // Find SLs that have an addon offering but no cohort assignment for it.
+  // Simplified heuristic: only count SLs whose offering is in addonOfferingIds.
+  const CHUNK = 250
+  const unassignedSlIds = new Set<string>()
+  for (let i = 0; i < slIds.length; i += CHUNK) {
+    const chunk = slIds.slice(i, i + CHUNK)
+    const { data: sls } = await db
+      .from('service_locations')
+      .select('id, service_offering_id')
+      .in('id', chunk)
+    for (const sl of (sls ?? []) as any[]) {
+      if (!sl.service_offering_id) continue
+      if (!addonOfferingIds.includes(sl.service_offering_id)) continue
+      const key = `${sl.id}::${sl.service_offering_id}`
+      if (!assignmentSet.has(key)) unassignedSlIds.add(sl.id)
+    }
+  }
+  if (unassignedSlIds.size === 0) return []
+  return [
+    {
+      check_type: 'cohort_unassigned',
+      severity: 'warning',
+      affected_count: unassignedSlIds.size,
+      affected_entity_type: 'service_location',
+      affected_entity_ids: Array.from(unassignedSlIds),
+      description: `${unassignedSlIds.size} service locations use addon offerings without cohort assignments`,
+      suggested_action: 'Run cohort auto-assignment, or set cohort manually on these properties',
+    },
+  ]
+}
+
+function checkExtendedIdle(ctx: CycleContext): PreflightIssue[] {
+  // Group crew_days by crew_index, sort by date, find streaks of working
+  // days where the crew has no scheduled work.
+  const byCrew = new Map<number, Map<string, boolean>>()
+  for (const cd of ctx.crewDays) {
+    const m = byCrew.get(cd.crew_index) ?? new Map<string, boolean>()
+    m.set(cd.scheduled_date, true)
+    byCrew.set(cd.crew_index, m)
+  }
+  const issues: PreflightIssue[] = []
+  // Walk every working day in the cycle for each crew.
+  const start = new Date(`${ctx.cycle.start_date}T00:00:00Z`)
+  const end = new Date(`${ctx.cycle.end_date}T00:00:00Z`)
+  for (const [crewIdx, busyMap] of byCrew) {
+    let streakStart: Date | null = null
+    let streakLen = 0
+    const cur = new Date(start)
+    while (cur <= end) {
+      const dow = cur.getUTCDay()
+      const isWeekday = dow !== 0 && dow !== 6
+      const dateKey = cur.toISOString().slice(0, 10)
+      const busy = busyMap.has(dateKey)
+      if (isWeekday && !busy) {
+        if (!streakStart) streakStart = new Date(cur)
+        streakLen++
+      } else if (streakStart) {
+        if (streakLen >= 5) {
+          const streakEnd = new Date(cur)
+          streakEnd.setUTCDate(cur.getUTCDate() - 1)
+          issues.push({
+            check_type: 'extended_idle_period',
+            severity: 'info',
+            affected_count: streakLen,
+            description: `Crew ${crewIdx + 1}: ${streakLen} consecutive idle weekdays (${streakStart.toISOString().slice(0, 10)} – ${streakEnd.toISOString().slice(0, 10)})`,
+            suggested_action: 'Redistribute work or lower crew count if this is structural',
+          })
+        }
+        streakStart = null
+        streakLen = 0
+      }
+      cur.setUTCDate(cur.getUTCDate() + 1)
+    }
+    // Tail streak
+    if (streakStart && streakLen >= 5) {
+      const streakEnd = new Date(end)
+      issues.push({
+        check_type: 'extended_idle_period',
+        severity: 'info',
+        affected_count: streakLen,
+        description: `Crew ${crewIdx + 1}: ${streakLen} consecutive idle weekdays through end of cycle (${streakStart.toISOString().slice(0, 10)} – ${streakEnd.toISOString().slice(0, 10)})`,
+        suggested_action: 'Redistribute work or lower crew count if this is structural',
+      })
+    }
+  }
+  return issues
+}
+
+function checkCycleStartsDuringHoliday(ctx: CycleContext): PreflightIssue[] {
+  const start = new Date(`${ctx.cycle.start_date}T00:00:00Z`)
+  // Look at holidays in the start week.
+  const weekStart = new Date(start)
+  weekStart.setUTCDate(start.getUTCDate() - start.getUTCDay())
+  const weekEnd = new Date(weekStart)
+  weekEnd.setUTCDate(weekStart.getUTCDate() + 6)
+  const holidays = getDefaultHolidays(weekStart, weekEnd).filter(
+    (h) => h >= weekStart && h <= weekEnd
+  )
+  if (holidays.length === 0) return []
+  return [
+    {
+      check_type: 'cycle_starts_during_holiday',
+      severity: 'warning',
+      affected_count: holidays.length,
+      description: `Cycle starts the week of a federal holiday (${holidays.map((h) => h.toISOString().slice(0, 10)).join(', ')})`,
+      suggested_action: 'Consider shifting the start date a week to capture a full first work week',
+    },
+  ]
+}
+
+// ── Aggregator ───────────────────────────────────────────────────────
+
+export async function runPreflightChecks(
+  db: SupabaseClient,
+  cycleInstanceId: string
+): Promise<PreflightResult> {
+  const ctx = await loadCycleContext(db, cycleInstanceId)
+  const all = await Promise.all([
+    Promise.resolve(checkHolidaysInWorkWeeks(ctx)),
+    Promise.resolve(checkBlackoutDateConflicts(ctx)),
+    Promise.resolve(checkSeasonalWindowViolations(ctx)),
+    checkPropertiesAddedSinceTemplate(db, ctx),
+    checkPropertiesRemovedSinceTemplate(db, ctx),
+    Promise.resolve(checkCapacityOverflow(ctx)),
+    Promise.resolve(checkCohortYearTransition(ctx)),
+    checkCohortUnassigned(db, ctx),
+    Promise.resolve(checkExtendedIdle(ctx)),
+    Promise.resolve(checkCycleStartsDuringHoliday(ctx)),
+  ])
+  const flat = all.flat()
+  return {
+    has_blocking_issues: flat.some((i) => i.severity === 'blocking'),
+    blocking: flat.filter((i) => i.severity === 'blocking'),
+    warnings: flat.filter((i) => i.severity === 'warning'),
+    info: flat.filter((i) => i.severity === 'info'),
+  }
+}
+
+// Persist preflight results to cycle_preflight_checks. Replaces any
+// existing UN-acknowledged rows for this cycle so re-runs don't
+// accumulate stale duplicates; acknowledged rows are left in place
+// for audit.
+export async function persistPreflightResults(
+  db: SupabaseClient,
+  cycleInstanceId: string,
+  templateId: string,
+  result: PreflightResult
+): Promise<void> {
+  await db
+    .from('cycle_preflight_checks')
+    .delete()
+    .eq('cycle_instance_id', cycleInstanceId)
+    .eq('acknowledged', false)
+  const rows: any[] = []
+  for (const i of [...result.blocking, ...result.warnings, ...result.info]) {
+    rows.push({
+      cycle_instance_id: cycleInstanceId,
+      template_id: templateId,
+      check_type: i.check_type,
+      severity: i.severity,
+      affected_count: i.affected_count ?? null,
+      affected_entity_type: i.affected_entity_type ?? null,
+      affected_entity_ids: i.affected_entity_ids ?? [],
+      description: i.description,
+      suggested_action: i.suggested_action ?? null,
+    })
+  }
+  if (rows.length > 0) {
+    await db.from('cycle_preflight_checks').insert(rows)
+  }
+}

--- a/api/cron/check-auto-generation.ts
+++ b/api/cron/check-auto-generation.ts
@@ -1,0 +1,58 @@
+// Vercel cron entrypoint: runs auto-generation check on every
+// in-progress cycle once per day. Schedule lives in vercel.json.
+//
+// Auth: Vercel cron service injects Authorization: Bearer <CRON_SECRET>
+// where CRON_SECRET is an env var on the project.
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { createAdminClient } from '../_lib/supabase.js'
+import { checkAndTriggerAutoGeneration } from '../_lib/scheduler/auto-generation.js'
+
+export const config = { maxDuration: 300 }
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  // Vercel Cron uses GET; allow POST too for manual smoke tests.
+  if (req.method !== 'GET' && req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+  const expected = process.env.CRON_SECRET
+  if (expected) {
+    const provided = req.headers.authorization ?? ''
+    if (provided !== `Bearer ${expected}`) {
+      return res.status(401).json({ error: 'Unauthorized' })
+    }
+  }
+
+  const db = createAdminClient()
+  const { data: rows, error } = await db
+    .from('cycle_instances')
+    .select('id, status, next_cycle_id')
+    .eq('status', 'in_progress')
+    .is('next_cycle_id', null)
+  if (error) return res.status(500).json({ error: error.message })
+
+  const results: Array<{ cycle_id: string; action: string; reason?: string }> = []
+  for (const row of (rows ?? []) as Array<{ id: string }>) {
+    try {
+      const outcome = await checkAndTriggerAutoGeneration(db, row.id)
+      results.push({
+        cycle_id: row.id,
+        action: outcome.action,
+        reason: outcome.reason,
+      })
+    } catch (err: any) {
+      results.push({
+        cycle_id: row.id,
+        action: 'error',
+        reason: err?.message ?? String(err),
+      })
+    }
+  }
+  return res.status(200).json({
+    checked: rows?.length ?? 0,
+    triggered: results.filter((r) => r.action === 'triggered').length,
+    deferred: results.filter((r) => r.action === 'deferred').length,
+    skipped: results.filter((r) => r.action === 'skipped').length,
+    errors: results.filter((r) => r.action === 'error').length,
+    results,
+  })
+}

--- a/api/scheduler/cycles/[cycleId]/cancel-auto-generation.ts
+++ b/api/scheduler/cycles/[cycleId]/cancel-auto-generation.ts
@@ -1,0 +1,40 @@
+// POST /api/scheduler/cycles/[cycleId]/cancel-auto-generation
+//
+// Phase 4e — undo a prior auto-generation: marks the linked next cycle
+// as 'cancelled', clears the parent cycle's next_cycle_id, and lets a
+// future trigger attempt run again.
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { createAdminClient } from '../../../_lib/supabase.js'
+import { authenticateRequest } from '../../../_lib/auth.js'
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'POST') return res.status(405).json({ error: 'Method not allowed' })
+  try {
+    await authenticateRequest(req)
+  } catch (err: any) {
+    return res.status(err.statusCode ?? 401).json({ error: err.message ?? 'Unauthorized' })
+  }
+  const cycleId = req.query.cycleId as string
+  if (!cycleId) return res.status(400).json({ error: 'cycleId required' })
+  const db = createAdminClient()
+
+  const { data: cycle } = await db
+    .from('cycle_instances')
+    .select('id, next_cycle_id')
+    .eq('id', cycleId)
+    .single()
+  if (!cycle) return res.status(404).json({ error: 'Cycle not found' })
+  const nextId = (cycle as any).next_cycle_id as string | null
+  if (!nextId) return res.status(200).json({ cancelled: false, reason: 'no_next_cycle' })
+
+  await db
+    .from('cycle_instances')
+    .update({ status: 'cancelled' })
+    .eq('id', nextId)
+  await db
+    .from('cycle_instances')
+    .update({ next_cycle_id: null, auto_generation_triggered_at: null })
+    .eq('id', cycleId)
+
+  return res.status(200).json({ cancelled: true, cancelled_cycle_id: nextId })
+}

--- a/api/scheduler/cycles/[cycleId]/check-auto-generation.ts
+++ b/api/scheduler/cycles/[cycleId]/check-auto-generation.ts
@@ -1,0 +1,32 @@
+// POST /api/scheduler/cycles/[cycleId]/check-auto-generation
+// Body: { force?: boolean }
+// Phase 4e — manually run the auto-generation check for this cycle.
+// Returns the action taken (triggered, deferred, skipped, blocked).
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { createAdminClient } from '../../../_lib/supabase.js'
+import { authenticateRequest } from '../../../_lib/auth.js'
+import { checkAndTriggerAutoGeneration } from '../../../_lib/scheduler/auto-generation.js'
+
+export const config = { maxDuration: 300 }
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'POST') return res.status(405).json({ error: 'Method not allowed' })
+  try {
+    await authenticateRequest(req)
+  } catch (err: any) {
+    return res.status(err.statusCode ?? 401).json({ error: err.message ?? 'Unauthorized' })
+  }
+  const cycleId = req.query.cycleId as string
+  if (!cycleId) return res.status(400).json({ error: 'cycleId required' })
+  const body = (req.body ?? {}) as Record<string, unknown>
+  const db = createAdminClient()
+
+  try {
+    const outcome = await checkAndTriggerAutoGeneration(db, cycleId, {
+      force: body.force === true,
+    })
+    return res.status(200).json(outcome)
+  } catch (err: any) {
+    return res.status(500).json({ error: err?.message ?? String(err) })
+  }
+}

--- a/api/scheduler/cycles/[cycleId]/completion.ts
+++ b/api/scheduler/cycles/[cycleId]/completion.ts
@@ -1,0 +1,42 @@
+// GET  /api/scheduler/cycles/[cycleId]/completion         — current stats (cheap)
+// POST /api/scheduler/cycles/[cycleId]/completion         — recalculate + persist
+//
+// Phase 4e completion tracker: counts completed/cancelled/placed/unplaced
+// visits, computes completion_pct, persists on cycle_instances, and
+// auto-transitions cycle.status (planned → in_progress on first
+// completion; in_progress → completed at 100%).
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { createAdminClient } from '../../../_lib/supabase.js'
+import { authenticateRequest } from '../../../_lib/auth.js'
+import {
+  calculateCycleCompletion,
+  refreshCycleCompletion,
+} from '../../../_lib/scheduler/cycle-completion.js'
+
+export const config = { maxDuration: 30 }
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method === 'OPTIONS') return res.status(200).end()
+  try {
+    await authenticateRequest(req)
+  } catch (err: any) {
+    return res.status(err.statusCode ?? 401).json({ error: err.message ?? 'Unauthorized' })
+  }
+  const cycleId = req.query.cycleId as string
+  if (!cycleId) return res.status(400).json({ error: 'cycleId required' })
+  const db = createAdminClient()
+
+  try {
+    if (req.method === 'GET') {
+      const stats = await calculateCycleCompletion(db, cycleId)
+      return res.status(200).json(stats)
+    }
+    if (req.method === 'POST') {
+      const result = await refreshCycleCompletion(db, cycleId)
+      return res.status(200).json({ ...result.stats, status_changed_to: result.status_changed_to })
+    }
+    return res.status(405).json({ error: 'Method not allowed' })
+  } catch (err: any) {
+    return res.status(500).json({ error: err?.message ?? String(err) })
+  }
+}

--- a/api/scheduler/cycles/[cycleId]/preflight-acknowledge.ts
+++ b/api/scheduler/cycles/[cycleId]/preflight-acknowledge.ts
@@ -1,0 +1,42 @@
+// POST /api/scheduler/cycles/[cycleId]/preflight-acknowledge
+// Body: { issue_ids: uuid[] }       — acknowledge specific issues
+//   or: { acknowledge_all_warnings: true }
+//
+// Phase 4e — operator acknowledges preflight issues so they drop to
+// the collapsed "acknowledged" section in the UI.
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { createAdminClient } from '../../../_lib/supabase.js'
+import { authenticateRequest } from '../../../_lib/auth.js'
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'POST') return res.status(405).json({ error: 'Method not allowed' })
+  let ctx
+  try {
+    ctx = await authenticateRequest(req)
+  } catch (err: any) {
+    return res.status(err.statusCode ?? 401).json({ error: err.message ?? 'Unauthorized' })
+  }
+  const cycleId = req.query.cycleId as string
+  const body = (req.body ?? {}) as Record<string, unknown>
+  const db = createAdminClient()
+  const who = ctx.email ?? ctx.userId ?? null
+  const stamp = new Date().toISOString()
+
+  let q = db
+    .from('cycle_preflight_checks')
+    .update({ acknowledged: true, acknowledged_at: stamp, acknowledged_by: who })
+    .eq('cycle_instance_id', cycleId)
+    .eq('acknowledged', false)
+
+  if (Array.isArray(body.issue_ids) && body.issue_ids.length > 0) {
+    q = q.in('id', body.issue_ids as string[])
+  } else if (body.acknowledge_all_warnings === true) {
+    q = q.in('severity', ['warning', 'info'])
+  } else {
+    return res.status(400).json({ error: 'Provide issue_ids[] or acknowledge_all_warnings=true' })
+  }
+
+  const { data, error } = await q.select('id')
+  if (error) return res.status(500).json({ error: error.message })
+  return res.status(200).json({ acknowledged: (data ?? []).length })
+}

--- a/api/scheduler/cycles/[cycleId]/preflight.ts
+++ b/api/scheduler/cycles/[cycleId]/preflight.ts
@@ -1,0 +1,60 @@
+// GET  /api/scheduler/cycles/[cycleId]/preflight    — list current
+//      (un-)acknowledged issues for the cycle
+// POST /api/scheduler/cycles/[cycleId]/preflight    — re-run all checks
+//      and persist results
+//
+// Phase 4e — preflight checks for an auto-generated (or manually
+// re-generated) cycle.
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { createAdminClient } from '../../../_lib/supabase.js'
+import { authenticateRequest } from '../../../_lib/auth.js'
+import {
+  runPreflightChecks,
+  persistPreflightResults,
+} from '../../../_lib/scheduler/preflight-checks.js'
+
+export const config = { maxDuration: 60 }
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method === 'OPTIONS') return res.status(200).end()
+  try {
+    await authenticateRequest(req)
+  } catch (err: any) {
+    return res.status(err.statusCode ?? 401).json({ error: err.message ?? 'Unauthorized' })
+  }
+  const cycleId = req.query.cycleId as string
+  if (!cycleId) return res.status(400).json({ error: 'cycleId required' })
+  const db = createAdminClient()
+
+  try {
+    if (req.method === 'GET') {
+      const { data, error } = await db
+        .from('cycle_preflight_checks')
+        .select('*')
+        .eq('cycle_instance_id', cycleId)
+        .order('created_at', { ascending: false })
+      if (error) return res.status(500).json({ error: error.message })
+      return res.status(200).json({ issues: data ?? [] })
+    }
+    if (req.method === 'POST') {
+      // Need template_id from cycle_instances for persistence.
+      const { data: cycle } = await db
+        .from('cycle_instances')
+        .select('template_id')
+        .eq('id', cycleId)
+        .single()
+      if (!cycle) return res.status(404).json({ error: 'Cycle not found' })
+      const result = await runPreflightChecks(db, cycleId)
+      await persistPreflightResults(db, cycleId, (cycle as any).template_id, result)
+      return res.status(200).json({
+        has_blocking_issues: result.has_blocking_issues,
+        blocking_count: result.blocking.length,
+        warning_count: result.warnings.length,
+        info_count: result.info.length,
+      })
+    }
+    return res.status(405).json({ error: 'Method not allowed' })
+  } catch (err: any) {
+    return res.status(500).json({ error: err?.message ?? String(err) })
+  }
+}

--- a/api/scheduler/cycles/compare.ts
+++ b/api/scheduler/cycles/compare.ts
@@ -1,0 +1,33 @@
+// GET /api/scheduler/cycles/compare?left=<cycleId>&right=<cycleId>
+//
+// Phase 4e — side-by-side cycle summary + delta computation.
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { createAdminClient } from '../../_lib/supabase.js'
+import { authenticateRequest } from '../../_lib/auth.js'
+import { compareCycles } from '../../_lib/scheduler/cycle-comparison.js'
+
+export const config = { maxDuration: 30 }
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'GET') return res.status(405).json({ error: 'Method not allowed' })
+  try {
+    await authenticateRequest(req)
+  } catch (err: any) {
+    return res.status(err.statusCode ?? 401).json({ error: err.message ?? 'Unauthorized' })
+  }
+  const left = req.query.left as string | undefined
+  const right = req.query.right as string | undefined
+  if (!left || !right) {
+    return res.status(400).json({ error: 'left and right cycle ids required' })
+  }
+  if (left === right) {
+    return res.status(400).json({ error: 'left and right must be different cycles' })
+  }
+  const db = createAdminClient()
+  try {
+    const result = await compareCycles(db, left, right)
+    return res.status(200).json(result)
+  } catch (err: any) {
+    return res.status(400).json({ error: err?.message ?? String(err) })
+  }
+}

--- a/api/scheduler/visits/[visitId]/mark-completed.ts
+++ b/api/scheduler/visits/[visitId]/mark-completed.ts
@@ -7,6 +7,7 @@ import { createAdminClient } from '../../../_lib/supabase.js'
 import { authenticateRequest } from '../../../_lib/auth.js'
 import { markVisitCompleted } from '../../../_lib/scheduler/edit-propagation.js'
 import { recordEdit } from '../../../_lib/scheduler/edit-history.js'
+import { refreshCycleCompletion } from '../../../_lib/scheduler/cycle-completion.js'
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method !== 'POST') return res.status(405).json({ error: 'Method not allowed' })
@@ -47,6 +48,26 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         })
       } catch (err) {
         console.error('[mark-completed] history record failed:', err)
+      }
+    }
+    // Phase 4e — refresh the cycle's completion stats so the UI banner
+    // and auto-generation trigger see the latest count immediately.
+    // Then opportunistically check the auto-generation trigger so a
+    // visit completion that crosses the threshold doesn't have to wait
+    // for the daily cron.
+    if (beforeRow?.cycle_instance_id) {
+      try {
+        await refreshCycleCompletion(db, beforeRow.cycle_instance_id)
+      } catch (err) {
+        console.error('[mark-completed] completion refresh failed:', err)
+      }
+      try {
+        const { checkAndTriggerAutoGeneration } = await import(
+          '../../../_lib/scheduler/auto-generation.js'
+        )
+        await checkAndTriggerAutoGeneration(db, beforeRow.cycle_instance_id)
+      } catch (err) {
+        console.error('[mark-completed] auto-generation check failed:', err)
       }
     }
     return res.status(200).json(result)

--- a/api/scheduler/visits/bulk-action.ts
+++ b/api/scheduler/visits/bulk-action.ts
@@ -124,6 +124,18 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     }
   }
 
+  // Phase 4e — refresh cycle completion stats after bulk mark_complete.
+  if (action === 'mark_complete' && cycleId) {
+    try {
+      const { refreshCycleCompletion } = await import(
+        '../../_lib/scheduler/cycle-completion.js'
+      )
+      await refreshCycleCompletion(db, cycleId)
+    } catch (err) {
+      console.error('[bulk-action] completion refresh failed:', err)
+    }
+  }
+
   return res.status(200).json({
     applied: forward.length,
     skipped: skipped.length,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,6 +31,7 @@ import ServiceOfferingsPage from './pages/accounts/ServiceOfferings'
 import TemplatesListPage from './pages/accounts/scheduler/TemplatesList'
 import NewTemplatePage from './pages/accounts/scheduler/NewTemplate'
 import TemplateDetailPage from './pages/accounts/scheduler/TemplateDetail'
+import CycleComparePage from './pages/accounts/scheduler/CycleCompare'
 import CycleDetailPage from './pages/accounts/scheduler/CycleDetail'
 import NewAccountClientPage from './pages/accounts/NewAccountClient'
 import ClientsListPage from './pages/clients/ClientsList'
@@ -159,6 +160,10 @@ export default function App() {
           <Route
             path="/accounts/:accountId/clients/:clientId/scheduler/cycles/:cycleId"
             element={<AuthGuard><CycleDetailPage /></AuthGuard>}
+          />
+          <Route
+            path="/accounts/:accountId/clients/:clientId/scheduler/compare"
+            element={<AuthGuard><CycleComparePage /></AuthGuard>}
           />
           <Route path="/accounts/:id/clients/new" element={<AuthGuard><NewAccountClientPage /></AuthGuard>} />
 

--- a/src/components/scheduler/PreflightIssuesBanner.tsx
+++ b/src/components/scheduler/PreflightIssuesBanner.tsx
@@ -1,0 +1,247 @@
+// Phase 4e — preflight issues banner for a cycle. Shows blocking +
+// unacknowledged warning/info issues with acknowledge buttons. Hides
+// itself when nothing's open. Triggers a backend re-run on demand.
+import { useCallback, useEffect, useState } from 'react'
+import { AlertTriangle, Info, Loader2, RotateCcw, X } from 'lucide-react'
+import { useAuth } from '../../hooks/useAuth'
+import Button from '../ui/Button'
+import { Badge } from '../ui/Badge'
+import { cn } from '../../lib/cn'
+
+interface PreflightIssue {
+  id: string
+  cycle_instance_id: string
+  template_id: string
+  check_type: string
+  severity: 'blocking' | 'warning' | 'info'
+  affected_count: number | null
+  affected_entity_type: string | null
+  description: string
+  suggested_action: string | null
+  acknowledged: boolean
+  acknowledged_at: string | null
+}
+
+interface Props {
+  cycleId: string
+}
+
+export default function PreflightIssuesBanner({ cycleId }: Props) {
+  const { getToken } = useAuth()
+  const [issues, setIssues] = useState<PreflightIssue[]>([])
+  const [loading, setLoading] = useState(true)
+  const [running, setRunning] = useState(false)
+  const [acking, setAcking] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [showAcked, setShowAcked] = useState(false)
+
+  const fetchIssues = useCallback(async () => {
+    if (!cycleId) return
+    setLoading(true)
+    try {
+      const token = await getToken()
+      const res = await fetch(`/api/scheduler/cycles/${cycleId}/preflight`, {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      if (!res.ok) throw new Error(`Preflight fetch failed: ${res.status}`)
+      const j = await res.json()
+      setIssues((j.issues ?? []) as PreflightIssue[])
+      setError(null)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setLoading(false)
+    }
+  }, [cycleId, getToken])
+
+  useEffect(() => {
+    fetchIssues()
+  }, [fetchIssues])
+
+  const reRun = async () => {
+    setRunning(true)
+    setError(null)
+    try {
+      const token = await getToken()
+      const res = await fetch(`/api/scheduler/cycles/${cycleId}/preflight`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}))
+        throw new Error((j as any).error ?? `Re-run failed: ${res.status}`)
+      }
+      await fetchIssues()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setRunning(false)
+    }
+  }
+
+  const acknowledgeAll = async () => {
+    setAcking(true)
+    setError(null)
+    try {
+      const token = await getToken()
+      const res = await fetch(`/api/scheduler/cycles/${cycleId}/preflight-acknowledge`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ acknowledge_all_warnings: true }),
+      })
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}))
+        throw new Error((j as any).error ?? `Ack failed: ${res.status}`)
+      }
+      await fetchIssues()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setAcking(false)
+    }
+  }
+
+  const ackOne = async (id: string) => {
+    setError(null)
+    try {
+      const token = await getToken()
+      await fetch(`/api/scheduler/cycles/${cycleId}/preflight-acknowledge`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ issue_ids: [id] }),
+      })
+      await fetchIssues()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    }
+  }
+
+  const open = issues.filter((i) => !i.acknowledged)
+  const acked = issues.filter((i) => i.acknowledged)
+  if (loading || (issues.length === 0 && !error)) return null
+
+  const blocking = open.filter((i) => i.severity === 'blocking')
+  const warnings = open.filter((i) => i.severity === 'warning')
+  const info = open.filter((i) => i.severity === 'info')
+
+  return (
+    <div
+      className={cn(
+        'rounded-md border',
+        blocking.length > 0
+          ? 'border-danger/40 bg-danger/5'
+          : 'border-warning/30 bg-warning/5'
+      )}
+    >
+      <div className="flex items-center justify-between gap-3 px-4 py-2 border-b border-border/40">
+        <div className="flex items-center gap-2">
+          <AlertTriangle
+            className={cn(
+              'h-4 w-4 shrink-0',
+              blocking.length > 0 ? 'text-danger' : 'text-warning'
+            )}
+          />
+          <p className="text-sm font-medium text-fg">
+            {open.length === 0
+              ? `${acked.length} preflight issues — all acknowledged`
+              : `${open.length} preflight issue${open.length === 1 ? '' : 's'} to review`}
+          </p>
+          {blocking.length > 0 && (
+            <Badge variant="danger" className="text-[10px]">
+              {blocking.length} blocking
+            </Badge>
+          )}
+        </div>
+        <div className="flex items-center gap-2">
+          <Button size="sm" variant="ghost" onClick={reRun} disabled={running}>
+            {running ? (
+              <>
+                <Loader2 className="h-3 w-3 mr-1 animate-spin" /> Re-running…
+              </>
+            ) : (
+              <>
+                <RotateCcw className="h-3 w-3 mr-1" /> Re-run checks
+              </>
+            )}
+          </Button>
+          {warnings.length + info.length > 0 && (
+            <Button
+              size="sm"
+              variant="secondary"
+              onClick={acknowledgeAll}
+              disabled={acking}
+            >
+              {acking ? 'Ack…' : 'Acknowledge all warnings/info'}
+            </Button>
+          )}
+        </div>
+      </div>
+      <ul className="divide-y divide-border/40">
+        {open.map((i) => (
+          <IssueRow key={i.id} issue={i} onAck={() => ackOne(i.id)} />
+        ))}
+      </ul>
+      {error && <p className="px-4 py-2 text-xs text-danger">{error}</p>}
+      {acked.length > 0 && (
+        <details className="px-4 py-2 text-xs text-fg-muted" open={showAcked}>
+          <summary
+            onClick={(e) => {
+              e.preventDefault()
+              setShowAcked((v) => !v)
+            }}
+            className="cursor-pointer"
+          >
+            Acknowledged ({acked.length})
+          </summary>
+          <ul className="mt-2 space-y-1">
+            {acked.map((i) => (
+              <li key={i.id} className="text-fg-subtle">
+                <span className="font-tabular">{i.severity}</span> · {i.description}
+              </li>
+            ))}
+          </ul>
+        </details>
+      )}
+    </div>
+  )
+}
+
+function IssueRow({ issue, onAck }: { issue: PreflightIssue; onAck: () => void }) {
+  const tone =
+    issue.severity === 'blocking'
+      ? 'text-danger'
+      : issue.severity === 'warning'
+        ? 'text-warning'
+        : 'text-fg-muted'
+  const Icon = issue.severity === 'info' ? Info : AlertTriangle
+  return (
+    <li className="px-4 py-2 flex items-start justify-between gap-3">
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2 text-sm">
+          <Icon className={cn('h-3.5 w-3.5 shrink-0', tone)} />
+          <span className={cn('font-medium uppercase text-[10px] tracking-wider', tone)}>
+            {issue.severity}
+          </span>
+          <span className="text-fg">{issue.description}</span>
+        </div>
+        {issue.suggested_action && (
+          <p className="text-xs text-fg-muted mt-0.5 ml-5">
+            {issue.suggested_action}
+          </p>
+        )}
+      </div>
+      {issue.severity !== 'blocking' && (
+        <Button size="sm" variant="ghost" onClick={onAck}>
+          <X className="h-3 w-3 mr-1" />
+          Acknowledge
+        </Button>
+      )}
+    </li>
+  )
+}

--- a/src/pages/accounts/scheduler/CycleCompare.tsx
+++ b/src/pages/accounts/scheduler/CycleCompare.tsx
@@ -1,0 +1,435 @@
+// Phase 4e — side-by-side cycle comparison.
+//
+// Route: /accounts/:accountId/clients/:clientId/scheduler/compare
+//   ?template=<templateId>&left=<cycleId>&right=<cycleId>
+//
+// Two cycle dropdowns at the top, then a summary card with deltas, then
+// added/removed/changed property lists. "Show only differences" filter
+// hides identical-row sections.
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { Link, useParams, useSearchParams } from 'react-router-dom'
+import { ArrowLeft, ArrowDown, ArrowUp, Minus } from 'lucide-react'
+import { useAuth } from '../../../hooks/useAuth'
+import AppShell from '../../../components/layout/AppShell'
+import Button from '../../../components/ui/Button'
+import { Card, CardTitle, CardDescription } from '../../../components/ui/Card'
+import { Badge } from '../../../components/ui/Badge'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '../../../components/ui/Select'
+import { cn } from '../../../lib/cn'
+
+interface Cycle {
+  id: string
+  cycle_number: number
+  start_date: string
+  end_date: string
+  status: string
+}
+
+interface Delta {
+  left: number
+  right: number
+  delta: number
+  pct_change: number
+}
+
+interface ComparisonResponse {
+  left: { cycle: any }
+  right: { cycle: any }
+  deltas: {
+    total_visits: Delta
+    total_drive_miles: Delta
+    total_work_hours: Delta
+    total_overnight_nights: Delta
+    total_estimated_cost: Delta
+    crews_used: Delta
+    hard_constraint_violations: Delta
+    soft_constraint_violations: Delta
+    properties_added: string[]
+    properties_removed: string[]
+    properties_with_changed_crew: Array<{
+      property_id: string
+      left_crew: number | null
+      right_crew: number | null
+    }>
+    properties_with_changed_date: Array<{
+      property_id: string
+      left_date: string | null
+      right_date: string | null
+    }>
+  }
+}
+
+export default function CycleComparePage() {
+  const { accountId, clientId } = useParams<{ accountId: string; clientId: string }>()
+  const [searchParams, setSearchParams] = useSearchParams()
+  const { getToken } = useAuth()
+
+  const templateId = searchParams.get('template') ?? ''
+  const leftId = searchParams.get('left') ?? ''
+  const rightId = searchParams.get('right') ?? ''
+
+  const [cycles, setCycles] = useState<Cycle[]>([])
+  const [loadingList, setLoadingList] = useState(false)
+  const [data, setData] = useState<ComparisonResponse | null>(null)
+  const [loadingData, setLoadingData] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [onlyDiffs, setOnlyDiffs] = useState(false)
+
+  // Load all cycles for the template so the dropdowns can populate.
+  useEffect(() => {
+    if (!templateId) return
+    let cancelled = false
+    const load = async () => {
+      setLoadingList(true)
+      try {
+        const token = await getToken()
+        const res = await fetch(
+          `/api/scheduler/cycles?template_id=${encodeURIComponent(templateId)}`,
+          { headers: { Authorization: `Bearer ${token}` } }
+        )
+        if (!res.ok) throw new Error(`Cycles fetch failed: ${res.status}`)
+        const j = await res.json()
+        if (!cancelled) setCycles((j.cycles ?? []) as Cycle[])
+      } catch (err) {
+        if (!cancelled) setError(err instanceof Error ? err.message : String(err))
+      } finally {
+        if (!cancelled) setLoadingList(false)
+      }
+    }
+    load()
+    return () => {
+      cancelled = true
+    }
+  }, [templateId, getToken])
+
+  // Fetch the comparison once both ids are picked.
+  const fetchComparison = useCallback(async () => {
+    if (!leftId || !rightId || leftId === rightId) {
+      setData(null)
+      return
+    }
+    setLoadingData(true)
+    setError(null)
+    try {
+      const token = await getToken()
+      const res = await fetch(
+        `/api/scheduler/cycles/compare?left=${leftId}&right=${rightId}`,
+        { headers: { Authorization: `Bearer ${token}` } }
+      )
+      const j = await res.json()
+      if (!res.ok) throw new Error(j.error ?? `Compare failed: ${res.status}`)
+      setData(j as ComparisonResponse)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setLoadingData(false)
+    }
+  }, [leftId, rightId, getToken])
+
+  useEffect(() => {
+    fetchComparison()
+  }, [fetchComparison])
+
+  const setLeft = (id: string) => {
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev)
+      next.set('left', id)
+      return next
+    })
+  }
+  const setRight = (id: string) => {
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev)
+      next.set('right', id)
+      return next
+    })
+  }
+
+  const cycleLabel = (c: Cycle) =>
+    `Cycle ${c.cycle_number}: ${c.start_date} → ${c.end_date}${
+      c.status === 'completed' ? ' (✓)' : ''
+    }`
+
+  const sortedCycles = useMemo(
+    () => [...cycles].sort((a, b) => a.cycle_number - b.cycle_number),
+    [cycles]
+  )
+
+  return (
+    <AppShell
+      breadcrumb={[
+        { label: 'Accounts', to: '/accounts' },
+        { label: 'Scheduler', to: `/accounts/${accountId}/clients/${clientId}/scheduler` },
+        { label: 'Compare cycles' },
+      ]}
+    >
+      <div className="mx-auto max-w-6xl px-6 py-8 space-y-6">
+        <header className="flex items-start justify-between gap-4">
+          <div>
+            <h1 className="text-2xl font-semibold text-fg">Compare cycles</h1>
+            <p className="text-sm text-fg-muted mt-1">
+              Pick two cycles from the same template to see deltas in visits, costs, drive miles, and crew assignments.
+            </p>
+          </div>
+          {templateId && (
+            <Link
+              to={`/accounts/${accountId}/clients/${clientId}/scheduler/templates/${templateId}`}
+              className="text-sm text-fg-muted hover:text-accent flex items-center gap-1"
+            >
+              <ArrowLeft className="h-3.5 w-3.5" /> Back to template
+            </Link>
+          )}
+        </header>
+
+        {/* Cycle pickers */}
+        <Card padding="md">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+            <div>
+              <p className="text-[10px] uppercase tracking-wider text-fg-subtle font-semibold mb-1">
+                Left cycle
+              </p>
+              <Select value={leftId} onValueChange={setLeft}>
+                <SelectTrigger>
+                  <SelectValue placeholder={loadingList ? 'Loading…' : 'Pick a cycle'} />
+                </SelectTrigger>
+                <SelectContent>
+                  {sortedCycles.map((c) => (
+                    <SelectItem key={c.id} value={c.id} disabled={c.id === rightId}>
+                      {cycleLabel(c)}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div>
+              <p className="text-[10px] uppercase tracking-wider text-fg-subtle font-semibold mb-1">
+                Right cycle
+              </p>
+              <Select value={rightId} onValueChange={setRight}>
+                <SelectTrigger>
+                  <SelectValue placeholder={loadingList ? 'Loading…' : 'Pick a cycle'} />
+                </SelectTrigger>
+                <SelectContent>
+                  {sortedCycles.map((c) => (
+                    <SelectItem key={c.id} value={c.id} disabled={c.id === leftId}>
+                      {cycleLabel(c)}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+          <label className="flex items-center gap-2 mt-3 text-sm text-fg-muted">
+            <input
+              type="checkbox"
+              checked={onlyDiffs}
+              onChange={(e) => setOnlyDiffs(e.target.checked)}
+            />
+            Show only differences
+          </label>
+        </Card>
+
+        {error && (
+          <div className="rounded-md border border-danger/30 bg-danger/5 px-4 py-2 text-sm text-danger">
+            {error}
+          </div>
+        )}
+
+        {!error && !leftId && !rightId && !loadingData && (
+          <Card padding="md">
+            <CardTitle>Select two cycles to compare</CardTitle>
+            <CardDescription>
+              Use the dropdowns above. Cycles must come from the same template.
+            </CardDescription>
+          </Card>
+        )}
+
+        {loadingData && (
+          <Card padding="md">
+            <p className="text-sm text-fg-muted">Loading comparison…</p>
+          </Card>
+        )}
+
+        {data && (
+          <>
+            <Card padding="md">
+              <CardTitle>Summary</CardTitle>
+              <div className="mt-3 overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="text-left text-[10px] uppercase tracking-wider text-fg-subtle">
+                      <th className="py-1.5">Metric</th>
+                      <th className="py-1.5">Left</th>
+                      <th className="py-1.5">Right</th>
+                      <th className="py-1.5">Delta</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-border">
+                    <DeltaRow label="Visits" d={data.deltas.total_visits} hideEqual={onlyDiffs} />
+                    <DeltaRow
+                      label="Cost"
+                      d={data.deltas.total_estimated_cost}
+                      hideEqual={onlyDiffs}
+                      format="money"
+                    />
+                    <DeltaRow
+                      label="Drive miles"
+                      d={data.deltas.total_drive_miles}
+                      hideEqual={onlyDiffs}
+                    />
+                    <DeltaRow
+                      label="Work hours"
+                      d={data.deltas.total_work_hours}
+                      hideEqual={onlyDiffs}
+                    />
+                    <DeltaRow
+                      label="Overnight nights"
+                      d={data.deltas.total_overnight_nights}
+                      hideEqual={onlyDiffs}
+                    />
+                    <DeltaRow label="Crews used" d={data.deltas.crews_used} hideEqual={onlyDiffs} />
+                    <DeltaRow
+                      label="Hard constraint violations"
+                      d={data.deltas.hard_constraint_violations}
+                      hideEqual={onlyDiffs}
+                      worseHigher
+                    />
+                    <DeltaRow
+                      label="Soft constraint violations"
+                      d={data.deltas.soft_constraint_violations}
+                      hideEqual={onlyDiffs}
+                      worseHigher
+                    />
+                  </tbody>
+                </table>
+              </div>
+            </Card>
+
+            <Card padding="md">
+              <CardTitle>Property changes</CardTitle>
+              <div className="mt-3 grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
+                <PropList
+                  title={`+ ${data.deltas.properties_added.length} added`}
+                  ids={data.deltas.properties_added}
+                  variant="success"
+                />
+                <PropList
+                  title={`− ${data.deltas.properties_removed.length} removed`}
+                  ids={data.deltas.properties_removed}
+                  variant="danger"
+                />
+              </div>
+              <div className="mt-4 grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
+                <div>
+                  <p className="text-[10px] uppercase tracking-wider text-fg-subtle font-semibold mb-2">
+                    Crew reassigned ({data.deltas.properties_with_changed_crew.length})
+                  </p>
+                  <ul className="text-xs text-fg-muted space-y-0.5 max-h-40 overflow-y-auto">
+                    {data.deltas.properties_with_changed_crew.slice(0, 50).map((c) => (
+                      <li key={c.property_id} className="font-mono break-all">
+                        {c.property_id.slice(0, 8)}: crew {c.left_crew ?? '—'} → {c.right_crew ?? '—'}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+                <div>
+                  <p className="text-[10px] uppercase tracking-wider text-fg-subtle font-semibold mb-2">
+                    Date changed ({data.deltas.properties_with_changed_date.length})
+                  </p>
+                  <ul className="text-xs text-fg-muted space-y-0.5 max-h-40 overflow-y-auto">
+                    {data.deltas.properties_with_changed_date.slice(0, 50).map((c) => (
+                      <li key={c.property_id} className="font-mono break-all">
+                        {c.property_id.slice(0, 8)}: {c.left_date ?? '—'} → {c.right_date ?? '—'}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              </div>
+            </Card>
+          </>
+        )}
+      </div>
+    </AppShell>
+  )
+}
+
+function DeltaRow({
+  label,
+  d,
+  hideEqual,
+  format,
+  worseHigher,
+}: {
+  label: string
+  d: Delta
+  hideEqual: boolean
+  format?: 'money'
+  worseHigher?: boolean
+}) {
+  if (hideEqual && d.delta === 0) return null
+  const fmt = (n: number) =>
+    format === 'money' ? `$${Math.round(n).toLocaleString()}` : n.toLocaleString()
+  const arrow = d.delta === 0 ? <Minus className="h-3 w-3" /> : d.delta > 0 ? <ArrowUp className="h-3 w-3" /> : <ArrowDown className="h-3 w-3" />
+  // Direction colour: by default, increases are neutral; for "worseHigher"
+  // metrics (constraint violations), increases are red.
+  const tone = d.delta === 0
+    ? 'text-fg-muted'
+    : worseHigher
+      ? d.delta > 0
+        ? 'text-danger'
+        : 'text-success'
+      : d.delta > 0
+        ? 'text-warning'
+        : 'text-success'
+  return (
+    <tr>
+      <td className="py-1.5 text-fg-muted">{label}</td>
+      <td className="py-1.5 font-tabular">{fmt(d.left)}</td>
+      <td className="py-1.5 font-tabular">{fmt(d.right)}</td>
+      <td className={cn('py-1.5 font-tabular flex items-center gap-1', tone)}>
+        {arrow}
+        {d.delta === 0 ? '—' : `${d.delta > 0 ? '+' : ''}${fmt(d.delta)} (${d.pct_change > 0 ? '+' : ''}${d.pct_change.toFixed(1)}%)`}
+      </td>
+    </tr>
+  )
+}
+
+function PropList({
+  title,
+  ids,
+  variant,
+}: {
+  title: string
+  ids: string[]
+  variant: 'success' | 'danger'
+}) {
+  return (
+    <div>
+      <p
+        className={cn(
+          'text-[10px] uppercase tracking-wider font-semibold mb-2',
+          variant === 'success' ? 'text-success' : 'text-danger'
+        )}
+      >
+        <Badge variant={variant}>{title}</Badge>
+      </p>
+      <ul className="text-xs text-fg-muted space-y-0.5 max-h-40 overflow-y-auto">
+        {ids.length === 0 && <li className="text-fg-subtle italic">None</li>}
+        {ids.slice(0, 50).map((id) => (
+          <li key={id} className="font-mono break-all">
+            {id}
+          </li>
+        ))}
+        {ids.length > 50 && (
+          <li className="text-fg-subtle italic">… {ids.length - 50} more</li>
+        )}
+      </ul>
+    </div>
+  )
+}

--- a/src/pages/accounts/scheduler/CycleDetail.tsx
+++ b/src/pages/accounts/scheduler/CycleDetail.tsx
@@ -2,10 +2,11 @@
 // Calendar / List / Map), polished header summary, status bar, and
 // undo/redo history drawer. Drag-drop + multi-select ship in 4f-2.
 import { useState, useEffect, useCallback, useMemo } from 'react'
-import { useParams } from 'react-router-dom'
+import { Link, useParams } from 'react-router-dom'
 import { Lock, Unlock, Check, MoveRight, Calendar } from 'lucide-react'
 import { useAuth } from '../../../hooks/useAuth'
 import AppShell from '../../../components/layout/AppShell'
+import PreflightIssuesBanner from '../../../components/scheduler/PreflightIssuesBanner'
 import Button from '../../../components/ui/Button'
 import { Badge } from '../../../components/ui/Badge'
 import { Card, CardTitle } from '../../../components/ui/Card'
@@ -315,12 +316,25 @@ export default function CycleDetailPage() {
                 <Calendar className="inline h-3.5 w-3.5 mr-1" />
                 {cycle.start_date} — {cycle.end_date}
               </p>
+              {cycle.cycle_number > 1 && (
+                <Link
+                  to={`/accounts/${accountId}/clients/${clientId}/scheduler/compare?template=${cycle.template_id}&right=${cycle.id}`}
+                  className="inline-flex items-center text-xs text-accent hover:underline mt-1"
+                >
+                  Compare to previous cycle ↗
+                </Link>
+              )}
             </div>
             <ViewSwitcher value={view} onChange={setView} />
           </div>
         </header>
 
         {error && <p className="text-sm text-danger">{error}</p>}
+
+        {/* Phase 4e — preflight issues banner. Hides itself when nothing
+            is open. Triggered automatically after auto-generation; can
+            be re-run on demand. */}
+        <PreflightIssuesBanner cycleId={cycle.id} />
 
         {/* Polished summary cards (4 across). Color-coded for at-a-
             glance status. */}

--- a/src/pages/accounts/scheduler/TemplateDetail.tsx
+++ b/src/pages/accounts/scheduler/TemplateDetail.tsx
@@ -51,6 +51,11 @@ interface Cycle {
   start_date: string
   end_date: string
   status: string
+  completion_pct?: number | null
+  visits_completed_count?: number | null
+  visits_total_count?: number | null
+  next_cycle_id?: string | null
+  auto_generation_triggered_at?: string | null
 }
 
 export default function TemplateDetailPage() {
@@ -310,6 +315,8 @@ export default function TemplateDetailPage() {
                   <TableHead>Start</TableHead>
                   <TableHead>End</TableHead>
                   <TableHead>Status</TableHead>
+                  <TableHead className="text-right">Completion</TableHead>
+                  <TableHead>Auto-gen</TableHead>
                   <TableHead />
                 </TableRow>
               </TableHeader>
@@ -324,13 +331,47 @@ export default function TemplateDetailPage() {
                         {c.status}
                       </Badge>
                     </TableCell>
+                    <TableCell className="text-right text-xs font-tabular">
+                      {c.completion_pct != null ? (
+                        <>
+                          {Number(c.completion_pct).toFixed(0)}%
+                          {c.visits_total_count != null && c.visits_total_count > 0 && (
+                            <span className="text-fg-subtle">
+                              {' '}
+                              ({c.visits_completed_count ?? 0}/{c.visits_total_count})
+                            </span>
+                          )}
+                        </>
+                      ) : (
+                        <span className="text-fg-subtle">—</span>
+                      )}
+                    </TableCell>
+                    <TableCell className="text-xs">
+                      {c.auto_generation_triggered_at ? (
+                        <span className="text-success" title={c.auto_generation_triggered_at}>
+                          ✓ {new Date(c.auto_generation_triggered_at).toLocaleDateString()}
+                        </span>
+                      ) : (
+                        <span className="text-fg-subtle">—</span>
+                      )}
+                    </TableCell>
                     <TableCell>
-                      <Link
-                        to={`/accounts/${accountId}/clients/${clientId}/scheduler/cycles/${c.id}`}
-                        className="text-xs text-accent hover:underline"
-                      >
-                        View
-                      </Link>
+                      <div className="flex items-center gap-2 text-xs">
+                        <Link
+                          to={`/accounts/${accountId}/clients/${clientId}/scheduler/cycles/${c.id}`}
+                          className="text-accent hover:underline"
+                        >
+                          View
+                        </Link>
+                        {c.cycle_number > 1 && (
+                          <Link
+                            to={`/accounts/${accountId}/clients/${clientId}/scheduler/compare?template=${templateId}&right=${c.id}`}
+                            className="text-fg-muted hover:text-accent"
+                          >
+                            Compare
+                          </Link>
+                        )}
+                      </div>
                     </TableCell>
                   </TableRow>
                 ))}

--- a/supabase/migrations/20260430181210_phase_4e_completion_and_preflight.sql
+++ b/supabase/migrations/20260430181210_phase_4e_completion_and_preflight.sql
@@ -1,0 +1,82 @@
+-- Phase 4e — recurring annual schedules with auto-generation,
+-- preflight checks, and side-by-side comparison.
+
+-- ── Visit-level completion tracking ───────────────────────────────────
+ALTER TABLE public.scheduled_visits
+  ADD COLUMN IF NOT EXISTS completed_at  timestamptz,
+  ADD COLUMN IF NOT EXISTS completed_by  text;
+
+-- ── Cycle-level completion tracking ───────────────────────────────────
+ALTER TABLE public.cycle_instances
+  ADD COLUMN IF NOT EXISTS completion_pct                numeric DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS visits_completed_count        int     DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS visits_total_count            int     DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS completion_last_calculated_at timestamptz,
+  ADD COLUMN IF NOT EXISTS auto_generation_triggered_at  timestamptz,
+  ADD COLUMN IF NOT EXISTS next_cycle_id                 uuid;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'cycle_instances_next_cycle_fk'
+  ) THEN
+    ALTER TABLE public.cycle_instances
+      ADD CONSTRAINT cycle_instances_next_cycle_fk
+      FOREIGN KEY (next_cycle_id) REFERENCES public.cycle_instances(id) ON DELETE SET NULL;
+  END IF;
+END $$;
+
+-- ── Auto-generation config on routing_templates ───────────────────────
+ALTER TABLE public.routing_templates
+  ADD COLUMN IF NOT EXISTS auto_generate_enabled              boolean DEFAULT true,
+  ADD COLUMN IF NOT EXISTS auto_generate_at_completion_pct    numeric DEFAULT 80,
+  ADD COLUMN IF NOT EXISTS auto_generate_lead_days            int     DEFAULT 14;
+
+-- ── cycle_preflight_checks ────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.cycle_preflight_checks (
+  id                    uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  cycle_instance_id     uuid NOT NULL REFERENCES public.cycle_instances(id) ON DELETE CASCADE,
+  template_id           uuid NOT NULL REFERENCES public.routing_templates(id) ON DELETE CASCADE,
+
+  check_type            text NOT NULL,
+  severity              text NOT NULL,
+
+  affected_count        int,
+  affected_entity_type  text,
+  affected_entity_ids   uuid[] DEFAULT ARRAY[]::uuid[],
+
+  description           text NOT NULL,
+  suggested_action      text,
+
+  acknowledged          boolean DEFAULT false,
+  acknowledged_at       timestamptz,
+  acknowledged_by       text,
+
+  created_at            timestamptz NOT NULL DEFAULT now()
+);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'cpc_check_type_chk') THEN
+    ALTER TABLE public.cycle_preflight_checks
+      ADD CONSTRAINT cpc_check_type_chk CHECK (check_type IN (
+        'holiday_in_work_week',
+        'blackout_date_conflict',
+        'seasonal_window_violation',
+        'property_added_since_template',
+        'property_removed_since_template',
+        'capacity_overflow',
+        'cohort_year_transition',
+        'cohort_unassigned',
+        'extended_idle_period',
+        'cycle_starts_during_holiday'
+      ));
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'cpc_severity_chk') THEN
+    ALTER TABLE public.cycle_preflight_checks
+      ADD CONSTRAINT cpc_severity_chk CHECK (severity IN ('blocking', 'warning', 'info'));
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS cpc_cycle_idx
+  ON public.cycle_preflight_checks(cycle_instance_id, severity, acknowledged);

--- a/vercel.json
+++ b/vercel.json
@@ -14,12 +14,19 @@
     },
     "api/cron/cleanup-uploads.ts": {
       "maxDuration": 120
+    },
+    "api/cron/check-auto-generation.ts": {
+      "maxDuration": 300
     }
   },
   "crons": [
     {
       "path": "/api/cron/cleanup-uploads",
       "schedule": "0 3 * * *"
+    },
+    {
+      "path": "/api/cron/check-auto-generation",
+      "schedule": "0 4 * * *"
     }
   ],
   "rewrites": [


### PR DESCRIPTION
## Summary
Three deliverables on top of Phase 4d's on-demand cycle generation:
1. **Cycle completion tracking** + auto status transitions
2. **Auto-generation trigger** (daily cron + opportunistic on visit completion + manual override)
3. **Pre-flight checks** (10 check types, persisted, with banner UI)
4. **Side-by-side cycle comparison** view

## What changed

### Schema
- \`cycle_instances\`: \`completion_pct\`, \`visits_completed_count\`, \`visits_total_count\`, \`completion_last_calculated_at\`, \`auto_generation_triggered_at\`, \`next_cycle_id\` (self-FK)
- \`scheduled_visits\`: \`completed_at\`, \`completed_by\`
- \`routing_templates\`: \`auto_generate_enabled\`, \`auto_generate_at_completion_pct\` (default 80), \`auto_generate_lead_days\` (default 14)
- New table: \`cycle_preflight_checks\` with check_type / severity enums

Already pushed to the linked Supabase project.

### Backend
- \`_lib/scheduler/cycle-completion.ts\`, \`auto-generation.ts\`, \`preflight-checks.ts\`, \`cycle-comparison.ts\`
- Endpoints: \`/cycles/{id}/completion\`, \`/preflight\`, \`/preflight-acknowledge\`, \`/check-auto-generation\`, \`/cancel-auto-generation\`, \`/compare\`
- Visit \`mark-completed\` and bulk \`mark_complete\` refresh completion stats and opportunistically check auto-gen
- Daily Vercel cron at 04:00 UTC walks all in_progress cycles (vercel.json)

### UI
- \`<PreflightIssuesBanner>\` on CycleDetail — surfaces open issues with severity-coloured chrome, per-issue and bulk acknowledge, on-demand re-run. Hides when nothing's open.
- \"Compare to previous cycle\" link in CycleDetail header (cycle_number > 1)
- TemplateDetail cycle table: new Completion% column + Auto-gen indicator + per-row Compare link
- New \`/scheduler/compare\` page: two cycle dropdowns, summary delta table, property added/removed/changed lists, \"show only differences\" filter

### All 10 preflight checks implemented
holiday_in_work_week, blackout_date_conflict (blocking), seasonal_window_violation (blocking), property_added_since_template, property_removed_since_template, capacity_overflow, cohort_year_transition, cohort_unassigned, extended_idle_period, cycle_starts_during_holiday

## Test plan
- [ ] Mark visits complete on an in-progress cycle → completion% updates; status transitions planned → in_progress on first; in_progress → completed at 100%
- [ ] At 80%+ completion with > 14 days lead, the cron (or visit completion trigger) generates the next cycle and runs preflight
- [ ] Preflight banner appears on the new cycle with any blocking/warning/info issues
- [ ] Acknowledge / re-run / per-issue ack all work
- [ ] Compare any two cycles from the same template → summary deltas + property change lists render
- [ ] Manual \"Generate next cycle now\" still works on TemplateDetail (existing flow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)