### PR TITLE
feat: user management + invite flow under /admin

### DIFF
--- a/api/_lib/auth-roles.ts
+++ b/api/_lib/auth-roles.ts
@@ -1,0 +1,60 @@
+// Role-based gates layered on top of authenticateRequest. Treats the
+// app_users table as the source of truth for role + active flag.
+import type { VercelRequest } from '@vercel/node'
+import { authenticateRequest, type AuthContext } from './auth.js'
+import { createAdminClient } from './supabase.js'
+
+export interface AppUserRecord {
+  id: string
+  email: string
+  name: string | null
+  role: 'admin' | 'member'
+  is_active: boolean
+}
+
+export async function getAppUser(
+  userId: string
+): Promise<AppUserRecord | null> {
+  const db = createAdminClient()
+  const { data } = await db
+    .from('app_users')
+    .select('id, email, name, role, is_active')
+    .eq('id', userId)
+    .maybeSingle()
+  return (data as AppUserRecord | null) ?? null
+}
+
+// Counts admins so the bootstrap path can detect "no admin yet".
+export async function adminCount(): Promise<number> {
+  const db = createAdminClient()
+  const { count } = await db
+    .from('app_users')
+    .select('id', { count: 'exact', head: true })
+    .eq('role', 'admin')
+    .eq('is_active', true)
+  return count ?? 0
+}
+
+// Authenticates AND requires the user to be an active admin. Throws
+// {statusCode, message} on failure (matches the existing pattern in
+// authenticateRequest).
+export async function requireAdmin(req: VercelRequest): Promise<{
+  ctx: AuthContext
+  user: AppUserRecord
+}> {
+  const ctx = await authenticateRequest(req)
+  if (ctx.mode !== 'user' || !ctx.userId) {
+    throw { statusCode: 403, message: 'Admin access requires a user session' }
+  }
+  const record = await getAppUser(ctx.userId)
+  if (!record) {
+    throw { statusCode: 403, message: 'No app user record — accept an invite first' }
+  }
+  if (!record.is_active) {
+    throw { statusCode: 403, message: 'Your account is deactivated' }
+  }
+  if (record.role !== 'admin') {
+    throw { statusCode: 403, message: 'Admin role required' }
+  }
+  return { ctx, user: record }
+}

--- a/api/_lib/email/send-invite.ts
+++ b/api/_lib/email/send-invite.ts
@@ -1,0 +1,127 @@
+// Resend wrapper for the user-invite email. Reads:
+//   RESEND_API_KEY   — Resend API key (required to actually send)
+//   INVITE_FROM_EMAIL — verified Resend "from" address (required)
+//   APP_URL or VITE_APP_URL — base URL for the accept link
+//
+// If RESEND_API_KEY isn't set we no-op and return { sent: false } so
+// the admin UI can fall back to "copy invite link" UX in dev.
+import { Resend } from 'resend'
+
+interface SendInviteArgs {
+  toEmail: string
+  inviteToken: string
+  invitedByEmail?: string | null
+  role: 'admin' | 'member'
+  expiresAt: Date
+}
+
+interface SendResult {
+  sent: boolean
+  message_id?: string
+  error?: string
+  link: string
+}
+
+export async function sendInviteEmail(args: SendInviteArgs): Promise<SendResult> {
+  const baseUrl =
+    process.env.APP_URL ??
+    process.env.VITE_APP_URL ??
+    'https://localhost:3000'
+  const link = `${baseUrl.replace(/\/$/, '')}/invite/${encodeURIComponent(args.inviteToken)}`
+
+  const apiKey = process.env.RESEND_API_KEY
+  const fromEmail = process.env.INVITE_FROM_EMAIL ?? process.env.RESEND_FROM_EMAIL
+  if (!apiKey) {
+    return { sent: false, error: 'RESEND_API_KEY not set; copy the link manually', link }
+  }
+  if (!fromEmail) {
+    return { sent: false, error: 'INVITE_FROM_EMAIL not set; copy the link manually', link }
+  }
+
+  try {
+    const resend = new Resend(apiKey)
+    const result = await resend.emails.send({
+      from: fromEmail,
+      to: args.toEmail,
+      subject: 'You have been invited to PortfolioIQ',
+      html: buildHtml({
+        link,
+        invitedByEmail: args.invitedByEmail ?? null,
+        role: args.role,
+        expiresAt: args.expiresAt,
+      }),
+      text: buildText({
+        link,
+        invitedByEmail: args.invitedByEmail ?? null,
+        role: args.role,
+        expiresAt: args.expiresAt,
+      }),
+    })
+    if (result.error) {
+      return { sent: false, error: result.error.message, link }
+    }
+    return { sent: true, message_id: result.data?.id, link }
+  } catch (err: any) {
+    return { sent: false, error: err?.message ?? String(err), link }
+  }
+}
+
+function buildHtml(args: {
+  link: string
+  invitedByEmail: string | null
+  role: 'admin' | 'member'
+  expiresAt: Date
+}): string {
+  const inviter = args.invitedByEmail
+    ? `<strong>${escape(args.invitedByEmail)}</strong>`
+    : 'Someone'
+  const roleLabel = args.role === 'admin' ? 'Admin' : 'Member'
+  const expires = args.expiresAt.toLocaleString('en-US', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  })
+  return `
+<!doctype html>
+<html>
+  <body style="font-family: -apple-system, system-ui, sans-serif; max-width: 560px; margin: 0 auto; padding: 24px; color: #0f172a;">
+    <h2 style="margin: 0 0 12px 0;">You've been invited to PortfolioIQ</h2>
+    <p>${inviter} invited you to join PortfolioIQ as <strong>${roleLabel}</strong>.</p>
+    <p style="margin: 24px 0;">
+      <a href="${args.link}"
+         style="display: inline-block; background: #0ea5e9; color: white; padding: 10px 18px; border-radius: 6px; text-decoration: none;">
+        Accept invite
+      </a>
+    </p>
+    <p style="font-size: 12px; color: #64748b;">
+      Or paste this link into your browser:<br/>
+      <span style="word-break: break-all;">${args.link}</span>
+    </p>
+    <p style="font-size: 12px; color: #64748b; margin-top: 16px;">
+      This invite expires on ${escape(expires)}. If you weren't expecting this, you can ignore the message.
+    </p>
+  </body>
+</html>`
+}
+
+function buildText(args: {
+  link: string
+  invitedByEmail: string | null
+  role: 'admin' | 'member'
+  expiresAt: Date
+}): string {
+  const inviter = args.invitedByEmail ?? 'Someone'
+  const roleLabel = args.role === 'admin' ? 'Admin' : 'Member'
+  return `${inviter} invited you to PortfolioIQ as ${roleLabel}.
+
+Accept the invite: ${args.link}
+
+Expires: ${args.expiresAt.toISOString()}`
+}
+
+function escape(s: string): string {
+  return String(s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+}

--- a/api/v1/admin/users.ts
+++ b/api/v1/admin/users.ts
@@ -1,0 +1,42 @@
+// GET /api/v1/admin/users
+//   → { users: AppUserRecord[], pending_invites: PendingInvite[], admin_count: number }
+//
+// Admin-gated. Returns the active user roster + still-pending invites.
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { createAdminClient } from '../../_lib/supabase.js'
+import { requireAdmin, adminCount } from '../../_lib/auth-roles.js'
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method === 'OPTIONS') return res.status(200).end()
+  if (req.method !== 'GET') return res.status(405).json({ error: 'Method not allowed' })
+
+  try {
+    await requireAdmin(req)
+  } catch (err: any) {
+    return res.status(err.statusCode ?? 401).json({ error: err.message ?? 'Unauthorized' })
+  }
+
+  const db = createAdminClient()
+
+  const { data: users, error: uErr } = await db
+    .from('app_users')
+    .select('id, email, name, role, is_active, created_at, last_seen_at')
+    .order('created_at', { ascending: true })
+  if (uErr) return res.status(500).json({ error: uErr.message })
+
+  const { data: invites, error: iErr } = await db
+    .from('user_invites')
+    .select(
+      'id, email, role, invited_by_email, expires_at, created_at, accepted_at, revoked_at'
+    )
+    .is('accepted_at', null)
+    .is('revoked_at', null)
+    .order('created_at', { ascending: false })
+  if (iErr) return res.status(500).json({ error: iErr.message })
+
+  return res.status(200).json({
+    users: users ?? [],
+    pending_invites: invites ?? [],
+    admin_count: await adminCount(),
+  })
+}

--- a/api/v1/admin/users/[id].ts
+++ b/api/v1/admin/users/[id].ts
@@ -1,0 +1,77 @@
+// PATCH /api/v1/admin/users/[id]
+// Body: { role?: 'admin' | 'member', is_active?: boolean, name?: string }
+//
+// Admin-gated. Update role / activation / display name. Won't allow
+// the calling admin to demote/deactivate themselves (avoids accidental
+// lockout) or remove the last admin.
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { createAdminClient } from '../../../_lib/supabase.js'
+import { requireAdmin, adminCount } from '../../../_lib/auth-roles.js'
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method === 'OPTIONS') return res.status(200).end()
+  if (req.method !== 'PATCH') return res.status(405).json({ error: 'Method not allowed' })
+
+  let auth
+  try {
+    auth = await requireAdmin(req)
+  } catch (err: any) {
+    return res.status(err.statusCode ?? 401).json({ error: err.message ?? 'Unauthorized' })
+  }
+
+  const targetId = req.query.id as string
+  if (!targetId) return res.status(400).json({ error: 'user id required' })
+
+  const body = (req.body ?? {}) as Record<string, unknown>
+  const updates: Record<string, unknown> = {}
+  if (body.role === 'admin' || body.role === 'member') updates.role = body.role
+  if (typeof body.is_active === 'boolean') updates.is_active = body.is_active
+  if (typeof body.name === 'string') updates.name = body.name.trim() || null
+  if (Object.keys(updates).length === 0) {
+    return res.status(400).json({ error: 'No editable fields in body' })
+  }
+
+  const db = createAdminClient()
+  const { data: target } = await db
+    .from('app_users')
+    .select('id, role, is_active')
+    .eq('id', targetId)
+    .single()
+  if (!target) return res.status(404).json({ error: 'User not found' })
+  const t = target as any
+
+  // Self-demote / self-deactivate guards.
+  if (targetId === auth.user.id) {
+    if (updates.role && updates.role !== 'admin') {
+      return res.status(400).json({ error: "Can't demote yourself; ask another admin to do it." })
+    }
+    if (updates.is_active === false) {
+      return res.status(400).json({ error: "Can't deactivate yourself." })
+    }
+  }
+
+  // Last-admin protection.
+  const wasAdmin = t.role === 'admin' && t.is_active
+  const stillAdmin =
+    (updates.role !== undefined ? updates.role === 'admin' : t.role === 'admin') &&
+    (updates.is_active !== undefined ? updates.is_active === true : t.is_active === true)
+  if (wasAdmin && !stillAdmin) {
+    const adminCt = await adminCount()
+    if (adminCt <= 1) {
+      return res.status(400).json({
+        error: 'Cannot remove the last admin. Promote another user first.',
+      })
+    }
+  }
+
+  updates.updated_at = new Date().toISOString()
+  const { data: updated, error } = await db
+    .from('app_users')
+    .update(updates)
+    .eq('id', targetId)
+    .select('id, email, name, role, is_active')
+    .single()
+  if (error) return res.status(500).json({ error: error.message })
+
+  return res.status(200).json({ user: updated })
+}

--- a/api/v1/admin/users/bootstrap.ts
+++ b/api/v1/admin/users/bootstrap.ts
@@ -1,0 +1,50 @@
+// POST /api/v1/admin/users/bootstrap
+//
+// One-shot endpoint to promote the calling user to admin when no
+// active admin exists yet. Auth-required (must be a real signed-in
+// user). After running once, this endpoint is a no-op.
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { createAdminClient } from '../../../_lib/supabase.js'
+import { authenticateRequest } from '../../../_lib/auth.js'
+import { adminCount } from '../../../_lib/auth-roles.js'
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method === 'OPTIONS') return res.status(200).end()
+  if (req.method !== 'POST') return res.status(405).json({ error: 'Method not allowed' })
+
+  let ctx
+  try {
+    ctx = await authenticateRequest(req)
+  } catch (err: any) {
+    return res.status(err.statusCode ?? 401).json({ error: err.message ?? 'Unauthorized' })
+  }
+  if (ctx.mode !== 'user' || !ctx.userId) {
+    return res.status(403).json({ error: 'User session required' })
+  }
+
+  if ((await adminCount()) > 0) {
+    return res.status(409).json({ error: 'An admin already exists; ask them to invite you' })
+  }
+
+  const db = createAdminClient()
+  const now = new Date().toISOString()
+  // Upsert by id so a pre-existing app_users row (e.g. created via a
+  // prior invite path) is promoted instead of double-inserted.
+  const { data, error } = await db
+    .from('app_users')
+    .upsert(
+      {
+        id: ctx.userId,
+        email: ctx.email ?? '',
+        role: 'admin',
+        is_active: true,
+        last_seen_at: now,
+        updated_at: now,
+      },
+      { onConflict: 'id' }
+    )
+    .select('id, email, role, is_active')
+    .single()
+  if (error) return res.status(500).json({ error: error.message })
+  return res.status(200).json({ user: data })
+}

--- a/api/v1/admin/users/invite.ts
+++ b/api/v1/admin/users/invite.ts
@@ -1,0 +1,89 @@
+// POST /api/v1/admin/users/invite
+// Body: { email: string, role?: 'admin' | 'member' }
+//
+// Admin-gated. Creates a user_invites row, sends a Resend invite
+// email when configured, and returns the invite plus a "link" the
+// admin can copy/paste manually if email isn't set up yet.
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import crypto from 'crypto'
+import { createAdminClient } from '../../../_lib/supabase.js'
+import { requireAdmin } from '../../../_lib/auth-roles.js'
+import { sendInviteEmail } from '../../../_lib/email/send-invite.js'
+
+const INVITE_EXPIRY_DAYS = 14
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method === 'OPTIONS') return res.status(200).end()
+  if (req.method !== 'POST') return res.status(405).json({ error: 'Method not allowed' })
+
+  let auth
+  try {
+    auth = await requireAdmin(req)
+  } catch (err: any) {
+    return res.status(err.statusCode ?? 401).json({ error: err.message ?? 'Unauthorized' })
+  }
+
+  const body = (req.body ?? {}) as Record<string, unknown>
+  const email =
+    typeof body.email === 'string' ? body.email.trim().toLowerCase() : ''
+  const role = body.role === 'admin' ? 'admin' : 'member'
+  if (!email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+    return res.status(400).json({ error: 'Valid email required' })
+  }
+
+  const db = createAdminClient()
+
+  // Don't double-invite an existing active user.
+  const { data: existing } = await db
+    .from('app_users')
+    .select('id, is_active')
+    .eq('email', email)
+    .maybeSingle()
+  if (existing && (existing as any).is_active) {
+    return res.status(409).json({ error: 'A user with that email already exists' })
+  }
+
+  // Revoke any prior pending invites for this email — we want exactly
+  // one valid token in flight at a time.
+  await db
+    .from('user_invites')
+    .update({ revoked_at: new Date().toISOString(), revoked_by: auth.user.id })
+    .eq('email', email)
+    .is('accepted_at', null)
+    .is('revoked_at', null)
+
+  const token = crypto.randomBytes(24).toString('base64url')
+  const expiresAt = new Date(Date.now() + INVITE_EXPIRY_DAYS * 86400_000)
+
+  const { data: invite, error: insertErr } = await db
+    .from('user_invites')
+    .insert({
+      email,
+      role,
+      token,
+      invited_by: auth.user.id,
+      invited_by_email: auth.user.email,
+      expires_at: expiresAt.toISOString(),
+    })
+    .select('id, email, role, expires_at, created_at')
+    .single()
+  if (insertErr) return res.status(500).json({ error: insertErr.message })
+
+  const sendResult = await sendInviteEmail({
+    toEmail: email,
+    inviteToken: token,
+    invitedByEmail: auth.user.email,
+    role,
+    expiresAt,
+  })
+
+  return res.status(200).json({
+    invite,
+    link: sendResult.link,
+    email: {
+      sent: sendResult.sent,
+      message_id: sendResult.message_id ?? null,
+      error: sendResult.error ?? null,
+    },
+  })
+}

--- a/api/v1/admin/users/invites/[id].ts
+++ b/api/v1/admin/users/invites/[id].ts
@@ -1,0 +1,43 @@
+// DELETE /api/v1/admin/users/invites/[id]
+//
+// Admin-gated. Revoke a pending invite — sets revoked_at so the token
+// stops working. Already-accepted invites can't be revoked.
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { createAdminClient } from '../../../../_lib/supabase.js'
+import { requireAdmin } from '../../../../_lib/auth-roles.js'
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method === 'OPTIONS') return res.status(200).end()
+  if (req.method !== 'DELETE') return res.status(405).json({ error: 'Method not allowed' })
+
+  let auth
+  try {
+    auth = await requireAdmin(req)
+  } catch (err: any) {
+    return res.status(err.statusCode ?? 401).json({ error: err.message ?? 'Unauthorized' })
+  }
+
+  const inviteId = req.query.id as string
+  if (!inviteId) return res.status(400).json({ error: 'invite id required' })
+
+  const db = createAdminClient()
+  const { data: invite } = await db
+    .from('user_invites')
+    .select('id, accepted_at')
+    .eq('id', inviteId)
+    .single()
+  if (!invite) return res.status(404).json({ error: 'Invite not found' })
+  if ((invite as any).accepted_at) {
+    return res.status(400).json({ error: 'Already accepted; cannot revoke' })
+  }
+
+  const { error } = await db
+    .from('user_invites')
+    .update({
+      revoked_at: new Date().toISOString(),
+      revoked_by: auth.user.id,
+    })
+    .eq('id', inviteId)
+  if (error) return res.status(500).json({ error: error.message })
+  return res.status(200).json({ revoked: true })
+}

--- a/api/v1/invites/[token].ts
+++ b/api/v1/invites/[token].ts
@@ -1,0 +1,101 @@
+// GET  /api/v1/invites/[token] — public lookup; returns invite metadata
+//   so the accept page can render context before the user signs up.
+//   Does NOT require auth.
+// POST /api/v1/invites/[token] — accept the invite. Requires the user
+//   to be authenticated (Supabase Auth) AND their email must match
+//   the invite's email. Creates/updates app_users with the invite's
+//   role and stamps the invite as accepted.
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { createAdminClient } from '../../_lib/supabase.js'
+import { authenticateRequest } from '../../_lib/auth.js'
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method === 'OPTIONS') return res.status(200).end()
+  const token = req.query.token as string
+  if (!token) return res.status(400).json({ error: 'token required' })
+  const db = createAdminClient()
+
+  if (req.method === 'GET') {
+    const { data: invite } = await db
+      .from('user_invites')
+      .select('email, role, expires_at, accepted_at, revoked_at, invited_by_email')
+      .eq('token', token)
+      .maybeSingle()
+    if (!invite) return res.status(404).json({ error: 'Invite not found' })
+    const i = invite as any
+    const status =
+      i.revoked_at != null
+        ? 'revoked'
+        : i.accepted_at != null
+          ? 'accepted'
+          : new Date(i.expires_at) < new Date()
+            ? 'expired'
+            : 'pending'
+    return res.status(200).json({
+      email: i.email,
+      role: i.role,
+      invited_by_email: i.invited_by_email,
+      expires_at: i.expires_at,
+      status,
+    })
+  }
+
+  if (req.method === 'POST') {
+    let ctx
+    try {
+      ctx = await authenticateRequest(req)
+    } catch (err: any) {
+      return res.status(err.statusCode ?? 401).json({ error: err.message ?? 'Unauthorized' })
+    }
+    if (ctx.mode !== 'user' || !ctx.userId || !ctx.email) {
+      return res.status(403).json({ error: 'User session required to accept invite' })
+    }
+
+    const { data: invite } = await db
+      .from('user_invites')
+      .select('id, email, role, expires_at, accepted_at, revoked_at')
+      .eq('token', token)
+      .maybeSingle()
+    if (!invite) return res.status(404).json({ error: 'Invite not found' })
+    const i = invite as any
+    if (i.revoked_at) return res.status(400).json({ error: 'Invite was revoked' })
+    if (i.accepted_at) return res.status(400).json({ error: 'Invite already accepted' })
+    if (new Date(i.expires_at) < new Date()) {
+      return res.status(400).json({ error: 'Invite expired; ask the inviter for a new link' })
+    }
+    if (i.email.toLowerCase() !== (ctx.email ?? '').toLowerCase()) {
+      return res.status(403).json({
+        error: `This invite is for ${i.email}; you're signed in as ${ctx.email}`,
+      })
+    }
+
+    const now = new Date().toISOString()
+    // Upsert app_users with the invite's role.
+    const { error: uErr } = await db
+      .from('app_users')
+      .upsert(
+        {
+          id: ctx.userId,
+          email: ctx.email,
+          role: i.role,
+          is_active: true,
+          last_seen_at: now,
+          updated_at: now,
+        },
+        { onConflict: 'id' }
+      )
+    if (uErr) return res.status(500).json({ error: uErr.message })
+
+    await db
+      .from('user_invites')
+      .update({ accepted_at: now, accepted_by_user_id: ctx.userId })
+      .eq('id', i.id)
+
+    return res.status(200).json({
+      accepted: true,
+      role: i.role,
+    })
+  }
+
+  return res.status(405).json({ error: 'Method not allowed' })
+}

--- a/api/v1/me.ts
+++ b/api/v1/me.ts
@@ -1,0 +1,42 @@
+// GET /api/v1/me
+//   → { user_id, email, app_user, admin_count, can_bootstrap }
+//
+// Lightweight self-introspection so the frontend can route admin pages
+// and show/hide the bootstrap-first-admin button.
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { authenticateRequest } from '../_lib/auth.js'
+import { adminCount, getAppUser } from '../_lib/auth-roles.js'
+import { createAdminClient } from '../_lib/supabase.js'
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method === 'OPTIONS') return res.status(200).end()
+  if (req.method !== 'GET') return res.status(405).json({ error: 'Method not allowed' })
+  let ctx
+  try {
+    ctx = await authenticateRequest(req)
+  } catch (err: any) {
+    return res.status(err.statusCode ?? 401).json({ error: err.message ?? 'Unauthorized' })
+  }
+  if (ctx.mode !== 'user' || !ctx.userId) {
+    return res.status(200).json({ mode: ctx.mode })
+  }
+  const appUser = await getAppUser(ctx.userId)
+  // Stamp last_seen_at when the row exists. Cheap heartbeat for the
+  // admin user list.
+  if (appUser) {
+    const db = createAdminClient()
+    await db
+      .from('app_users')
+      .update({ last_seen_at: new Date().toISOString() })
+      .eq('id', ctx.userId)
+  }
+  const ct = await adminCount()
+  return res.status(200).json({
+    mode: ctx.mode,
+    user_id: ctx.userId,
+    email: ctx.email,
+    app_user: appUser,
+    admin_count: ct,
+    can_bootstrap: ct === 0,
+  })
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,10 @@ import FallbacksPage from './pages/admin/parcels/Fallbacks'
 import DangerousAdminPage from './pages/admin/Dangerous'
 import AdminUploadsPage from './pages/admin/Uploads'
 import AdminHubPage from './pages/admin/AdminHub'
+import AdminUsersPage from './pages/admin/Users'
+import AdminBootstrapPage from './pages/admin/Bootstrap'
+import InviteAcceptPage from './pages/InviteAccept'
+import AdminGuard from './components/auth/AdminGuard'
 import AccountsListPage from './pages/accounts/AccountsList'
 import NewAccountPage from './pages/accounts/NewAccount'
 import AccountDetailPage from './pages/accounts/AccountDetail'
@@ -174,12 +178,15 @@ export default function App() {
           <Route path="/clients/:id/setup" element={<AuthGuard><ClientSetupPage /></AuthGuard>} />
 
           {/* Admin */}
-          <Route path="/admin" element={<AuthGuard><AdminHubPage /></AuthGuard>} />
-          <Route path="/admin/dangerous" element={<AuthGuard><DangerousAdminPage /></AuthGuard>} />
-          <Route path="/admin/uploads" element={<AuthGuard><AdminUploadsPage /></AuthGuard>} />
-          <Route path="/admin/parcels/import" element={<AuthGuard><ParcelImportPage /></AuthGuard>} />
-          <Route path="/admin/parcels/counties" element={<AuthGuard><CountiesPage /></AuthGuard>} />
-          <Route path="/admin/parcels/fallbacks" element={<AuthGuard><FallbacksPage /></AuthGuard>} />
+          <Route path="/admin" element={<AuthGuard><AdminGuard><AdminHubPage /></AdminGuard></AuthGuard>} />
+          <Route path="/admin/bootstrap" element={<AuthGuard><AdminBootstrapPage /></AuthGuard>} />
+          <Route path="/admin/users" element={<AuthGuard><AdminGuard><AdminUsersPage /></AdminGuard></AuthGuard>} />
+          <Route path="/admin/dangerous" element={<AuthGuard><AdminGuard><DangerousAdminPage /></AdminGuard></AuthGuard>} />
+          <Route path="/admin/uploads" element={<AuthGuard><AdminGuard><AdminUploadsPage /></AdminGuard></AuthGuard>} />
+          <Route path="/admin/parcels/import" element={<AuthGuard><AdminGuard><ParcelImportPage /></AdminGuard></AuthGuard>} />
+          <Route path="/admin/parcels/counties" element={<AuthGuard><AdminGuard><CountiesPage /></AdminGuard></AuthGuard>} />
+          <Route path="/admin/parcels/fallbacks" element={<AuthGuard><AdminGuard><FallbacksPage /></AdminGuard></AuthGuard>} />
+          <Route path="/invite/:token" element={<InviteAcceptPage />} />
 
           {/* Design system reference (Phase B). Public for now — no AuthGuard
               so designers can hit the URL directly during review. */}

--- a/src/components/auth/AdminGuard.tsx
+++ b/src/components/auth/AdminGuard.tsx
@@ -1,0 +1,70 @@
+// AdminGuard wraps an authenticated page and additionally requires
+// the user to have role='admin' in app_users. If the user is signed
+// in but has no app_user record AND no admin exists yet, the guard
+// redirects to /admin/bootstrap so they can claim the first admin
+// seat. Otherwise non-admins land on /map with a notice.
+import { useEffect, useState } from 'react'
+import { Navigate } from 'react-router-dom'
+import { useAuth } from '../../hooks/useAuth'
+
+interface MeResponse {
+  mode: string
+  user_id?: string
+  email?: string
+  app_user: { role: 'admin' | 'member'; is_active: boolean } | null
+  admin_count: number
+  can_bootstrap: boolean
+}
+
+export default function AdminGuard({ children }: { children: React.ReactNode }) {
+  const { getToken } = useAuth()
+  const [me, setMe] = useState<MeResponse | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    const load = async () => {
+      try {
+        const token = await getToken()
+        const res = await fetch('/api/v1/me', {
+          headers: { Authorization: `Bearer ${token}` },
+        })
+        if (!res.ok) throw new Error(`Auth check failed: ${res.status}`)
+        const data = (await res.json()) as MeResponse
+        if (!cancelled) setMe(data)
+      } catch (err) {
+        if (!cancelled) setError(err instanceof Error ? err.message : String(err))
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+    load()
+    return () => {
+      cancelled = true
+    }
+  }, [getToken])
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-gray-900 flex items-center justify-center">
+        <div className="w-6 h-6 border-2 border-blue-500 border-t-transparent rounded-full animate-spin" />
+      </div>
+    )
+  }
+
+  if (error || !me) {
+    return <Navigate to="/login" replace />
+  }
+
+  // No admin yet — let the user become the first admin.
+  if (me.can_bootstrap) {
+    return <Navigate to="/admin/bootstrap" replace />
+  }
+
+  if (!me.app_user || me.app_user.role !== 'admin' || !me.app_user.is_active) {
+    return <Navigate to="/map" replace state={{ adminBlocked: true }} />
+  }
+
+  return <>{children}</>
+}

--- a/src/pages/InviteAccept.tsx
+++ b/src/pages/InviteAccept.tsx
@@ -1,0 +1,196 @@
+// /invite/:token landing page. Public — does NOT require an existing
+// session because the recipient might not have signed up yet. Renders
+// the invite metadata, then either:
+//  - Shows "Sign in / sign up" links (with redirect back here) if the
+//    user has no session, OR
+//  - Shows a signed-in-as email + "Accept invite" button if the
+//    session email matches the invite email, OR
+//  - Shows a friendly "This invite is for someone else" message if
+//    they're signed in as a different email.
+import { useCallback, useEffect, useState } from 'react'
+import { Link, useNavigate, useParams } from 'react-router-dom'
+import { CheckCircle2, Loader2, ShieldAlert } from 'lucide-react'
+import { useAuth } from '../hooks/useAuth'
+import { supabase } from '../lib/supabase/client'
+import AppShell from '../components/layout/AppShell'
+import Button from '../components/ui/Button'
+import { Card, CardDescription, CardTitle } from '../components/ui/Card'
+
+interface InviteInfo {
+  email: string
+  role: 'admin' | 'member'
+  invited_by_email: string | null
+  expires_at: string
+  status: 'pending' | 'accepted' | 'revoked' | 'expired'
+}
+
+export default function InviteAcceptPage() {
+  const { token } = useParams<{ token: string }>()
+  const nav = useNavigate()
+  const { getToken } = useAuth()
+  const [invite, setInvite] = useState<InviteInfo | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [sessionEmail, setSessionEmail] = useState<string | null>(null)
+  const [accepting, setAccepting] = useState(false)
+  const [done, setDone] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+    const load = async () => {
+      try {
+        const res = await fetch(`/api/v1/invites/${encodeURIComponent(token ?? '')}`)
+        const j = await res.json()
+        if (!res.ok) throw new Error(j.error ?? `Lookup failed: ${res.status}`)
+        if (!cancelled) setInvite(j as InviteInfo)
+      } catch (err) {
+        if (!cancelled) setError(err instanceof Error ? err.message : String(err))
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+    load()
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      if (!cancelled) setSessionEmail(session?.user?.email ?? null)
+    })
+    const { data: sub } = supabase.auth.onAuthStateChange((_e, session) => {
+      if (!cancelled) setSessionEmail(session?.user?.email ?? null)
+    })
+    return () => {
+      cancelled = true
+      sub.subscription.unsubscribe()
+    }
+  }, [token])
+
+  const accept = useCallback(async () => {
+    if (!token) return
+    setAccepting(true)
+    setError(null)
+    try {
+      const t = await getToken()
+      const res = await fetch(`/api/v1/invites/${encodeURIComponent(token)}`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${t}` },
+      })
+      const j = await res.json()
+      if (!res.ok) throw new Error(j.error ?? `Accept failed: ${res.status}`)
+      setDone(true)
+      setTimeout(() => nav('/map'), 1500)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setAccepting(false)
+    }
+  }, [token, getToken, nav])
+
+  if (loading) {
+    return (
+      <AppShell>
+        <div className="mx-auto max-w-xl px-6 py-16 text-center">
+          <Loader2 className="h-6 w-6 animate-spin mx-auto" />
+        </div>
+      </AppShell>
+    )
+  }
+
+  if (error || !invite) {
+    return (
+      <AppShell>
+        <div className="mx-auto max-w-xl px-6 py-12">
+          <Card padding="md">
+            <ShieldAlert className="h-8 w-8 text-danger mb-3" />
+            <CardTitle>Invite not found</CardTitle>
+            <CardDescription>{error ?? 'This invite link is invalid.'}</CardDescription>
+          </Card>
+        </div>
+      </AppShell>
+    )
+  }
+
+  const sameEmail =
+    sessionEmail && sessionEmail.toLowerCase() === invite.email.toLowerCase()
+
+  return (
+    <AppShell>
+      <div className="mx-auto max-w-xl px-6 py-12">
+        <Card padding="md">
+          <CardTitle>You've been invited to PortfolioIQ</CardTitle>
+          <CardDescription>
+            <span className="font-medium text-fg">{invite.invited_by_email ?? 'Someone'}</span>{' '}
+            invited <span className="font-medium text-fg">{invite.email}</span> to join as{' '}
+            <span className="font-medium text-fg">
+              {invite.role === 'admin' ? 'Admin' : 'Member'}
+            </span>
+            .
+          </CardDescription>
+
+          {invite.status === 'expired' && (
+            <p className="mt-3 rounded-md border border-warning/30 bg-warning/5 px-3 py-2 text-sm text-warning">
+              This invite expired on {new Date(invite.expires_at).toLocaleDateString()}. Ask the inviter for a new link.
+            </p>
+          )}
+          {invite.status === 'revoked' && (
+            <p className="mt-3 rounded-md border border-danger/30 bg-danger/5 px-3 py-2 text-sm text-danger">
+              This invite has been revoked.
+            </p>
+          )}
+          {invite.status === 'accepted' && (
+            <p className="mt-3 rounded-md border border-success/30 bg-success/5 px-3 py-2 text-sm text-success">
+              This invite has already been accepted. <Link to="/login" className="underline">Sign in →</Link>
+            </p>
+          )}
+
+          {invite.status === 'pending' && (
+            <div className="mt-4 space-y-3">
+              {!sessionEmail && (
+                <>
+                  <p className="text-sm text-fg-muted">
+                    Sign in or create your account, then come back to accept.
+                  </p>
+                  <div className="flex gap-2">
+                    <Button asChild>
+                      <Link to={`/login?redirect=/invite/${encodeURIComponent(token ?? '')}`}>
+                        Sign in
+                      </Link>
+                    </Button>
+                    <Button asChild variant="secondary">
+                      <Link
+                        to={`/signup?redirect=/invite/${encodeURIComponent(token ?? '')}&email=${encodeURIComponent(invite.email)}`}
+                      >
+                        Create account
+                      </Link>
+                    </Button>
+                  </div>
+                </>
+              )}
+              {sessionEmail && !sameEmail && (
+                <p className="rounded-md border border-warning/30 bg-warning/5 px-3 py-2 text-sm text-warning">
+                  You're signed in as <strong>{sessionEmail}</strong>, but this invite is for{' '}
+                  <strong>{invite.email}</strong>. Sign out and sign in with the right account.
+                </p>
+              )}
+              {sessionEmail && sameEmail && !done && (
+                <Button onClick={accept} disabled={accepting}>
+                  {accepting ? (
+                    <>
+                      <Loader2 className="h-4 w-4 mr-1.5 animate-spin" />
+                      Accepting…
+                    </>
+                  ) : (
+                    'Accept invite'
+                  )}
+                </Button>
+              )}
+              {done && (
+                <p className="rounded-md border border-success/30 bg-success/5 px-3 py-2 text-sm text-success flex items-center gap-2">
+                  <CheckCircle2 className="h-4 w-4" />
+                  Welcome aboard! Redirecting…
+                </p>
+              )}
+            </div>
+          )}
+        </Card>
+      </div>
+    </AppShell>
+  )
+}

--- a/src/pages/admin/AdminHub.tsx
+++ b/src/pages/admin/AdminHub.tsx
@@ -201,6 +201,20 @@ export default function AdminHubPage() {
             </div>
           </div>
 
+          {/* User management */}
+          <div className="bg-white rounded-xl shadow-sm border p-5">
+            <h2 className="font-semibold text-gray-800 mb-2">User Management</h2>
+            <p className="text-xs text-gray-500 mb-2">
+              Invite teammates, manage roles, and deactivate accounts.
+            </p>
+            <Link
+              to="/admin/users"
+              className="inline-block px-3 py-1.5 text-sm font-medium text-white bg-blue-600 rounded-lg hover:bg-blue-700"
+            >
+              Manage users →
+            </Link>
+          </div>
+
           {/* Other admin links */}
           <div className="bg-white rounded-xl shadow-sm border p-5">
             <h2 className="font-semibold text-gray-800 mb-2">Other Admin Tools</h2>

--- a/src/pages/admin/Bootstrap.tsx
+++ b/src/pages/admin/Bootstrap.tsx
@@ -1,0 +1,108 @@
+// One-shot page: shown when an authenticated user lands on /admin
+// before any admin exists. Promoting yourself to first admin is a
+// one-click button that hits /api/v1/admin/users/bootstrap.
+import { useEffect, useState } from 'react'
+import { Navigate, useNavigate } from 'react-router-dom'
+import { Loader2, ShieldCheck } from 'lucide-react'
+import { useAuth } from '../../hooks/useAuth'
+import AppShell from '../../components/layout/AppShell'
+import Button from '../../components/ui/Button'
+import { Card, CardTitle, CardDescription } from '../../components/ui/Card'
+
+export default function AdminBootstrapPage() {
+  const { getToken } = useAuth()
+  const nav = useNavigate()
+  const [loading, setLoading] = useState(true)
+  const [canBootstrap, setCanBootstrap] = useState(false)
+  const [email, setEmail] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [busy, setBusy] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+    const load = async () => {
+      try {
+        const token = await getToken()
+        const res = await fetch('/api/v1/me', {
+          headers: { Authorization: `Bearer ${token}` },
+        })
+        const j = await res.json()
+        if (!res.ok) throw new Error(j.error ?? `Auth check failed: ${res.status}`)
+        if (!cancelled) {
+          setCanBootstrap(!!j.can_bootstrap)
+          setEmail(j.email ?? null)
+        }
+      } catch (err) {
+        if (!cancelled) setError(err instanceof Error ? err.message : String(err))
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+    load()
+    return () => {
+      cancelled = true
+    }
+  }, [getToken])
+
+  const claim = async () => {
+    setBusy(true)
+    setError(null)
+    try {
+      const token = await getToken()
+      const res = await fetch('/api/v1/admin/users/bootstrap', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      const j = await res.json()
+      if (!res.ok) throw new Error(j.error ?? `Bootstrap failed: ${res.status}`)
+      nav('/admin/users', { replace: true })
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  if (loading) {
+    return (
+      <AppShell>
+        <div className="mx-auto max-w-xl px-6 py-16 text-center">
+          <Loader2 className="h-6 w-6 animate-spin mx-auto" />
+        </div>
+      </AppShell>
+    )
+  }
+  if (!canBootstrap) {
+    return <Navigate to="/admin/users" replace />
+  }
+
+  return (
+    <AppShell breadcrumb={[{ label: 'Admin' }]}>
+      <div className="mx-auto max-w-xl px-6 py-12">
+        <Card padding="md">
+          <ShieldCheck className="h-8 w-8 text-accent mb-3" />
+          <CardTitle>Claim the first admin seat</CardTitle>
+          <CardDescription>
+            No admin user has been set up yet. Click below to promote yourself
+            ({email ?? 'this account'}) to admin so you can invite teammates.
+            This option disappears as soon as the first admin exists.
+          </CardDescription>
+          {error && (
+            <p className="mt-3 rounded-md border border-danger/30 bg-danger/5 px-3 py-2 text-sm text-danger">
+              {error}
+            </p>
+          )}
+          <Button onClick={claim} disabled={busy} className="mt-4">
+            {busy ? (
+              <>
+                <Loader2 className="h-4 w-4 mr-1.5 animate-spin" /> Promoting…
+              </>
+            ) : (
+              'Become first admin'
+            )}
+          </Button>
+        </Card>
+      </div>
+    </AppShell>
+  )
+}

--- a/src/pages/admin/Users.tsx
+++ b/src/pages/admin/Users.tsx
@@ -1,0 +1,426 @@
+// Admin user management — invite + role + activation. All actions
+// are admin-gated server-side; the page itself is wrapped in
+// AdminGuard so non-admins never reach it.
+import { useCallback, useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+import {
+  Loader2,
+  Mail,
+  ShieldCheck,
+  ShieldOff,
+  Trash2,
+  UserPlus,
+  Copy,
+  Check,
+} from 'lucide-react'
+import { useAuth } from '../../hooks/useAuth'
+import AppShell from '../../components/layout/AppShell'
+import Button from '../../components/ui/Button'
+import { Card, CardTitle, CardDescription } from '../../components/ui/Card'
+import { Badge } from '../../components/ui/Badge'
+import { Input, FormField } from '../../components/ui/Input'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '../../components/ui/Select'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '../../components/ui/Table'
+import { cn } from '../../lib/cn'
+
+interface AppUser {
+  id: string
+  email: string
+  name: string | null
+  role: 'admin' | 'member'
+  is_active: boolean
+  created_at: string
+  last_seen_at: string | null
+}
+
+interface PendingInvite {
+  id: string
+  email: string
+  role: 'admin' | 'member'
+  invited_by_email: string | null
+  expires_at: string
+  created_at: string
+}
+
+interface UsersResponse {
+  users: AppUser[]
+  pending_invites: PendingInvite[]
+  admin_count: number
+}
+
+export default function AdminUsersPage() {
+  const { getToken } = useAuth()
+  const [data, setData] = useState<UsersResponse | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  // Invite form
+  const [inviteEmail, setInviteEmail] = useState('')
+  const [inviteRole, setInviteRole] = useState<'admin' | 'member'>('member')
+  const [inviting, setInviting] = useState(false)
+  const [inviteResult, setInviteResult] = useState<{
+    link: string
+    sent: boolean
+    error?: string
+  } | null>(null)
+  const [linkCopied, setLinkCopied] = useState(false)
+
+  const refresh = useCallback(async () => {
+    try {
+      const token = await getToken()
+      const res = await fetch('/api/v1/admin/users', {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      if (!res.ok) throw new Error(`Load failed: ${res.status}`)
+      setData((await res.json()) as UsersResponse)
+      setError(null)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setLoading(false)
+    }
+  }, [getToken])
+
+  useEffect(() => {
+    refresh()
+  }, [refresh])
+
+  const submitInvite = async () => {
+    setInviting(true)
+    setError(null)
+    setInviteResult(null)
+    try {
+      const token = await getToken()
+      const res = await fetch('/api/v1/admin/users/invite', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ email: inviteEmail.trim(), role: inviteRole }),
+      })
+      const j = await res.json()
+      if (!res.ok) throw new Error(j.error ?? `Invite failed: ${res.status}`)
+      setInviteResult({
+        link: j.link,
+        sent: !!j.email?.sent,
+        error: j.email?.error ?? undefined,
+      })
+      setInviteEmail('')
+      await refresh()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setInviting(false)
+    }
+  }
+
+  const copyLink = (link: string) => {
+    navigator.clipboard.writeText(link).then(() => {
+      setLinkCopied(true)
+      setTimeout(() => setLinkCopied(false), 2000)
+    })
+  }
+
+  const updateUser = async (userId: string, body: any) => {
+    setError(null)
+    try {
+      const token = await getToken()
+      const res = await fetch(`/api/v1/admin/users/${userId}`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify(body),
+      })
+      const j = await res.json()
+      if (!res.ok) throw new Error(j.error ?? `Update failed: ${res.status}`)
+      await refresh()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    }
+  }
+
+  const revokeInvite = async (inviteId: string) => {
+    if (!window.confirm('Revoke this invite? The link will stop working.')) return
+    setError(null)
+    try {
+      const token = await getToken()
+      const res = await fetch(`/api/v1/admin/users/invites/${inviteId}`, {
+        method: 'DELETE',
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}))
+        throw new Error((j as any).error ?? `Revoke failed: ${res.status}`)
+      }
+      await refresh()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    }
+  }
+
+  return (
+    <AppShell breadcrumb={[{ label: 'Admin', to: '/admin' }, { label: 'Users' }]}>
+      <div className="mx-auto max-w-5xl px-6 py-8 space-y-6">
+        <header>
+          <h1 className="text-2xl font-semibold text-fg">User Management</h1>
+          <p className="text-sm text-fg-muted mt-1">
+            Invite teammates, manage roles, and deactivate accounts.
+          </p>
+        </header>
+
+        {error && (
+          <div className="rounded-md border border-danger/30 bg-danger/5 px-4 py-2 text-sm text-danger">
+            {error}
+          </div>
+        )}
+
+        {/* Invite form */}
+        <Card padding="md">
+          <CardTitle>Invite a new user</CardTitle>
+          <CardDescription>
+            Sends an email if Resend is configured (RESEND_API_KEY +
+            INVITE_FROM_EMAIL); otherwise you can copy the invite link from below
+            and share it manually. Invites expire in 14 days.
+          </CardDescription>
+          <div className="mt-4 grid grid-cols-1 sm:grid-cols-[1fr_180px_auto] gap-3 items-end">
+            <FormField label="Email">
+              <Input
+                type="email"
+                value={inviteEmail}
+                onChange={(e) => setInviteEmail(e.target.value)}
+                placeholder="teammate@example.com"
+              />
+            </FormField>
+            <FormField label="Role">
+              <Select
+                value={inviteRole}
+                onValueChange={(v) => setInviteRole(v as 'admin' | 'member')}
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="member">Member</SelectItem>
+                  <SelectItem value="admin">Admin</SelectItem>
+                </SelectContent>
+              </Select>
+            </FormField>
+            <Button onClick={submitInvite} disabled={!inviteEmail.trim() || inviting}>
+              {inviting ? (
+                <>
+                  <Loader2 className="h-4 w-4 mr-1.5 animate-spin" />
+                  Sending…
+                </>
+              ) : (
+                <>
+                  <UserPlus className="h-4 w-4 mr-1.5" />
+                  Invite
+                </>
+              )}
+            </Button>
+          </div>
+          {inviteResult && (
+            <div
+              className={cn(
+                'mt-3 rounded-md border px-3 py-2 text-xs',
+                inviteResult.sent
+                  ? 'border-success/30 bg-success/5'
+                  : 'border-warning/30 bg-warning/5'
+              )}
+            >
+              <p className="font-medium">
+                {inviteResult.sent
+                  ? '✓ Invite emailed'
+                  : `Email not sent: ${inviteResult.error ?? 'Resend not configured'}`}
+              </p>
+              <div className="mt-1 flex items-center gap-2">
+                <span className="font-mono text-fg-muted break-all flex-1">
+                  {inviteResult.link}
+                </span>
+                <button
+                  type="button"
+                  onClick={() => copyLink(inviteResult.link)}
+                  className="text-fg-subtle hover:text-accent"
+                  title="Copy link"
+                >
+                  {linkCopied ? (
+                    <Check className="h-3.5 w-3.5 text-success" />
+                  ) : (
+                    <Copy className="h-3.5 w-3.5" />
+                  )}
+                </button>
+              </div>
+            </div>
+          )}
+        </Card>
+
+        {/* Pending invites */}
+        {data && data.pending_invites.length > 0 && (
+          <Card padding="md">
+            <CardTitle>Pending invites ({data.pending_invites.length})</CardTitle>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Email</TableHead>
+                  <TableHead>Role</TableHead>
+                  <TableHead>Invited by</TableHead>
+                  <TableHead>Expires</TableHead>
+                  <TableHead />
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {data.pending_invites.map((i) => (
+                  <TableRow key={i.id}>
+                    <TableCell>{i.email}</TableCell>
+                    <TableCell>
+                      <Badge variant={i.role === 'admin' ? 'accent' : 'outline'}>
+                        {i.role}
+                      </Badge>
+                    </TableCell>
+                    <TableCell className="text-xs text-fg-muted">
+                      {i.invited_by_email ?? '—'}
+                    </TableCell>
+                    <TableCell className="text-xs font-tabular">
+                      {new Date(i.expires_at).toLocaleDateString()}
+                    </TableCell>
+                    <TableCell>
+                      <button
+                        type="button"
+                        onClick={() => revokeInvite(i.id)}
+                        className="text-fg-subtle hover:text-danger"
+                        title="Revoke invite"
+                      >
+                        <Trash2 className="h-3.5 w-3.5" />
+                      </button>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </Card>
+        )}
+
+        {/* User list */}
+        <Card padding="md">
+          <CardTitle>
+            Users {data ? `(${data.users.length})` : ''}
+          </CardTitle>
+          {loading && (
+            <p className="text-sm text-fg-muted mt-3 flex items-center gap-2">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Loading users…
+            </p>
+          )}
+          {data && (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Email</TableHead>
+                  <TableHead>Role</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Last seen</TableHead>
+                  <TableHead>Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {data.users.length === 0 && (
+                  <TableRow>
+                    <TableCell className="text-fg-muted text-sm">
+                      No users yet — start by inviting one above.
+                    </TableCell>
+                  </TableRow>
+                )}
+                {data.users.map((u) => (
+                  <TableRow key={u.id} className={!u.is_active ? 'opacity-60' : undefined}>
+                    <TableCell>
+                      <p className="text-fg">{u.email}</p>
+                      {u.name && <p className="text-xs text-fg-muted">{u.name}</p>}
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant={u.role === 'admin' ? 'accent' : 'outline'}>
+                        {u.role}
+                      </Badge>
+                    </TableCell>
+                    <TableCell>
+                      {u.is_active ? (
+                        <Badge variant="success">Active</Badge>
+                      ) : (
+                        <Badge variant="outline">Inactive</Badge>
+                      )}
+                    </TableCell>
+                    <TableCell className="text-xs font-tabular text-fg-muted">
+                      {u.last_seen_at
+                        ? new Date(u.last_seen_at).toLocaleString()
+                        : '—'}
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex items-center gap-2 text-xs">
+                        {u.role === 'member' ? (
+                          <button
+                            type="button"
+                            onClick={() => updateUser(u.id, { role: 'admin' })}
+                            className="text-fg-subtle hover:text-accent inline-flex items-center gap-1"
+                            title="Promote to admin"
+                          >
+                            <ShieldCheck className="h-3.5 w-3.5" />
+                            Promote
+                          </button>
+                        ) : (
+                          <button
+                            type="button"
+                            onClick={() => updateUser(u.id, { role: 'member' })}
+                            className="text-fg-subtle hover:text-warning inline-flex items-center gap-1"
+                            title="Demote to member"
+                          >
+                            <ShieldOff className="h-3.5 w-3.5" />
+                            Demote
+                          </button>
+                        )}
+                        <button
+                          type="button"
+                          onClick={() =>
+                            updateUser(u.id, { is_active: !u.is_active })
+                          }
+                          className="text-fg-subtle hover:text-danger"
+                          title={u.is_active ? 'Deactivate' : 'Reactivate'}
+                        >
+                          {u.is_active ? 'Deactivate' : 'Reactivate'}
+                        </button>
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </Card>
+
+        <p className="text-xs text-fg-subtle">
+          <Mail className="inline h-3 w-3 mr-1" />
+          Email delivery uses Resend. Set <code>RESEND_API_KEY</code> and{' '}
+          <code>INVITE_FROM_EMAIL</code> on Vercel to enable invite emails;
+          otherwise copy the link from the invite result.{' '}
+          <Link to="/admin" className="underline">
+            Back to admin
+          </Link>
+        </p>
+      </div>
+    </AppShell>
+  )
+}

--- a/supabase/migrations/20260430185957_app_users_and_invites.sql
+++ b/supabase/migrations/20260430185957_app_users_and_invites.sql
@@ -1,0 +1,66 @@
+-- User management — app_users + user_invites.
+--
+-- app_users mirrors auth.users for the rows we care about (so we can
+-- store role + active flag without touching Supabase's auth schema).
+-- The id column is the same uuid as auth.users.id; rows are inserted
+-- when a user accepts an invite (or via the bootstrap endpoint that
+-- promotes the first signed-in user to admin).
+
+CREATE TABLE IF NOT EXISTS public.app_users (
+  id            uuid PRIMARY KEY,
+  email         text NOT NULL UNIQUE,
+  name          text,
+  role          text NOT NULL DEFAULT 'member',
+  is_active     boolean NOT NULL DEFAULT true,
+  created_at    timestamptz NOT NULL DEFAULT now(),
+  updated_at    timestamptz NOT NULL DEFAULT now(),
+  last_seen_at  timestamptz
+);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'app_users_role_chk') THEN
+    ALTER TABLE public.app_users
+      ADD CONSTRAINT app_users_role_chk CHECK (role IN ('admin', 'member'));
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS app_users_email_idx ON public.app_users(email);
+
+CREATE TABLE IF NOT EXISTS public.user_invites (
+  id                    uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  email                 text NOT NULL,
+  role                  text NOT NULL DEFAULT 'member',
+  token                 text NOT NULL UNIQUE,
+  invited_by            uuid,
+  invited_by_email      text,
+  expires_at            timestamptz NOT NULL,
+  created_at            timestamptz NOT NULL DEFAULT now(),
+  accepted_at           timestamptz,
+  accepted_by_user_id   uuid,
+  revoked_at            timestamptz,
+  revoked_by            uuid
+);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'user_invites_role_chk') THEN
+    ALTER TABLE public.user_invites
+      ADD CONSTRAINT user_invites_role_chk CHECK (role IN ('admin', 'member'));
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'user_invites_state_chk') THEN
+    ALTER TABLE public.user_invites
+      ADD CONSTRAINT user_invites_state_chk CHECK (
+        accepted_at IS NULL OR revoked_at IS NULL
+      );
+  END IF;
+END $$;
+
+-- Lookup by token (very common: invite-accept flow)
+CREATE INDEX IF NOT EXISTS user_invites_token_idx ON public.user_invites(token);
+-- Pending-invites-by-email index (the admin UI shows pending invites
+-- per email so a re-invite can either revoke + re-create or just
+-- bump the expiry).
+CREATE INDEX IF NOT EXISTS user_invites_email_pending_idx
+  ON public.user_invites(email)
+  WHERE accepted_at IS NULL AND revoked_at IS NULL;


### PR DESCRIPTION
## What this adds
A full user-management module so you can invite teammates from \`/admin/users\`, manage their roles, and deactivate accounts. Single-tenant scope — all users see all data; the only role distinction is admin vs member (admins are the only ones who can reach \`/admin\`).

## How it works
1. **First time you visit \`/admin\`** with no admin user yet → redirected to \`/admin/bootstrap\` → one-click "Become first admin".
2. **From \`/admin/users\`**: enter an email + role → invite link is generated, Resend sends it (if configured), and the invitee lands on \`/invite/:token\`.
3. Invitee signs up / signs in with the matching email, hits "Accept invite" → app_users row created with the invited role.

## Setup the deployer needs to do
Set these env vars on Vercel (no email sending without the first two — but the UI shows a copy-link fallback):
- \`RESEND_API_KEY\`
- \`INVITE_FROM_EMAIL\` (verified Resend sender)
- \`APP_URL\` (e.g. \`https://your-app.vercel.app\`)

## DB
- \`app_users\` (id matches auth.users.id, role, is_active, last_seen_at)
- \`user_invites\` (token, expires_at, accepted/revoked stamps)

Both already pushed to the linked Supabase.

## API
- \`GET  /api/v1/me\` — role + can_bootstrap
- \`GET  /api/v1/admin/users\` — list users + pending invites
- \`POST /api/v1/admin/users/invite\` — create invite + send email
- \`DELETE /api/v1/admin/users/invites/{id}\` — revoke
- \`PATCH /api/v1/admin/users/{id}\` — role / activation / name
- \`POST /api/v1/admin/users/bootstrap\` — claim first admin seat
- \`GET  /api/v1/invites/{token}\` — public invite metadata
- \`POST /api/v1/invites/{token}\` — accept (auth required; email must match)

## Guards
- \`AdminGuard\` wraps all \`/admin/*\` routes (except bootstrap) so non-admins land on \`/map\`.
- \`requireAdmin()\` server-side enforces the same on every endpoint.
- Self-demote / self-deactivate is blocked, and removing the last admin is blocked.

## Test plan
- [ ] First user visits \`/admin\` → redirected to \`/admin/bootstrap\` → click "Become first admin" → land on \`/admin/users\`
- [ ] Invite a user with Resend env unset → link appears in the result with a copy button; pasting it into a new browser as the invited email lets them accept
- [ ] Invite a user with Resend configured → email arrives, link works
- [ ] Promote a member → demote them again
- [ ] Try to demote yourself → blocked
- [ ] Try to remove the last admin → blocked
- [ ] Revoke a pending invite → token stops working
- [ ] Non-admin signs in and visits \`/admin\` → redirected to \`/map\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)