### PR TITLE
feat(auth): email-OTP sign-in + redirect-aware login + /auth/callback

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,7 @@ import AdminHubPage from './pages/admin/AdminHub'
 import AdminUsersPage from './pages/admin/Users'
 import AdminBootstrapPage from './pages/admin/Bootstrap'
 import InviteAcceptPage from './pages/InviteAccept'
+import AuthCallbackPage from './pages/AuthCallback'
 import AdminGuard from './components/auth/AdminGuard'
 import AccountsListPage from './pages/accounts/AccountsList'
 import NewAccountPage from './pages/accounts/NewAccount'
@@ -187,6 +188,7 @@ export default function App() {
           <Route path="/admin/parcels/counties" element={<AuthGuard><AdminGuard><CountiesPage /></AdminGuard></AuthGuard>} />
           <Route path="/admin/parcels/fallbacks" element={<AuthGuard><AdminGuard><FallbacksPage /></AdminGuard></AuthGuard>} />
           <Route path="/invite/:token" element={<InviteAcceptPage />} />
+          <Route path="/auth/callback" element={<AuthCallbackPage />} />
 
           {/* Design system reference (Phase B). Public for now — no AuthGuard
               so designers can hit the URL directly during review. */}

--- a/src/pages/AuthCallback.tsx
+++ b/src/pages/AuthCallback.tsx
@@ -1,0 +1,81 @@
+// /auth/callback — landing page for Supabase magic-link redirects.
+// Exchanges the `code` query param for a session via
+// supabase.auth.exchangeCodeForSession, then forwards to the
+// `redirect` query param (or "/" if absent). The Supabase client
+// also processes hash-fragment tokens automatically on load via the
+// 'detectSessionInUrl' default, so the link with a hash works too.
+import { useEffect, useState } from 'react'
+import { useNavigate, useSearchParams } from 'react-router-dom'
+import { supabase } from '../lib/supabase/client'
+
+function safeRedirect(raw: string | null): string {
+  if (!raw) return '/'
+  if (raw.startsWith('/') && !raw.startsWith('//')) return raw
+  return '/'
+}
+
+export default function AuthCallbackPage() {
+  const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const target = safeRedirect(searchParams.get('redirect'))
+    const code = searchParams.get('code')
+
+    const finish = (path: string) => navigate(path, { replace: true })
+
+    const run = async () => {
+      // Code-flow link (e.g. PKCE / magic-link with ?code=...)
+      if (code) {
+        const { error } = await supabase.auth.exchangeCodeForSession(code)
+        if (error) {
+          setError(error.message)
+          return
+        }
+        finish(target)
+        return
+      }
+      // Hash-fragment link (older magic-link format with #access_token=...).
+      // The Supabase client auto-detects this on load; just check the
+      // session and forward.
+      const { data } = await supabase.auth.getSession()
+      if (data.session) {
+        finish(target)
+        return
+      }
+      // Wait briefly for the SDK's URL-hash handler to populate, then
+      // re-check once.
+      setTimeout(async () => {
+        const { data: again } = await supabase.auth.getSession()
+        if (again.session) finish(target)
+        else setError('No session found from the link. The link may have expired or already been used.')
+      }, 400)
+    }
+    run()
+  }, [searchParams, navigate])
+
+  return (
+    <div className="min-h-screen bg-gray-900 flex items-center justify-center px-4">
+      <div className="w-full max-w-sm bg-gray-800 rounded-xl border border-gray-700 p-6 shadow-xl">
+        {error ? (
+          <>
+            <h2 className="text-white font-semibold text-lg mb-2">Couldn't sign you in</h2>
+            <p className="text-sm text-red-300 mb-4">{error}</p>
+            <a
+              href="/login"
+              className="inline-block px-3 py-1.5 text-sm font-medium text-white bg-blue-600 rounded-lg hover:bg-blue-500"
+            >
+              Back to sign in
+            </a>
+          </>
+        ) : (
+          <div className="flex items-center gap-2 text-gray-300">
+            <span className="w-4 h-4 border-2 border-blue-500 border-t-transparent rounded-full animate-spin" />
+            <span className="text-sm">Signing you in…</span>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,24 +1,102 @@
-import { useState, type FormEvent } from 'react'
-import { useNavigate, Link } from 'react-router-dom'
+import { useMemo, useState, type FormEvent } from 'react'
+import { Link, useNavigate, useSearchParams } from 'react-router-dom'
 import { supabase } from '../lib/supabase/client'
+
+type Mode = 'password' | 'otp_request' | 'otp_verify'
+
+function safeRedirect(raw: string | null): string {
+  // Only allow same-origin paths to avoid open-redirect abuse.
+  if (!raw) return '/'
+  if (raw.startsWith('/') && !raw.startsWith('//')) return raw
+  return '/'
+}
 
 export default function LoginPage() {
   const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
+  const redirectTarget = useMemo(
+    () => safeRedirect(searchParams.get('redirect')),
+    [searchParams]
+  )
+
+  const [mode, setMode] = useState<Mode>('password')
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
+  const [otpCode, setOtpCode] = useState('')
   const [error, setError] = useState<string | null>(null)
+  const [info, setInfo] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
 
-  const handleSubmit = async (e: FormEvent) => {
+  // ── Password sign-in ─────────────────────────────────────────────
+  const handlePasswordSubmit = async (e: FormEvent) => {
     e.preventDefault()
     setError(null)
+    setInfo(null)
     setLoading(true)
     try {
       const { error } = await supabase.auth.signInWithPassword({ email, password })
       if (error) {
         setError(error.message)
       } else {
-        navigate('/')
+        navigate(redirectTarget)
+      }
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  // ── OTP request: send the email ──────────────────────────────────
+  const handleOtpRequest = async (e: FormEvent) => {
+    e.preventDefault()
+    setError(null)
+    setInfo(null)
+    setLoading(true)
+    try {
+      // emailRedirectTo lands the user on /auth/callback after they
+      // click the magic link; the callback exchanges the code and
+      // forwards them to redirectTarget. The 6-digit code in the
+      // same email also works via verifyOtp below.
+      const baseUrl = import.meta.env.VITE_APP_URL ?? window.location.origin
+      const callbackUrl = `${baseUrl.replace(/\/$/, '')}/auth/callback?redirect=${encodeURIComponent(redirectTarget)}`
+      const { error } = await supabase.auth.signInWithOtp({
+        email,
+        options: {
+          emailRedirectTo: callbackUrl,
+          // shouldCreateUser=false matches the "invite-only" model —
+          // teammates only become users via accepting an invite, so
+          // an OTP request for an unknown email shouldn't silently
+          // create one.
+          shouldCreateUser: false,
+        },
+      })
+      if (error) {
+        setError(error.message)
+      } else {
+        setInfo(
+          `Sent a sign-in link + 6-digit code to ${email}. Click the link, or paste the code below.`
+        )
+        setMode('otp_verify')
+      }
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  // ── OTP verify: paste the 6-digit code ───────────────────────────
+  const handleOtpVerify = async (e: FormEvent) => {
+    e.preventDefault()
+    setError(null)
+    setLoading(true)
+    try {
+      const { error } = await supabase.auth.verifyOtp({
+        email,
+        token: otpCode.trim(),
+        type: 'email',
+      })
+      if (error) {
+        setError(error.message)
+      } else {
+        navigate(redirectTarget)
       }
     } finally {
       setLoading(false)
@@ -39,62 +117,182 @@ export default function LoginPage() {
         </div>
 
         <div className="bg-gray-800 rounded-xl border border-gray-700 p-6 shadow-xl">
-          <h2 className="text-white font-semibold text-lg mb-5">Sign in to your account</h2>
+          <h2 className="text-white font-semibold text-lg mb-4">Sign in to your account</h2>
+
+          {/* Mode switcher */}
+          <div className="grid grid-cols-2 gap-1 bg-gray-900 rounded-lg p-1 mb-5 text-xs">
+            <button
+              type="button"
+              onClick={() => {
+                setMode('password')
+                setError(null)
+                setInfo(null)
+              }}
+              className={`px-3 py-1.5 rounded-md transition ${
+                mode === 'password'
+                  ? 'bg-gray-700 text-white'
+                  : 'text-gray-400 hover:text-gray-200'
+              }`}
+            >
+              Password
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setMode('otp_request')
+                setError(null)
+                setInfo(null)
+              }}
+              className={`px-3 py-1.5 rounded-md transition ${
+                mode === 'password'
+                  ? 'text-gray-400 hover:text-gray-200'
+                  : 'bg-gray-700 text-white'
+              }`}
+            >
+              Email code
+            </button>
+          </div>
 
           {error && (
             <div className="mb-4 px-3 py-2 bg-red-900/50 border border-red-700 rounded-lg text-red-300 text-sm">
               {error}
             </div>
           )}
-
-          <form onSubmit={handleSubmit} className="space-y-4">
-            <div>
-              <label className="block text-sm font-medium text-gray-300 mb-1.5">
-                Email address
-              </label>
-              <input
-                type="email"
-                autoComplete="email"
-                required
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                className="w-full bg-gray-700 border border-gray-600 rounded-lg px-3 py-2 text-white placeholder-gray-500 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                placeholder="you@example.com"
-              />
+          {info && (
+            <div className="mb-4 px-3 py-2 bg-blue-900/40 border border-blue-700 rounded-lg text-blue-200 text-sm">
+              {info}
             </div>
+          )}
 
-            <div>
-              <div className="flex items-center justify-between mb-1.5">
-                <label className="block text-sm font-medium text-gray-300">Password</label>
-                <Link
-                  to="/login/forgot-password"
-                  className="text-xs text-blue-400 hover:text-blue-300"
-                >
-                  Forgot password?
-                </Link>
+          {/* ── Password mode ───────────────────────────────── */}
+          {mode === 'password' && (
+            <form onSubmit={handlePasswordSubmit} className="space-y-4">
+              <div>
+                <label className="block text-sm font-medium text-gray-300 mb-1.5">
+                  Email address
+                </label>
+                <input
+                  type="email"
+                  autoComplete="email"
+                  required
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  className="w-full bg-gray-700 border border-gray-600 rounded-lg px-3 py-2 text-white placeholder-gray-500 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  placeholder="you@example.com"
+                />
               </div>
-              <input
-                type="password"
-                autoComplete="current-password"
-                required
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                className="w-full bg-gray-700 border border-gray-600 rounded-lg px-3 py-2 text-white placeholder-gray-500 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                placeholder="••••••••"
-              />
-            </div>
 
-            <button
-              type="submit"
-              disabled={loading}
-              className="w-full bg-blue-600 hover:bg-blue-500 disabled:bg-blue-800 disabled:cursor-not-allowed text-white font-medium rounded-lg px-4 py-2.5 text-sm transition-colors flex items-center justify-center gap-2"
-            >
-              {loading && (
-                <span className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />
-              )}
-              {loading ? 'Signing in…' : 'Sign in'}
-            </button>
-          </form>
+              <div>
+                <div className="flex items-center justify-between mb-1.5">
+                  <label className="block text-sm font-medium text-gray-300">Password</label>
+                  <Link
+                    to="/login/forgot-password"
+                    className="text-xs text-blue-400 hover:text-blue-300"
+                  >
+                    Forgot password?
+                  </Link>
+                </div>
+                <input
+                  type="password"
+                  autoComplete="current-password"
+                  required
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  className="w-full bg-gray-700 border border-gray-600 rounded-lg px-3 py-2 text-white placeholder-gray-500 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  placeholder="••••••••"
+                />
+              </div>
+
+              <button
+                type="submit"
+                disabled={loading}
+                className="w-full bg-blue-600 hover:bg-blue-500 disabled:bg-blue-800 disabled:cursor-not-allowed text-white font-medium rounded-lg px-4 py-2.5 text-sm transition-colors flex items-center justify-center gap-2"
+              >
+                {loading && (
+                  <span className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />
+                )}
+                {loading ? 'Signing in…' : 'Sign in'}
+              </button>
+            </form>
+          )}
+
+          {/* ── OTP request mode ───────────────────────────── */}
+          {mode === 'otp_request' && (
+            <form onSubmit={handleOtpRequest} className="space-y-4">
+              <div>
+                <label className="block text-sm font-medium text-gray-300 mb-1.5">
+                  Email address
+                </label>
+                <input
+                  type="email"
+                  autoComplete="email"
+                  required
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  className="w-full bg-gray-700 border border-gray-600 rounded-lg px-3 py-2 text-white placeholder-gray-500 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  placeholder="you@example.com"
+                />
+              </div>
+              <p className="text-xs text-gray-400">
+                We'll email you a sign-in link and a 6-digit code. Either works.
+              </p>
+              <button
+                type="submit"
+                disabled={loading}
+                className="w-full bg-blue-600 hover:bg-blue-500 disabled:bg-blue-800 disabled:cursor-not-allowed text-white font-medium rounded-lg px-4 py-2.5 text-sm transition-colors flex items-center justify-center gap-2"
+              >
+                {loading && (
+                  <span className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />
+                )}
+                {loading ? 'Sending…' : 'Send sign-in code'}
+              </button>
+            </form>
+          )}
+
+          {/* ── OTP verify mode ────────────────────────────── */}
+          {mode === 'otp_verify' && (
+            <form onSubmit={handleOtpVerify} className="space-y-4">
+              <div>
+                <label className="block text-sm font-medium text-gray-300 mb-1.5">
+                  6-digit code
+                </label>
+                <input
+                  type="text"
+                  inputMode="numeric"
+                  pattern="\d{6}"
+                  maxLength={6}
+                  autoComplete="one-time-code"
+                  required
+                  value={otpCode}
+                  onChange={(e) => setOtpCode(e.target.value.replace(/\D/g, ''))}
+                  className="w-full bg-gray-700 border border-gray-600 rounded-lg px-3 py-2 text-white text-center text-lg font-mono tracking-[0.5em] focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  placeholder="••••••"
+                />
+              </div>
+              <button
+                type="submit"
+                disabled={loading || otpCode.length !== 6}
+                className="w-full bg-blue-600 hover:bg-blue-500 disabled:bg-blue-800 disabled:cursor-not-allowed text-white font-medium rounded-lg px-4 py-2.5 text-sm transition-colors flex items-center justify-center gap-2"
+              >
+                {loading && (
+                  <span className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />
+                )}
+                {loading ? 'Verifying…' : 'Verify code'}
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  setMode('otp_request')
+                  setOtpCode('')
+                  setError(null)
+                  setInfo(null)
+                }}
+                className="block w-full text-center text-xs text-gray-400 hover:text-gray-200"
+              >
+                ← Use a different email
+              </button>
+            </form>
+          )}
         </div>
 
         {import.meta.env.VITE_ALLOW_SIGNUP === 'true' && (


### PR DESCRIPTION
## What
Two changes so the new invite flow round-trips correctly when teammates sign in via OTP rather than password:

1. **Redirect-aware Login** — \`Login.tsx\` reads \`?redirect=<same-origin-path>\` from the query string and navigates to it after sign-in (password or OTP), instead of always landing on \`/\`. Same-origin only; external URLs coerce to \`/\`.
2. **Email-OTP sign-in tab** — alongside the existing password form, a new \"Email code\" tab runs Supabase's \`signInWithOtp\` (6-digit code + magic link) and \`verifyOtp\`. \`shouldCreateUser=false\` matches the invite-only model — OTP requests for unknown emails won't silently create users.
3. **\`/auth/callback\`** — public route that handles both the code-flow link (\`?code=...\`) and older hash-fragment magic links, exchanges for a session, and forwards to \`?redirect=\`.

## Why now
The \`InviteAccept\` page sends users to \`/login?redirect=/invite/<token>\`, but the old \`Login.tsx\` ignored the redirect. Without these fixes, OTP-using teammates would sign in successfully but land on the dashboard instead of the invite page.

## Server-side
**Nothing changed.** \`authenticateRequest\` validates whatever Supabase JWT comes in regardless of sign-in method, so all the v1 endpoints + \`AdminGuard\` + invite-accept just work.

## Test plan
- [ ] \`/login?redirect=/admin/users\` → password sign-in lands on \`/admin/users\`
- [ ] Click \"Email code\" → enter email → receive code + link → paste code → land on the redirect target
- [ ] Click the magic link in the email → \`/auth/callback?code=...\` → forwarded to redirect target
- [ ] Invite a teammate → they click invite link → sign-in via OTP → land back on \`/invite/<token>\` → accept
- [ ] Existing forgot-password flow still works (it uses its own callback at \`/login/update-password\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)