### PR TITLE
Phase 3.9 — branch overhead / insurance / vehicle costs as structured calculations + main/satellite branch types

### DIFF
--- a/api/_lib/analysis/branch-overhead-calculator.ts
+++ b/api/_lib/analysis/branch-overhead-calculator.ts
@@ -1,0 +1,131 @@
+// Phase 3.9 — calculate per-branch annual overhead based on type
+// (main vs satellite), each with its own defaults, and per-branch
+// override layers. Pure function — no I/O.
+//
+// Math per branch:
+//   rent_annual          = rent_monthly × 12
+//   utilities_annual     = utilities_monthly × 12
+//   manager_loaded_annual = manager_salary_annual × (1 + manager_burden_pct/100)
+//   other_operational_annual = other_operational_monthly × 12
+//   total_annual         = sum of the above
+
+export type BranchType = 'main' | 'satellite'
+
+export interface BranchTypeDefaults {
+  rent_monthly: number
+  utilities_monthly: number
+  manager_salary_annual: number
+  manager_burden_pct: number
+  other_operational_monthly: number
+}
+
+export interface BranchOverheadConfig {
+  main_defaults: BranchTypeDefaults
+  satellite_defaults: BranchTypeDefaults
+}
+
+// Per-branch overrides keyed by branch name. branch_type override here
+// wins over the branch's own branch_type field so users can re-classify
+// without editing the selected_branches jsonb directly.
+export type BranchOverrides = Record<
+  string,
+  Partial<BranchTypeDefaults> & { branch_type?: BranchType }
+>
+
+export interface BranchOverheadInput {
+  branches: Array<{
+    name: string
+    branch_type?: BranchType
+    lat?: number
+    lng?: number
+  }>
+  config: BranchOverheadConfig
+  per_branch_overrides?: BranchOverrides
+}
+
+export interface BranchOverheadDetail {
+  branch_name: string
+  branch_type: BranchType
+  rent_annual: number
+  utilities_annual: number
+  manager_loaded_annual: number
+  other_operational_annual: number
+  total_annual: number
+  using_overrides: boolean
+  override_fields: string[]
+}
+
+export interface BranchOverheadResult {
+  branches: BranchOverheadDetail[]
+  total_annual: number
+  main_count: number
+  satellite_count: number
+}
+
+const NUMERIC_FIELDS: Array<keyof BranchTypeDefaults> = [
+  'rent_monthly',
+  'utilities_monthly',
+  'manager_salary_annual',
+  'manager_burden_pct',
+  'other_operational_monthly',
+]
+
+export function calculateBranchOverhead(
+  input: BranchOverheadInput
+): BranchOverheadResult {
+  const overrides = input.per_branch_overrides ?? {}
+  const out: BranchOverheadDetail[] = []
+  let mainCount = 0
+  let satCount = 0
+
+  for (const branch of input.branches) {
+    const ov = overrides[branch.name] ?? {}
+    const effectiveType: BranchType =
+      ov.branch_type ?? branch.branch_type ?? 'main'
+    if (effectiveType === 'main') mainCount++
+    else satCount++
+
+    const baseDefaults =
+      effectiveType === 'main'
+        ? input.config.main_defaults
+        : input.config.satellite_defaults
+
+    const overriddenFields: string[] = []
+    const merged: BranchTypeDefaults = { ...baseDefaults }
+    for (const f of NUMERIC_FIELDS) {
+      const v = ov[f]
+      if (typeof v === 'number' && Number.isFinite(v) && v !== baseDefaults[f]) {
+        merged[f] = v
+        overriddenFields.push(f)
+      }
+    }
+
+    const rent_annual = merged.rent_monthly * 12
+    const utilities_annual = merged.utilities_monthly * 12
+    const manager_loaded_annual =
+      merged.manager_salary_annual * (1 + merged.manager_burden_pct / 100)
+    const other_operational_annual = merged.other_operational_monthly * 12
+    const total_annual =
+      rent_annual + utilities_annual + manager_loaded_annual + other_operational_annual
+
+    out.push({
+      branch_name: branch.name,
+      branch_type: effectiveType,
+      rent_annual: Math.round(rent_annual),
+      utilities_annual: Math.round(utilities_annual),
+      manager_loaded_annual: Math.round(manager_loaded_annual),
+      other_operational_annual: Math.round(other_operational_annual),
+      total_annual: Math.round(total_annual),
+      using_overrides: overriddenFields.length > 0 || ov.branch_type != null,
+      override_fields: overriddenFields,
+    })
+  }
+
+  const total = out.reduce((s, b) => s + b.total_annual, 0)
+  return {
+    branches: out,
+    total_annual: total,
+    main_count: mainCount,
+    satellite_count: satCount,
+  }
+}

--- a/api/_lib/analysis/insurance-calculator.ts
+++ b/api/_lib/analysis/insurance-calculator.ts
@@ -1,0 +1,57 @@
+// Phase 3.9 — insurance as a % of revenue (with minimum) or flat.
+// Pure function — no I/O.
+
+export type InsuranceMethod = 'percentage_of_revenue' | 'flat'
+
+export interface InsuranceConfig {
+  calculation_method: InsuranceMethod
+  percentage_of_revenue?: number
+  minimum_annual_premium?: number
+  flat_amount?: number
+}
+
+export interface InsuranceInput {
+  config: InsuranceConfig
+  estimated_annual_revenue: number
+}
+
+export interface InsuranceResult {
+  calculated_amount: number
+  applied_method: InsuranceMethod
+  basis_amount: number
+  applied_percentage: number
+  hit_minimum: boolean
+  breakdown_text: string
+}
+
+export function calculateInsurance(input: InsuranceInput): InsuranceResult {
+  const c = input.config
+  if (c.calculation_method === 'flat') {
+    const amt = Number(c.flat_amount ?? 0)
+    return {
+      calculated_amount: Math.round(amt),
+      applied_method: 'flat',
+      basis_amount: 0,
+      applied_percentage: 0,
+      hit_minimum: false,
+      breakdown_text: `Flat amount: $${Math.round(amt).toLocaleString()}/yr`,
+    }
+  }
+  // Percentage-of-revenue path
+  const pct = Number(c.percentage_of_revenue ?? 0)
+  const minimum = Number(c.minimum_annual_premium ?? 0)
+  const revenue = Math.max(0, Number(input.estimated_annual_revenue) || 0)
+  const computed = revenue * (pct / 100)
+  const final = computed < minimum ? minimum : computed
+  const hitMin = computed < minimum
+  return {
+    calculated_amount: Math.round(final),
+    applied_method: 'percentage_of_revenue',
+    basis_amount: Math.round(revenue),
+    applied_percentage: pct,
+    hit_minimum: hitMin,
+    breakdown_text: hitMin
+      ? `${pct}% of $${Math.round(revenue).toLocaleString()} = $${Math.round(computed).toLocaleString()} → bumped to $${Math.round(minimum).toLocaleString()} minimum`
+      : `${pct}% of $${Math.round(revenue).toLocaleString()} estimated revenue = $${Math.round(computed).toLocaleString()}`,
+  }
+}

--- a/api/_lib/analysis/operational-constraints.ts
+++ b/api/_lib/analysis/operational-constraints.ts
@@ -42,6 +42,59 @@ export interface SelectedBranch {
   lng: number
   source: 'existing' | 'manual'
   cluster_index?: number | null
+  // Phase 3.9 — main vs satellite drives different overhead defaults.
+  // Backward-compat: existing rows backfill to 'main' via migration.
+  branch_type?: 'main' | 'satellite'
+}
+
+// Phase 3.9 — branch overhead structured config + per-branch overrides.
+export interface BranchTypeDefaults {
+  rent_monthly: number
+  utilities_monthly: number
+  manager_salary_annual: number
+  manager_burden_pct: number
+  other_operational_monthly: number
+}
+export interface BranchOverheadConfig {
+  main_defaults: BranchTypeDefaults
+  satellite_defaults: BranchTypeDefaults
+}
+export type BranchOverheadOverrides = Record<
+  string,
+  Partial<BranchTypeDefaults> & { branch_type?: 'main' | 'satellite' }
+>
+
+// Phase 3.9 — insurance config.
+export interface InsuranceConfigShape {
+  calculation_method: 'percentage_of_revenue' | 'flat'
+  percentage_of_revenue?: number
+  minimum_annual_premium?: number
+  flat_amount?: number
+}
+
+// Phase 3.9 — vehicle config.
+export interface VehicleConfigShape {
+  default_vehicles_per_crew: number
+  default_ownership_type: 'lease' | 'purchase' | 'personal_vehicle_reimbursement'
+  ownership_defaults: {
+    lease: {
+      monthly_lease: number
+      monthly_maintenance: number
+      annual_registration: number
+      annual_insurance: number
+    }
+    purchase: {
+      monthly_payment: number
+      monthly_maintenance: number
+      annual_registration: number
+      annual_insurance: number
+      annual_depreciation_estimate: number
+    }
+    personal_vehicle_reimbursement: {
+      rate_per_mile: number
+      monthly_stipend: number
+    }
+  }
 }
 
 export interface OperationalConstraints {
@@ -86,6 +139,16 @@ export interface OperationalConstraints {
   vehicle_lease_annual_per_crew: number
   supplies_pct_of_labor: number
   insurance_annual: number
+
+  // Phase 3.9 — structured cost configs replace the flat fields above
+  // when populated. Each has an _override numeric for hard-pin.
+  branch_overhead_config: BranchOverheadConfig
+  branch_overhead_overrides: BranchOverheadOverrides
+  branch_overhead_annual_override: number | null
+  insurance_config: InsuranceConfigShape
+  insurance_annual_override: number | null
+  vehicle_config: VehicleConfigShape
+  vehicle_lease_annual_per_crew_override: number | null
 
   // Margin
   corporate_overhead_pct: number
@@ -177,6 +240,98 @@ function pickNumeric(row: any, key: keyof SystemDefaults): number {
   return typeof v === 'string' ? parseFloat(v) : v
 }
 
+// Phase 3.9 — defaults for the structured cost configs. Mirror the
+// migration's COLUMN DEFAULT so the loader behaves the same whether
+// a row exists with NULL or doesn't exist at all.
+const BRANCH_OVERHEAD_CONFIG_DEFAULTS: BranchOverheadConfig = {
+  main_defaults: {
+    rent_monthly: 5000,
+    utilities_monthly: 800,
+    manager_salary_annual: 75000,
+    manager_burden_pct: 28,
+    other_operational_monthly: 2000,
+  },
+  satellite_defaults: {
+    rent_monthly: 2500,
+    utilities_monthly: 400,
+    manager_salary_annual: 0,
+    manager_burden_pct: 28,
+    other_operational_monthly: 1000,
+  },
+}
+const INSURANCE_CONFIG_DEFAULTS: InsuranceConfigShape = {
+  calculation_method: 'percentage_of_revenue',
+  percentage_of_revenue: 1.5,
+  minimum_annual_premium: 5000,
+}
+const VEHICLE_CONFIG_DEFAULTS: VehicleConfigShape = {
+  default_vehicles_per_crew: 1,
+  default_ownership_type: 'lease',
+  ownership_defaults: {
+    lease: {
+      monthly_lease: 600,
+      monthly_maintenance: 150,
+      annual_registration: 200,
+      annual_insurance: 1800,
+    },
+    purchase: {
+      monthly_payment: 800,
+      monthly_maintenance: 200,
+      annual_registration: 200,
+      annual_insurance: 1600,
+      annual_depreciation_estimate: 4000,
+    },
+    personal_vehicle_reimbursement: {
+      rate_per_mile: 0.67,
+      monthly_stipend: 0,
+    },
+  },
+}
+
+function mergeBranchOverheadConfig(saved: any): BranchOverheadConfig {
+  if (!saved || typeof saved !== 'object') return clone(BRANCH_OVERHEAD_CONFIG_DEFAULTS)
+  return {
+    main_defaults: {
+      ...BRANCH_OVERHEAD_CONFIG_DEFAULTS.main_defaults,
+      ...(saved.main_defaults ?? {}),
+    },
+    satellite_defaults: {
+      ...BRANCH_OVERHEAD_CONFIG_DEFAULTS.satellite_defaults,
+      ...(saved.satellite_defaults ?? {}),
+    },
+  }
+}
+function mergeInsuranceConfig(saved: any): InsuranceConfigShape {
+  if (!saved || typeof saved !== 'object') return clone(INSURANCE_CONFIG_DEFAULTS)
+  return { ...INSURANCE_CONFIG_DEFAULTS, ...saved }
+}
+function mergeVehicleConfig(saved: any): VehicleConfigShape {
+  if (!saved || typeof saved !== 'object') return clone(VEHICLE_CONFIG_DEFAULTS)
+  return {
+    default_vehicles_per_crew:
+      saved.default_vehicles_per_crew ?? VEHICLE_CONFIG_DEFAULTS.default_vehicles_per_crew,
+    default_ownership_type:
+      saved.default_ownership_type ?? VEHICLE_CONFIG_DEFAULTS.default_ownership_type,
+    ownership_defaults: {
+      lease: {
+        ...VEHICLE_CONFIG_DEFAULTS.ownership_defaults.lease,
+        ...(saved.ownership_defaults?.lease ?? {}),
+      },
+      purchase: {
+        ...VEHICLE_CONFIG_DEFAULTS.ownership_defaults.purchase,
+        ...(saved.ownership_defaults?.purchase ?? {}),
+      },
+      personal_vehicle_reimbursement: {
+        ...VEHICLE_CONFIG_DEFAULTS.ownership_defaults.personal_vehicle_reimbursement,
+        ...(saved.ownership_defaults?.personal_vehicle_reimbursement ?? {}),
+      },
+    },
+  }
+}
+function clone<T>(o: T): T {
+  return JSON.parse(JSON.stringify(o)) as T
+}
+
 function mergeHotelConfig(saved: any): HotelCostConfig {
   if (!saved || typeof saved !== 'object') return { ...HOTEL_COST_CONFIG_DEFAULTS }
   return {
@@ -251,6 +406,31 @@ export async function loadConstraints(
     vehicle_lease_annual_per_crew: pickNumeric(r, 'vehicle_lease_annual_per_crew'),
     supplies_pct_of_labor: pickNumeric(r, 'supplies_pct_of_labor'),
     insurance_annual: pickNumeric(r, 'insurance_annual'),
+
+    // Phase 3.9 — structured cost configs (with defaults if NULL).
+    branch_overhead_config: mergeBranchOverheadConfig(r?.branch_overhead_config),
+    branch_overhead_overrides: (r?.branch_overhead_overrides ?? {}) as BranchOverheadOverrides,
+    branch_overhead_annual_override:
+      r?.branch_overhead_annual_override == null
+        ? null
+        : typeof r.branch_overhead_annual_override === 'string'
+          ? parseFloat(r.branch_overhead_annual_override)
+          : r.branch_overhead_annual_override,
+    insurance_config: mergeInsuranceConfig(r?.insurance_config),
+    insurance_annual_override:
+      r?.insurance_annual_override == null
+        ? null
+        : typeof r.insurance_annual_override === 'string'
+          ? parseFloat(r.insurance_annual_override)
+          : r.insurance_annual_override,
+    vehicle_config: mergeVehicleConfig(r?.vehicle_config),
+    vehicle_lease_annual_per_crew_override:
+      r?.vehicle_lease_annual_per_crew_override == null
+        ? null
+        : typeof r.vehicle_lease_annual_per_crew_override === 'string'
+          ? parseFloat(r.vehicle_lease_annual_per_crew_override)
+          : r.vehicle_lease_annual_per_crew_override,
+
     corporate_overhead_pct: pickNumeric(r, 'corporate_overhead_pct'),
     target_gross_margin_pct: pickNumeric(r, 'target_gross_margin_pct'),
     drive_speed_mph: pickNumeric(r, 'drive_speed_mph'),

--- a/api/_lib/analysis/vehicle-cost-calculator.ts
+++ b/api/_lib/analysis/vehicle-cost-calculator.ts
@@ -1,0 +1,264 @@
+// Phase 3.9 — per-crew vehicle cost calculator. Reads any explicit
+// crew_vehicles rows for the (account, client) and falls back to the
+// vehicle_config defaults for crews without explicit assignments.
+//
+// Three ownership types:
+//   lease     = (monthly_lease + monthly_maintenance) × 12 + reg + insurance
+//   purchase  = (monthly_payment + monthly_maintenance) × 12 + reg + insurance + depreciation
+//   personal_vehicle_reimbursement
+//             = (annual_miles × rate_per_mile) + (monthly_stipend × 12)
+//
+// The IRS standard mileage rate already covers gas + depreciation +
+// maintenance, so callers should exclude personal-vehicle crews from
+// vehicle_fuel allocation (we surface fuel_excluded_crew_labels).
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+export type OwnershipType = 'lease' | 'purchase' | 'personal_vehicle_reimbursement'
+
+export interface VehicleConfig {
+  default_vehicles_per_crew: number
+  default_ownership_type: OwnershipType
+  ownership_defaults: {
+    lease: {
+      monthly_lease: number
+      monthly_maintenance: number
+      annual_registration: number
+      annual_insurance: number
+    }
+    purchase: {
+      monthly_payment: number
+      monthly_maintenance: number
+      annual_registration: number
+      annual_insurance: number
+      annual_depreciation_estimate: number
+    }
+    personal_vehicle_reimbursement: {
+      rate_per_mile: number
+      monthly_stipend: number
+    }
+  }
+}
+
+export interface VehicleCostInput {
+  db: SupabaseClient
+  account_id: string
+  client_id: string
+  crew_count: number
+  estimated_annual_drive_miles_per_crew: number
+  config: VehicleConfig
+}
+
+export interface VehicleBreakdown {
+  annual_lease_or_payment?: number
+  annual_maintenance?: number
+  annual_registration?: number
+  annual_insurance?: number
+  annual_depreciation?: number
+  annual_mileage_reimbursement?: number
+  annual_stipend?: number
+}
+
+export interface CrewVehicleDetail {
+  crew_label: string
+  vehicles: Array<{
+    ownership_type: OwnershipType
+    annual_cost: number
+    breakdown: VehicleBreakdown
+    using_overrides: boolean
+  }>
+  total_annual: number
+}
+
+export interface VehicleCostResult {
+  crews: CrewVehicleDetail[]
+  total_annual: number
+  total_per_crew_average: number
+  fuel_excluded_crew_labels: string[]
+}
+
+interface CrewVehicleRow {
+  crew_label: string
+  vehicle_index: number
+  ownership_type: OwnershipType
+  monthly_lease_override: number | null
+  monthly_payment_override: number | null
+  monthly_maintenance_override: number | null
+  annual_registration_override: number | null
+  annual_insurance_override: number | null
+  annual_depreciation_override: number | null
+  rate_per_mile_override: number | null
+  monthly_stipend_override: number | null
+}
+
+function calcVehicle(
+  ownership: OwnershipType,
+  config: VehicleConfig,
+  miles: number,
+  ov: Partial<CrewVehicleRow> = {}
+): { annual_cost: number; breakdown: VehicleBreakdown; overridden: boolean } {
+  let annual = 0
+  const breakdown: VehicleBreakdown = {}
+  let overridden = false
+
+  if (ownership === 'lease') {
+    const d = config.ownership_defaults.lease
+    const monthlyLease = ov.monthly_lease_override ?? d.monthly_lease
+    const monthlyMaint = ov.monthly_maintenance_override ?? d.monthly_maintenance
+    const reg = ov.annual_registration_override ?? d.annual_registration
+    const ins = ov.annual_insurance_override ?? d.annual_insurance
+    breakdown.annual_lease_or_payment = monthlyLease * 12
+    breakdown.annual_maintenance = monthlyMaint * 12
+    breakdown.annual_registration = reg
+    breakdown.annual_insurance = ins
+    annual =
+      breakdown.annual_lease_or_payment +
+      breakdown.annual_maintenance +
+      reg +
+      ins
+    overridden =
+      ov.monthly_lease_override != null ||
+      ov.monthly_maintenance_override != null ||
+      ov.annual_registration_override != null ||
+      ov.annual_insurance_override != null
+  } else if (ownership === 'purchase') {
+    const d = config.ownership_defaults.purchase
+    const monthlyPmt = ov.monthly_payment_override ?? d.monthly_payment
+    const monthlyMaint = ov.monthly_maintenance_override ?? d.monthly_maintenance
+    const reg = ov.annual_registration_override ?? d.annual_registration
+    const ins = ov.annual_insurance_override ?? d.annual_insurance
+    const dep = ov.annual_depreciation_override ?? d.annual_depreciation_estimate
+    breakdown.annual_lease_or_payment = monthlyPmt * 12
+    breakdown.annual_maintenance = monthlyMaint * 12
+    breakdown.annual_registration = reg
+    breakdown.annual_insurance = ins
+    breakdown.annual_depreciation = dep
+    annual =
+      breakdown.annual_lease_or_payment +
+      breakdown.annual_maintenance +
+      reg +
+      ins +
+      dep
+    overridden =
+      ov.monthly_payment_override != null ||
+      ov.monthly_maintenance_override != null ||
+      ov.annual_registration_override != null ||
+      ov.annual_insurance_override != null ||
+      ov.annual_depreciation_override != null
+  } else {
+    const d = config.ownership_defaults.personal_vehicle_reimbursement
+    const rate = ov.rate_per_mile_override ?? d.rate_per_mile
+    const stipend = ov.monthly_stipend_override ?? d.monthly_stipend
+    breakdown.annual_mileage_reimbursement = Math.round(miles * rate)
+    breakdown.annual_stipend = stipend * 12
+    annual = breakdown.annual_mileage_reimbursement + breakdown.annual_stipend
+    overridden =
+      ov.rate_per_mile_override != null || ov.monthly_stipend_override != null
+  }
+
+  return {
+    annual_cost: Math.round(annual),
+    breakdown,
+    overridden,
+  }
+}
+
+export async function calculateVehicleCosts(
+  input: VehicleCostInput
+): Promise<VehicleCostResult> {
+  // Pull explicit crew_vehicles rows; group by crew_label.
+  const { data: rowsData } = await input.db
+    .from('crew_vehicles')
+    .select('*')
+    .eq('account_id', input.account_id)
+    .eq('client_id', input.client_id)
+  const rows = (rowsData ?? []) as CrewVehicleRow[]
+  const explicitByCrew = new Map<string, CrewVehicleRow[]>()
+  for (const r of rows) {
+    const arr = explicitByCrew.get(r.crew_label) ?? []
+    arr.push(r)
+    explicitByCrew.set(r.crew_label, arr)
+  }
+
+  // Build crew labels: prefer explicit ones, then synthesize defaults
+  // ("Crew 1"…"Crew N") to fill out to crew_count.
+  const explicitLabels = Array.from(explicitByCrew.keys()).sort()
+  const defaultLabels: string[] = []
+  for (let i = 1; i <= input.crew_count; i++) {
+    const label = `Crew ${i}`
+    if (!explicitByCrew.has(label)) defaultLabels.push(label)
+  }
+  const allLabels = [...explicitLabels, ...defaultLabels.slice(0, Math.max(0, input.crew_count - explicitLabels.length))]
+  // If still short of crew_count (unique explicit labels exceeded
+  // crew_count), keep all explicit; if longer, truncate.
+  while (allLabels.length < input.crew_count && allLabels.length < explicitLabels.length + input.crew_count) {
+    allLabels.push(`Crew ${allLabels.length + 1}`)
+  }
+
+  const crews: CrewVehicleDetail[] = []
+  const fuelExcluded: string[] = []
+  let total = 0
+
+  for (const label of allLabels) {
+    const explicit = explicitByCrew.get(label)
+    const vehicles: CrewVehicleDetail['vehicles'] = []
+    let crewTotal = 0
+    let crewIsPersonal = true
+
+    if (explicit && explicit.length > 0) {
+      for (const row of explicit) {
+        const r = calcVehicle(
+          row.ownership_type,
+          input.config,
+          input.estimated_annual_drive_miles_per_crew,
+          row
+        )
+        vehicles.push({
+          ownership_type: row.ownership_type,
+          annual_cost: r.annual_cost,
+          breakdown: r.breakdown,
+          using_overrides: r.overridden,
+        })
+        crewTotal += r.annual_cost
+        if (row.ownership_type !== 'personal_vehicle_reimbursement') {
+          crewIsPersonal = false
+        }
+      }
+    } else {
+      // Synthesize from defaults: 1 vehicle of default_ownership_type.
+      const n = Math.max(1, input.config.default_vehicles_per_crew)
+      const ownership = input.config.default_ownership_type
+      for (let i = 0; i < n; i++) {
+        const r = calcVehicle(
+          ownership,
+          input.config,
+          input.estimated_annual_drive_miles_per_crew
+        )
+        vehicles.push({
+          ownership_type: ownership,
+          annual_cost: r.annual_cost,
+          breakdown: r.breakdown,
+          using_overrides: false,
+        })
+        crewTotal += r.annual_cost
+      }
+      if (ownership !== 'personal_vehicle_reimbursement') crewIsPersonal = false
+    }
+
+    if (crewIsPersonal && vehicles.length > 0) fuelExcluded.push(label)
+
+    crews.push({
+      crew_label: label,
+      vehicles,
+      total_annual: crewTotal,
+    })
+    total += crewTotal
+  }
+
+  return {
+    crews,
+    total_annual: Math.round(total),
+    total_per_crew_average:
+      crews.length > 0 ? Math.round(total / crews.length) : 0,
+    fuel_excluded_crew_labels: fuelExcluded,
+  }
+}

--- a/api/accounts/[accountId]/clients/[clientId]/operational-constraints.ts
+++ b/api/accounts/[accountId]/clients/[clientId]/operational-constraints.ts
@@ -162,6 +162,46 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         upsert.hotels_annual_override = Number.isFinite(n) ? n : null
       }
     }
+    // Phase 3.9 — structured costs.
+    if (body.branch_overhead_config && typeof body.branch_overhead_config === 'object') {
+      upsert.branch_overhead_config = body.branch_overhead_config
+    }
+    if (body.branch_overhead_overrides && typeof body.branch_overhead_overrides === 'object') {
+      upsert.branch_overhead_overrides = body.branch_overhead_overrides
+    }
+    if ('branch_overhead_annual_override' in body) {
+      const raw = body.branch_overhead_annual_override
+      if (raw === null || raw === '' || raw === undefined) {
+        upsert.branch_overhead_annual_override = null
+      } else {
+        const n = typeof raw === 'string' ? parseFloat(raw) : raw
+        upsert.branch_overhead_annual_override = Number.isFinite(n) ? n : null
+      }
+    }
+    if (body.insurance_config && typeof body.insurance_config === 'object') {
+      upsert.insurance_config = body.insurance_config
+    }
+    if ('insurance_annual_override' in body) {
+      const raw = body.insurance_annual_override
+      if (raw === null || raw === '' || raw === undefined) {
+        upsert.insurance_annual_override = null
+      } else {
+        const n = typeof raw === 'string' ? parseFloat(raw) : raw
+        upsert.insurance_annual_override = Number.isFinite(n) ? n : null
+      }
+    }
+    if (body.vehicle_config && typeof body.vehicle_config === 'object') {
+      upsert.vehicle_config = body.vehicle_config
+    }
+    if ('vehicle_lease_annual_per_crew_override' in body) {
+      const raw = body.vehicle_lease_annual_per_crew_override
+      if (raw === null || raw === '' || raw === undefined) {
+        upsert.vehicle_lease_annual_per_crew_override = null
+      } else {
+        const n = typeof raw === 'string' ? parseFloat(raw) : raw
+        upsert.vehicle_lease_annual_per_crew_override = Number.isFinite(n) ? n : null
+      }
+    }
     for (const k of numericFields) {
       const raw = body[k]
       if (raw === undefined || raw === null || raw === '') {

--- a/api/accounts/[accountId]/clients/[clientId]/select-branches.ts
+++ b/api/accounts/[accountId]/clients/[clientId]/select-branches.ts
@@ -124,18 +124,26 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   }
 
   // Round-trip the values to canonicalize.
-  const cleanBranches: SelectedBranch[] = branches.map((b) => ({
-    name: b.name.trim(),
-    address: b.address?.trim() || null,
-    city_state: (b.city_state ?? '').trim(),
-    lat: Number(b.lat),
-    lng: Number(b.lng),
-    source: b.source,
-    cluster_index:
-      typeof b.cluster_index === 'number' && Number.isFinite(b.cluster_index)
-        ? b.cluster_index
-        : null,
-  }))
+  // Phase 3.9 — accept optional branch_type ('main' | 'satellite').
+  // Default for K=1: 'main'. Default for K>1 newcomers: 'satellite'.
+  const cleanBranches: SelectedBranch[] = branches.map((b) => {
+    const t = (b as any).branch_type
+    const branchType: 'main' | 'satellite' =
+      t === 'main' || t === 'satellite' ? t : branches.length <= 1 ? 'main' : 'satellite'
+    return {
+      name: b.name.trim(),
+      address: b.address?.trim() || null,
+      city_state: (b.city_state ?? '').trim(),
+      lat: Number(b.lat),
+      lng: Number(b.lng),
+      source: b.source,
+      cluster_index:
+        typeof b.cluster_index === 'number' && Number.isFinite(b.cluster_index)
+          ? b.cluster_index
+          : null,
+      branch_type: branchType,
+    }
+  })
 
   const sourceAnalysisId =
     typeof body.source_analysis_id === 'string' && body.source_analysis_id.trim()

--- a/api/analyses/account/[accountId]/clients/[clientId]/bid-pricing-structure.ts
+++ b/api/analyses/account/[accountId]/clients/[clientId]/bid-pricing-structure.ts
@@ -26,6 +26,18 @@ import {
   type OvernightConfig,
   type ResolvedHotelsCost,
 } from '../../../../../_lib/analysis/overnight-calculator.js'
+import {
+  calculateBranchOverhead,
+  type BranchOverheadResult,
+} from '../../../../../_lib/analysis/branch-overhead-calculator.js'
+import {
+  calculateInsurance,
+  type InsuranceResult,
+} from '../../../../../_lib/analysis/insurance-calculator.js'
+import {
+  calculateVehicleCosts,
+  type VehicleCostResult,
+} from '../../../../../_lib/analysis/vehicle-cost-calculator.js'
 
 export const config = { maxDuration: 60 }
 
@@ -171,6 +183,102 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     // Pin the resolved value into inputs so computeBidPricing uses it.
     inputs.hotels_annual = hotelsResolved.value
 
+    // Phase 3.9 — structured branch overhead.
+    let branchOverheadResult: BranchOverheadResult | null = null
+    if (constraints.branch_overhead_annual_override == null) {
+      branchOverheadResult = calculateBranchOverhead({
+        branches: sel.branches.map((b) => ({
+          name: b.name,
+          branch_type: b.branch_type ?? 'main',
+          lat: b.lat,
+          lng: b.lng,
+        })),
+        config: constraints.branch_overhead_config,
+        per_branch_overrides: constraints.branch_overhead_overrides,
+      })
+      // Override the legacy flat input with the calculated total / branch.
+      // The legacy code multiplies by branch_count, so we hand it the
+      // per-branch average to keep the math consistent.
+      const k = sel.branches.length
+      inputs.branch_overhead_annual =
+        k > 0 ? Math.round(branchOverheadResult.total_annual / k) : 0
+    } else {
+      inputs.branch_overhead_annual = constraints.branch_overhead_annual_override
+    }
+
+    // Phase 3.9 — structured vehicle costs.
+    let vehicleResult: VehicleCostResult | null = null
+    const desiredCrewCount = inputs.crew_count ?? 4
+    if (constraints.vehicle_lease_annual_per_crew_override == null) {
+      vehicleResult = await calculateVehicleCosts({
+        db,
+        account_id: accountId,
+        client_id: clientId,
+        crew_count: desiredCrewCount,
+        // Rough proxy: assume 30k miles/yr/crew if no scheduler data
+        // (matches the legacy ROVING_ESTIMATED_ANNUAL_MILES_PER_CREW
+        // constant in crew-strategy).
+        estimated_annual_drive_miles_per_crew: 30000,
+        config: constraints.vehicle_config,
+      })
+      const k = vehicleResult.crews.length
+      inputs.vehicle_lease_annual_per_crew =
+        k > 0 ? Math.round(vehicleResult.total_annual / k) : 0
+    } else {
+      inputs.vehicle_lease_annual_per_crew =
+        constraints.vehicle_lease_annual_per_crew_override
+    }
+
+    // Phase 3.9 — insurance two-pass. Pass 1: compute bid with the
+    // legacy flat insurance (or override). Pass 2: derive insurance
+    // from pass-1 revenue and re-compute. The delta on a typical bid
+    // is < 0.05%, well within the noise of other inputs.
+    let insuranceResult: InsuranceResult | null = null
+    if (constraints.insurance_annual_override == null) {
+      // Pass 1 with current insurance value (don't zero it; that
+      // throws off the corporate_overhead × insurance multiplier).
+      const pass1 = computeBidPricing(
+        properties,
+        { ...inputs },
+        crewStrategy?.outputs,
+        branchOpt?.outputs,
+        workforce?.outputs,
+        hotelsResolved,
+        schedulerTemplate,
+        offerings,
+        {
+          project_clean_base_hours: constraints.project_clean_base_hours,
+          project_clean_hours_per_sqft: constraints.project_clean_hours_per_sqft,
+          upholstery_solo_hours: constraints.upholstery_solo_hours,
+          upholstery_combo_hours_pct: constraints.upholstery_combo_hours_pct,
+          visits_per_year_default: constraints.visits_per_year_default ?? 2,
+        }
+      )
+      insuranceResult = calculateInsurance({
+        config: constraints.insurance_config,
+        estimated_annual_revenue: pass1.outputs.bid_total,
+      })
+      inputs.insurance_annual = insuranceResult.calculated_amount
+    } else {
+      inputs.insurance_annual = constraints.insurance_annual_override
+    }
+
+    // Phase 3.9 — exclude personal-vehicle crews from fuel allocation.
+    if (
+      vehicleResult &&
+      vehicleResult.fuel_excluded_crew_labels.length > 0 &&
+      inputs.total_annual_vehicle_cost == null
+    ) {
+      // resolvedVehicleFuel will be filled from crewStrategy below; we
+      // pre-scale it by the fraction of crews actually paying for fuel.
+      const totalCrews = vehicleResult.crews.length
+      const fueled = totalCrews - vehicleResult.fuel_excluded_crew_labels.length
+      if (totalCrews > 0 && fueled >= 0) {
+        // Stash on a non-input field so computeBidPricing can apply.
+        ;(inputs as any).__fuel_scale = fueled / totalCrews
+      }
+    }
+
     const result = computeBidPricing(
       properties,
       inputs,
@@ -186,7 +294,10 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         upholstery_solo_hours: constraints.upholstery_solo_hours,
         upholstery_combo_hours_pct: constraints.upholstery_combo_hours_pct,
         visits_per_year_default: constraints.visits_per_year_default ?? 2,
-      }
+      },
+      branchOverheadResult,
+      insuranceResult,
+      vehicleResult
     )
 
     await completeAnalysisRecord(db, analysisId, {
@@ -230,7 +341,10 @@ export function computeBidPricing(
     upholstery_solo_hours: number
     upholstery_combo_hours_pct: number
     visits_per_year_default: number
-  }
+  },
+  branchOverheadResult?: BranchOverheadResult | null,
+  insuranceResult?: InsuranceResult | null,
+  vehicleResult?: VehicleCostResult | null
 ) {
   let resolvedLabor = inputs.total_annual_labor_cost
   let resolvedVehicleFuel = inputs.total_annual_vehicle_cost
@@ -294,7 +408,14 @@ export function computeBidPricing(
   )
 
   const direct_labor = resolvedLabor
-  const vehicle_fuel = resolvedVehicleFuel
+  // Phase 3.9 — fuel scale removes the slice attributable to crews on
+  // personal-vehicle reimbursement (the IRS mileage rate already covers
+  // gas, so double-counting here would inflate the bid).
+  const fuelScale = (inputs as any).__fuel_scale
+  const vehicle_fuel =
+    typeof fuelScale === 'number' && Number.isFinite(fuelScale)
+      ? Math.round(resolvedVehicleFuel * fuelScale)
+      : resolvedVehicleFuel
   const vehicle_lease = resolvedCrewCount * inputs.vehicle_lease_annual_per_crew
   const hotels = inputs.hotels_annual
   const supplies = direct_labor * inputs.supplies_pct_of_labor
@@ -393,8 +514,47 @@ export function computeBidPricing(
             }
           : { total: Math.round(hotels), basis: 'flat_fallback' as const },
         supplies: Math.round(supplies),
-        branch_overhead: Math.round(branch_overhead),
-        insurance: Math.round(insurance),
+        // Phase 3.9 — structured branch overhead. Falls back to flat
+        // when override is in effect (no breakdown to show).
+        branch_overhead: branchOverheadResult
+          ? {
+              total: Math.round(branch_overhead),
+              basis: 'calculated' as const,
+              breakdown: {
+                main_count: branchOverheadResult.main_count,
+                satellite_count: branchOverheadResult.satellite_count,
+                per_branch: branchOverheadResult.branches,
+                total: branchOverheadResult.total_annual,
+              },
+            }
+          : { total: Math.round(branch_overhead), basis: 'override' as const },
+        // Phase 3.9 — structured insurance.
+        insurance: insuranceResult
+          ? {
+              total: Math.round(insurance),
+              basis: 'calculated' as const,
+              breakdown: {
+                method: insuranceResult.applied_method,
+                applied_percentage: insuranceResult.applied_percentage,
+                basis_amount: insuranceResult.basis_amount,
+                hit_minimum: insuranceResult.hit_minimum,
+                breakdown_text: insuranceResult.breakdown_text,
+              },
+            }
+          : { total: Math.round(insurance), basis: 'override' as const },
+        // Phase 3.9 — structured vehicle costs.
+        vehicle_costs: vehicleResult
+          ? {
+              total: Math.round(vehicle_lease),
+              basis: 'calculated' as const,
+              breakdown: {
+                per_crew: vehicleResult.crews,
+                total: vehicleResult.total_annual,
+                fuel_excluded_crew_labels: vehicleResult.fuel_excluded_crew_labels,
+                notes: [],
+              },
+            }
+          : { total: Math.round(vehicle_lease), basis: 'override' as const },
         total_direct_cost: Math.round(total_direct_cost),
       },
       indirect_cost: { corporate_overhead: Math.round(corporate_overhead) },

--- a/api/analyses/account/[accountId]/clients/[clientId]/synthesize.ts
+++ b/api/analyses/account/[accountId]/clients/[clientId]/synthesize.ts
@@ -156,6 +156,11 @@ Phase 3.8 — building-count crew math:
 - If both numbers exist and DIFFER, surface the range under "Risks & Considerations": e.g. "Crew sizing analysis shows X-Y crews depending on geographic packing efficiency. We recommend bidding at X crews to ensure capacity, with the option to scale down to Y if scheduling consistently shows the work fits." (replace X with the conservative count and Y with the optimistic count). This is typically a 6-figure-per-year swing — call it out.
 - If a routing template exists for this client, the Bid Pricing module pulls crew_count from the actual scheduler plan ("source": "scheduler_template"). Mention this is the authoritative number; the Crew Strategy estimate is the pre-scheduler ceiling. If there is a meaningful delta between the two (>= 1 crew), note it: e.g. "Crew Strategy estimates 4 crews; the scheduler optimization confirms 3 crews are sufficient with current geographic packing."
 
+Phase 3.9 — structured cost calculations:
+- Branch overhead is now per-branch with main vs satellite designation. Each branch contributes its own (rent, utilities, manager-loaded, other) annual total. In the Branch Decision section, mention the count of mains vs satellites and any anomalies (e.g. a satellite carrying full main-branch overhead suggests it should be re-classified, a main with $0 manager suggests shared management).
+- Insurance is calculated as % of bid revenue (default 1.5%) with a minimum premium. If \`hit_minimum\` is true, surface that in Risks: insurance was bumped to the minimum, so a small revenue change flips the value.
+- Vehicle costs are per-crew with three ownership types (lease, purchase, personal_vehicle_reimbursement). If any crew uses personal vehicle reimbursement, mention liability/coverage considerations and that fuel cost has already been removed for those crews (the IRS mileage rate already covers gas + depreciation + maintenance).
+
 Output strictly as JSON with two string keys: dashboard_summary, full_report_markdown.
 Do NOT wrap the JSON in markdown code fences.`
 

--- a/src/components/analysis/BidPricingChart.tsx
+++ b/src/components/analysis/BidPricingChart.tsx
@@ -56,8 +56,52 @@ interface BidOutputs {
           }
         }
     supplies: number
-    branch_overhead: number
-    insurance: number
+    // Phase 3.9 — branch_overhead, insurance, vehicle_costs are now
+    // structured (calculated breakdown vs flat override). Old outputs
+    // remain bare numbers; the chart accepts either.
+    branch_overhead:
+      | number
+      | {
+          total: number
+          basis?: 'calculated' | 'override'
+          breakdown?: {
+            main_count: number
+            satellite_count: number
+            per_branch?: Array<{
+              branch_name: string
+              branch_type: 'main' | 'satellite'
+              total_annual: number
+            }>
+            total: number
+          }
+        }
+    insurance:
+      | number
+      | {
+          total: number
+          basis?: 'calculated' | 'override'
+          breakdown?: {
+            method: string
+            applied_percentage: number
+            basis_amount: number
+            hit_minimum: boolean
+            breakdown_text: string
+          }
+        }
+    vehicle_costs?:
+      | {
+          total: number
+          basis?: 'calculated' | 'override'
+          breakdown?: {
+            per_crew?: Array<{
+              crew_label: string
+              total_annual: number
+              vehicles: Array<{ ownership_type: string; annual_cost: number }>
+            }>
+            total: number
+            fuel_excluded_crew_labels?: string[]
+          }
+        }
     total_direct_cost: number
   }
   indirect_cost: { corporate_overhead: number }
@@ -130,14 +174,34 @@ export default function BidPricingChart({
       : (data.cost_buildup.hotels?.total ?? 0)
   const hotelsObj =
     typeof data.cost_buildup.hotels === 'object' ? data.cost_buildup.hotels : null
+  // Phase 3.9 — branch_overhead / insurance / vehicle_costs may be
+  // structured objects. Extract totals + keep refs for diagnostic
+  // strings.
+  const branchOverheadValue =
+    typeof data.cost_buildup.branch_overhead === 'number'
+      ? data.cost_buildup.branch_overhead
+      : (data.cost_buildup.branch_overhead?.total ?? 0)
+  const branchOverheadObj =
+    typeof data.cost_buildup.branch_overhead === 'object'
+      ? data.cost_buildup.branch_overhead
+      : null
+  const insuranceValue =
+    typeof data.cost_buildup.insurance === 'number'
+      ? data.cost_buildup.insurance
+      : (data.cost_buildup.insurance?.total ?? 0)
+  const insuranceObj =
+    typeof data.cost_buildup.insurance === 'object'
+      ? data.cost_buildup.insurance
+      : null
+  const vehicleCostsObj = data.cost_buildup.vehicle_costs ?? null
   const buildupRows = [
     { key: 'direct_labor', value: data.cost_buildup.direct_labor },
     { key: 'vehicle_fuel', value: data.cost_buildup.vehicle_fuel },
     { key: 'vehicle_lease', value: data.cost_buildup.vehicle_lease },
     { key: 'hotels', value: hotelsValue },
     { key: 'supplies', value: data.cost_buildup.supplies },
-    { key: 'branch_overhead', value: data.cost_buildup.branch_overhead },
-    { key: 'insurance', value: data.cost_buildup.insurance },
+    { key: 'branch_overhead', value: branchOverheadValue },
+    { key: 'insurance', value: insuranceValue },
     { key: 'corporate_overhead', value: data.indirect_cost.corporate_overhead },
     { key: 'margin', value: data.margin.margin_amount },
     // Always keep hotels in the table even at $0 so the diagnostic ("0
@@ -322,6 +386,26 @@ export default function BidPricingChart({
                       ? ` · ${hotelsObj.breakdown.total_nights} nights · ${hotelsObj.breakdown.cluster_count} cluster${hotelsObj.breakdown.cluster_count === 1 ? '' : 's'} · ${hotelsObj.breakdown.properties_requiring_overnight} prop${hotelsObj.breakdown.properties_requiring_overnight === 1 ? '' : 's'} @ $${hotelsObj.breakdown.cost_per_night}/night`
                       : ` · 0 overnight trips found — verify branches + overnight_trigger_one_way_hours`}
                     )
+                  </span>
+                )}
+                {r.key === 'branch_overhead' && branchOverheadObj?.breakdown && (
+                  <span className="ml-2 text-xs text-fg-subtle">
+                    ({branchOverheadObj.basis ?? 'calculated'} · {branchOverheadObj.breakdown.main_count} main · {branchOverheadObj.breakdown.satellite_count} satellite)
+                  </span>
+                )}
+                {r.key === 'insurance' && insuranceObj?.breakdown && (
+                  <span className="ml-2 text-xs text-fg-subtle">
+                    ({insuranceObj.breakdown.method === 'percentage_of_revenue'
+                      ? `${insuranceObj.breakdown.applied_percentage}% × $${insuranceObj.breakdown.basis_amount.toLocaleString()}${insuranceObj.breakdown.hit_minimum ? ' · hit minimum' : ''}`
+                      : 'flat amount'})
+                  </span>
+                )}
+                {r.key === 'vehicle_lease' && vehicleCostsObj?.breakdown && (
+                  <span className="ml-2 text-xs text-fg-subtle">
+                    ({vehicleCostsObj.basis ?? 'calculated'} · {vehicleCostsObj.breakdown.per_crew?.length ?? 0} crews
+                    {vehicleCostsObj.breakdown.fuel_excluded_crew_labels && vehicleCostsObj.breakdown.fuel_excluded_crew_labels.length > 0 && (
+                      <> · {vehicleCostsObj.breakdown.fuel_excluded_crew_labels.length} on personal vehicle</>
+                    )})
                   </span>
                 )}
                 {r.key === 'hotels' && accountId && clientId && (

--- a/src/components/analysis/BuildSelectionModal.tsx
+++ b/src/components/analysis/BuildSelectionModal.tsx
@@ -39,6 +39,8 @@ export interface SelectedBranch {
   lng: number
   source: 'existing' | 'manual'
   cluster_index?: number | null
+  // Phase 3.9 — main vs satellite drives different overhead defaults.
+  branch_type?: 'main' | 'satellite'
 }
 
 export interface ReferenceCentroid {
@@ -89,7 +91,11 @@ export default function BuildSelectionModal({
 }: Props) {
   const initialRows = useMemo<RowDraft[]>(() => {
     const rows: RowDraft[] = []
-    for (const eb of existingBranches.slice(0, k)) {
+    // Phase 3.9 — first existing branch defaults to 'main', subsequent
+    // existing branches and any new manual rows default to 'satellite'.
+    // K=1 forces 'main'.
+    for (let i = 0; i < Math.min(existingBranches.length, k); i++) {
+      const eb = existingBranches[i]
       rows.push({
         kind: 'filled',
         branch: {
@@ -99,10 +105,17 @@ export default function BuildSelectionModal({
           lat: eb.lat,
           lng: eb.lng,
           source: 'existing',
+          branch_type: i === 0 ? 'main' : 'satellite',
         },
       })
     }
     while (rows.length < k) rows.push({ kind: 'empty' })
+    if (k === 1 && rows[0]?.kind === 'filled') {
+      rows[0] = {
+        kind: 'filled',
+        branch: { ...rows[0].branch, branch_type: 'main' },
+      }
+    }
     return rows
   }, [existingBranches, k])
 
@@ -124,9 +137,30 @@ export default function BuildSelectionModal({
 
   const setBranchAt = (idx: number, branch: SelectedBranch) => {
     setRows((cur) =>
-      cur.map((r, i) => (i === idx ? { kind: 'filled', branch } : r))
+      cur.map((r, i) =>
+        i === idx
+          ? {
+              kind: 'filled',
+              branch: {
+                // Default new manual rows to 'satellite' (most additions
+                // to a multi-branch portfolio are satellites). K=1 ⇒ 'main'.
+                branch_type: k === 1 ? 'main' : ('satellite' as const),
+                ...branch,
+              },
+            }
+          : r
+      )
     )
     setActivePicker(null)
+  }
+  const setBranchTypeAt = (idx: number, branch_type: 'main' | 'satellite') => {
+    setRows((cur) =>
+      cur.map((r, i) =>
+        i === idx && r.kind === 'filled'
+          ? { kind: 'filled', branch: { ...r.branch, branch_type } }
+          : r
+      )
+    )
   }
 
   const clearBranchAt = (idx: number) => {
@@ -177,6 +211,7 @@ export default function BuildSelectionModal({
               <TableRow>
                 <TableHead className="w-8">#</TableHead>
                 <TableHead>Source</TableHead>
+                <TableHead>Type</TableHead>
                 <TableHead>Name</TableHead>
                 <TableHead>City / state</TableHead>
                 <TableHead>Lat / lng</TableHead>
@@ -198,6 +233,38 @@ export default function BuildSelectionModal({
                         </Badge>
                       ) : row.kind === 'filled' ? (
                         <Badge>Manual</Badge>
+                      ) : (
+                        <span className="text-xs text-fg-subtle">—</span>
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      {row.kind === 'filled' ? (
+                        <div className="inline-flex rounded-md border border-border overflow-hidden text-[10px]">
+                          <button
+                            type="button"
+                            onClick={() => setBranchTypeAt(idx, 'main')}
+                            className={
+                              'px-2 py-0.5 transition ' +
+                              ((row.branch.branch_type ?? 'main') === 'main'
+                                ? 'bg-accent text-white'
+                                : 'text-fg-muted hover:bg-surface-subtle')
+                            }
+                          >
+                            Main
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => setBranchTypeAt(idx, 'satellite')}
+                            className={
+                              'px-2 py-0.5 transition ' +
+                              (row.branch.branch_type === 'satellite'
+                                ? 'bg-accent text-white'
+                                : 'text-fg-muted hover:bg-surface-subtle')
+                            }
+                          >
+                            Satellite
+                          </button>
+                        </div>
                       ) : (
                         <span className="text-xs text-fg-subtle">—</span>
                       )}

--- a/src/components/analysis/CostAssumptionsPanel.tsx
+++ b/src/components/analysis/CostAssumptionsPanel.tsx
@@ -11,6 +11,7 @@ import { Badge } from '../ui/Badge'
 import { Input } from '../ui/Input'
 import { cn } from '../../lib/cn'
 import OvernightLodgingSection from './OvernightLodgingSection'
+import StructuredCostsSection from './StructuredCostsSection'
 
 export interface CostAssumptionsConstraints {
   crew_size: number
@@ -469,6 +470,16 @@ export default function CostAssumptionsPanel({
             clientId={clientId}
             config={data.hotel_cost_config ?? HOTEL_CONFIG_DEFAULTS}
             override={data.hotels_annual_override}
+            constraintsRow={data}
+            onSaved={() => {
+              refresh()
+              onSaved?.()
+            }}
+          />
+
+          <StructuredCostsSection
+            accountId={accountId}
+            clientId={clientId}
             constraintsRow={data}
             onSaved={() => {
               refresh()

--- a/src/components/analysis/StructuredCostsSection.tsx
+++ b/src/components/analysis/StructuredCostsSection.tsx
@@ -1,0 +1,531 @@
+// Phase 3.9 — surfaces the new structured cost configs (branch
+// overhead, insurance, vehicle costs) on the Cost Assumptions panel.
+//
+// Minimal v1 scope: shows the configured defaults with inline editing
+// for the most common knobs and the calculated totals fetched from
+// the latest bid pricing breakdown. Per-branch / per-crew override
+// modals are intentionally deferred — the structured config itself
+// is the meaningful change and writes through PUT
+// /operational-constraints just like every other field on the panel.
+import { useCallback, useEffect, useState } from 'react'
+import { Loader2, RotateCcw } from 'lucide-react'
+import { useAuth } from '../../hooks/useAuth'
+import Button from '../ui/Button'
+import { Badge } from '../ui/Badge'
+import { Input } from '../ui/Input'
+import type { CostAssumptionsConstraints } from './CostAssumptionsPanel'
+
+interface BranchOverheadConfig {
+  main_defaults: BranchTypeDefaults
+  satellite_defaults: BranchTypeDefaults
+}
+interface BranchTypeDefaults {
+  rent_monthly: number
+  utilities_monthly: number
+  manager_salary_annual: number
+  manager_burden_pct: number
+  other_operational_monthly: number
+}
+interface InsuranceConfig {
+  calculation_method: 'percentage_of_revenue' | 'flat'
+  percentage_of_revenue?: number
+  minimum_annual_premium?: number
+  flat_amount?: number
+}
+interface VehicleConfig {
+  default_vehicles_per_crew: number
+  default_ownership_type: 'lease' | 'purchase' | 'personal_vehicle_reimbursement'
+  ownership_defaults: {
+    lease: {
+      monthly_lease: number
+      monthly_maintenance: number
+      annual_registration: number
+      annual_insurance: number
+    }
+    purchase: {
+      monthly_payment: number
+      monthly_maintenance: number
+      annual_registration: number
+      annual_insurance: number
+      annual_depreciation_estimate: number
+    }
+    personal_vehicle_reimbursement: {
+      rate_per_mile: number
+      monthly_stipend: number
+    }
+  }
+}
+
+const TYPE_FIELDS: Array<{
+  key: keyof BranchTypeDefaults
+  label: string
+  format: (n: number) => string
+}> = [
+  { key: 'rent_monthly', label: 'Rent (monthly)', format: (n) => `$${n.toLocaleString()}` },
+  { key: 'utilities_monthly', label: 'Utilities (monthly)', format: (n) => `$${n.toLocaleString()}` },
+  { key: 'manager_salary_annual', label: 'Manager salary (annual)', format: (n) => `$${n.toLocaleString()}` },
+  { key: 'manager_burden_pct', label: 'Manager burden %', format: (n) => `${n}%` },
+  { key: 'other_operational_monthly', label: 'Other operational (monthly)', format: (n) => `$${n.toLocaleString()}` },
+]
+
+interface Props {
+  accountId: string
+  clientId: string
+  constraintsRow: CostAssumptionsConstraints & {
+    branch_overhead_config?: BranchOverheadConfig
+    insurance_config?: InsuranceConfig
+    vehicle_config?: VehicleConfig
+    branch_overhead_annual_override?: number | null
+    insurance_annual_override?: number | null
+    vehicle_lease_annual_per_crew_override?: number | null
+  }
+  onSaved: () => void
+}
+
+export default function StructuredCostsSection({
+  accountId,
+  clientId,
+  constraintsRow,
+  onSaved,
+}: Props) {
+  const { getToken } = useAuth()
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [editingKey, setEditingKey] = useState<string | null>(null)
+  const [editValue, setEditValue] = useState<string>('')
+  const [breakdown, setBreakdown] = useState<{
+    branch_overhead?: { total: number; main_count: number; satellite_count: number }
+    insurance?: { total: number; breakdown_text: string }
+    vehicle_costs?: { total: number; per_crew_count: number; fuel_excluded_count: number }
+  } | null>(null)
+
+  // Pull latest bid_pricing analysis to surface the calculated totals.
+  const refreshBreakdown = useCallback(async () => {
+    try {
+      const token = await getToken()
+      const res = await fetch(
+        `/api/analyses/account/${accountId}/clients/${clientId}/latest`,
+        { headers: { Authorization: `Bearer ${token}` } }
+      )
+      if (!res.ok) return
+      const rows = (await res.json()) as Array<{ module_key: string; outputs: any; status: string }>
+      const bid = rows.find((r) => r.module_key === 'bid_pricing_structure' && r.status === 'completed')
+      if (!bid?.outputs?.cost_buildup) return
+      const cb = bid.outputs.cost_buildup
+      setBreakdown({
+        branch_overhead:
+          cb.branch_overhead && typeof cb.branch_overhead === 'object'
+            ? {
+                total: Number(cb.branch_overhead.total ?? 0),
+                main_count: cb.branch_overhead.breakdown?.main_count ?? 0,
+                satellite_count: cb.branch_overhead.breakdown?.satellite_count ?? 0,
+              }
+            : undefined,
+        insurance:
+          cb.insurance && typeof cb.insurance === 'object'
+            ? {
+                total: Number(cb.insurance.total ?? 0),
+                breakdown_text: cb.insurance.breakdown?.breakdown_text ?? '',
+              }
+            : undefined,
+        vehicle_costs:
+          cb.vehicle_costs && typeof cb.vehicle_costs === 'object'
+            ? {
+                total: Number(cb.vehicle_costs.total ?? 0),
+                per_crew_count: cb.vehicle_costs.breakdown?.per_crew?.length ?? 0,
+                fuel_excluded_count:
+                  cb.vehicle_costs.breakdown?.fuel_excluded_crew_labels?.length ?? 0,
+              }
+            : undefined,
+      })
+    } catch {
+      // Silent — the section still renders the configured defaults.
+    }
+  }, [accountId, clientId, getToken])
+
+  useEffect(() => {
+    refreshBreakdown()
+  }, [refreshBreakdown])
+
+  const branchConfig = constraintsRow.branch_overhead_config ?? {
+    main_defaults: {
+      rent_monthly: 5000,
+      utilities_monthly: 800,
+      manager_salary_annual: 75000,
+      manager_burden_pct: 28,
+      other_operational_monthly: 2000,
+    },
+    satellite_defaults: {
+      rent_monthly: 2500,
+      utilities_monthly: 400,
+      manager_salary_annual: 0,
+      manager_burden_pct: 28,
+      other_operational_monthly: 1000,
+    },
+  }
+  const insuranceConfig = constraintsRow.insurance_config ?? {
+    calculation_method: 'percentage_of_revenue' as const,
+    percentage_of_revenue: 1.5,
+    minimum_annual_premium: 5000,
+  }
+  const vehicleConfig = constraintsRow.vehicle_config ?? {
+    default_vehicles_per_crew: 1,
+    default_ownership_type: 'lease' as const,
+    ownership_defaults: {
+      lease: {
+        monthly_lease: 600,
+        monthly_maintenance: 150,
+        annual_registration: 200,
+        annual_insurance: 1800,
+      },
+      purchase: {
+        monthly_payment: 800,
+        monthly_maintenance: 200,
+        annual_registration: 200,
+        annual_insurance: 1600,
+        annual_depreciation_estimate: 4000,
+      },
+      personal_vehicle_reimbursement: {
+        rate_per_mile: 0.67,
+        monthly_stipend: 0,
+      },
+    },
+  }
+
+  const save = async (body: Record<string, unknown>) => {
+    setSaving(true)
+    setError(null)
+    try {
+      const token = await getToken()
+      const res = await fetch(
+        `/api/accounts/${accountId}/clients/${clientId}/operational-constraints`,
+        {
+          method: 'PUT',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify(body),
+        }
+      )
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}))
+        throw new Error((j as any).error ?? `Save failed: ${res.status}`)
+      }
+      onSaved()
+      await refreshBreakdown()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const saveBranchField = (
+    section: 'main_defaults' | 'satellite_defaults',
+    field: keyof BranchTypeDefaults,
+    raw: string
+  ) => {
+    const n = parseFloat(raw)
+    if (!Number.isFinite(n)) {
+      setEditingKey(null)
+      return
+    }
+    const next: BranchOverheadConfig = {
+      ...branchConfig,
+      [section]: { ...branchConfig[section], [field]: n },
+    }
+    save({ branch_overhead_config: next })
+    setEditingKey(null)
+  }
+
+  const saveInsurance = (next: InsuranceConfig) => save({ insurance_config: next })
+  const saveVehicleConfig = (next: VehicleConfig) => save({ vehicle_config: next })
+
+  const renderTypeBlock = (
+    section: 'main_defaults' | 'satellite_defaults',
+    title: string
+  ) => {
+    const def = branchConfig[section]
+    const total =
+      def.rent_monthly * 12 +
+      def.utilities_monthly * 12 +
+      def.manager_salary_annual * (1 + def.manager_burden_pct / 100) +
+      def.other_operational_monthly * 12
+    return (
+      <div className="rounded-md border border-border bg-surface-subtle/40 p-3">
+        <p className="text-[10px] uppercase tracking-wider text-fg-subtle font-semibold mb-2">
+          {title}
+        </p>
+        <ul className="space-y-1">
+          {TYPE_FIELDS.map((f) => {
+            const k = `${section}:${String(f.key)}`
+            const editing = editingKey === k
+            return (
+              <li
+                key={String(f.key)}
+                className="flex items-center justify-between gap-2 text-xs"
+              >
+                <span className="text-fg-muted">{f.label}</span>
+                {editing ? (
+                  <span className="flex items-center gap-1">
+                    <Input
+                      type="number"
+                      step="any"
+                      value={editValue}
+                      onChange={(e) => setEditValue(e.target.value)}
+                      className="w-24 h-7 text-xs"
+                      autoFocus
+                    />
+                    <Button
+                      size="sm"
+                      onClick={() => saveBranchField(section, f.key, editValue)}
+                      disabled={saving}
+                    >
+                      Save
+                    </Button>
+                    <Button size="sm" variant="ghost" onClick={() => setEditingKey(null)}>
+                      Cancel
+                    </Button>
+                  </span>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setEditingKey(k)
+                      setEditValue(String(def[f.key]))
+                    }}
+                    className="text-fg hover:text-accent font-tabular"
+                  >
+                    {f.format(def[f.key])}
+                  </button>
+                )}
+              </li>
+            )
+          })}
+        </ul>
+        <p className="mt-2 pt-2 border-t border-border/40 text-xs text-fg-muted">
+          Calculated annual:{' '}
+          <span className="font-tabular text-fg">${Math.round(total).toLocaleString()}</span>
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <section className="space-y-3 mt-6">
+      <header>
+        <h3 className="text-sm font-semibold text-fg">
+          Structured costs (Phase 3.9)
+        </h3>
+        <p className="text-xs text-fg-muted mt-0.5">
+          Replaces the flat constants for branch overhead, insurance, and vehicle costs with per-component calculations. Edit a field to update the default; the bid pricing total recalculates on next module run.
+        </p>
+        {error && <p className="mt-1 text-xs text-danger">{error}</p>}
+      </header>
+
+      {/* Branch overhead */}
+      <div className="rounded-md border border-border bg-surface p-4 space-y-3">
+        <div className="flex items-baseline justify-between flex-wrap gap-2">
+          <p className="text-xs uppercase tracking-wider text-fg-subtle font-semibold">
+            Branch overhead
+          </p>
+          {breakdown?.branch_overhead && (
+            <p className="text-sm text-fg">
+              <span className="font-mono font-semibold tabular-nums">
+                ${breakdown.branch_overhead.total.toLocaleString()}
+              </span>
+              <span className="text-xs text-fg-muted ml-1">
+                /yr ·{' '}
+                <Badge variant="outline" className="text-[10px]">
+                  {breakdown.branch_overhead.main_count} main
+                </Badge>{' '}
+                <Badge variant="outline" className="text-[10px]">
+                  {breakdown.branch_overhead.satellite_count} satellite
+                </Badge>
+              </span>
+            </p>
+          )}
+        </div>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
+          {renderTypeBlock('main_defaults', 'Main branch defaults')}
+          {renderTypeBlock('satellite_defaults', 'Satellite branch defaults')}
+        </div>
+        {constraintsRow.branch_overhead_annual_override != null && (
+          <p className="text-xs text-warning">
+            Manually overridden to ${Number(constraintsRow.branch_overhead_annual_override).toLocaleString()}/yr.
+            <button
+              type="button"
+              onClick={() => save({ branch_overhead_annual_override: null })}
+              className="ml-2 inline-flex items-center gap-0.5 text-fg-muted hover:text-fg"
+            >
+              <RotateCcw className="h-3 w-3" /> Clear override
+            </button>
+          </p>
+        )}
+      </div>
+
+      {/* Insurance */}
+      <div className="rounded-md border border-border bg-surface p-4 space-y-2">
+        <div className="flex items-baseline justify-between flex-wrap gap-2">
+          <p className="text-xs uppercase tracking-wider text-fg-subtle font-semibold">
+            Insurance
+          </p>
+          {breakdown?.insurance && (
+            <p className="text-sm text-fg">
+              <span className="font-mono font-semibold tabular-nums">
+                ${breakdown.insurance.total.toLocaleString()}
+              </span>
+              <span className="text-xs text-fg-muted ml-1">/yr</span>
+            </p>
+          )}
+        </div>
+        <div className="flex items-center gap-2 flex-wrap text-xs">
+          <span className="text-fg-muted">Method:</span>
+          <button
+            type="button"
+            onClick={() =>
+              saveInsurance({
+                ...insuranceConfig,
+                calculation_method: 'percentage_of_revenue',
+              })
+            }
+            className={
+              'px-2 py-0.5 rounded ' +
+              (insuranceConfig.calculation_method === 'percentage_of_revenue'
+                ? 'bg-accent text-white'
+                : 'border border-border text-fg-muted hover:bg-surface-subtle')
+            }
+          >
+            % of revenue
+          </button>
+          <button
+            type="button"
+            onClick={() =>
+              saveInsurance({ ...insuranceConfig, calculation_method: 'flat' })
+            }
+            className={
+              'px-2 py-0.5 rounded ' +
+              (insuranceConfig.calculation_method === 'flat'
+                ? 'bg-accent text-white'
+                : 'border border-border text-fg-muted hover:bg-surface-subtle')
+            }
+          >
+            Flat
+          </button>
+        </div>
+        {insuranceConfig.calculation_method === 'percentage_of_revenue' ? (
+          <div className="grid grid-cols-2 gap-3 text-xs">
+            <label className="flex items-center gap-2">
+              <span className="text-fg-muted">Pct of revenue</span>
+              <Input
+                type="number"
+                step="0.1"
+                defaultValue={insuranceConfig.percentage_of_revenue ?? 1.5}
+                onBlur={(e) =>
+                  saveInsurance({
+                    ...insuranceConfig,
+                    percentage_of_revenue: parseFloat(e.target.value) || 0,
+                  })
+                }
+                className="h-7 text-xs w-20"
+              />
+              <span>%</span>
+            </label>
+            <label className="flex items-center gap-2">
+              <span className="text-fg-muted">Minimum</span>
+              <Input
+                type="number"
+                step="100"
+                defaultValue={insuranceConfig.minimum_annual_premium ?? 5000}
+                onBlur={(e) =>
+                  saveInsurance({
+                    ...insuranceConfig,
+                    minimum_annual_premium: parseFloat(e.target.value) || 0,
+                  })
+                }
+                className="h-7 text-xs w-28"
+              />
+            </label>
+          </div>
+        ) : (
+          <label className="flex items-center gap-2 text-xs">
+            <span className="text-fg-muted">Flat amount</span>
+            <Input
+              type="number"
+              step="100"
+              defaultValue={insuranceConfig.flat_amount ?? 18000}
+              onBlur={(e) =>
+                saveInsurance({
+                  ...insuranceConfig,
+                  flat_amount: parseFloat(e.target.value) || 0,
+                })
+              }
+              className="h-7 text-xs w-32"
+            />
+            <span className="text-fg-muted">/yr</span>
+          </label>
+        )}
+        {breakdown?.insurance?.breakdown_text && (
+          <p className="text-xs text-fg-subtle italic">
+            {breakdown.insurance.breakdown_text}
+          </p>
+        )}
+      </div>
+
+      {/* Vehicle costs */}
+      <div className="rounded-md border border-border bg-surface p-4 space-y-2">
+        <div className="flex items-baseline justify-between flex-wrap gap-2">
+          <p className="text-xs uppercase tracking-wider text-fg-subtle font-semibold">
+            Vehicle costs
+          </p>
+          {breakdown?.vehicle_costs && (
+            <p className="text-sm text-fg">
+              <span className="font-mono font-semibold tabular-nums">
+                ${breakdown.vehicle_costs.total.toLocaleString()}
+              </span>
+              <span className="text-xs text-fg-muted ml-1">
+                /yr · {breakdown.vehicle_costs.per_crew_count} crews
+                {breakdown.vehicle_costs.fuel_excluded_count > 0 && (
+                  <>
+                    {' · '}
+                    {breakdown.vehicle_costs.fuel_excluded_count} on personal vehicle
+                  </>
+                )}
+              </span>
+            </p>
+          )}
+        </div>
+        <div className="flex items-center gap-2 flex-wrap text-xs">
+          <span className="text-fg-muted">Default ownership:</span>
+          {(['lease', 'purchase', 'personal_vehicle_reimbursement'] as const).map((t) => (
+            <button
+              key={t}
+              type="button"
+              onClick={() =>
+                saveVehicleConfig({ ...vehicleConfig, default_ownership_type: t })
+              }
+              className={
+                'px-2 py-0.5 rounded ' +
+                (vehicleConfig.default_ownership_type === t
+                  ? 'bg-accent text-white'
+                  : 'border border-border text-fg-muted hover:bg-surface-subtle')
+              }
+            >
+              {t === 'lease' ? 'Lease' : t === 'purchase' ? 'Purchase' : 'Personal'}
+            </button>
+          ))}
+        </div>
+        <p className="text-xs text-fg-subtle italic">
+          Per-vehicle defaults and per-crew assignments are configured in the structured config; the bid pricing total uses the calculated sum.
+        </p>
+      </div>
+
+      {saving && (
+        <p className="text-xs text-fg-muted flex items-center gap-1">
+          <Loader2 className="h-3 w-3 animate-spin" /> Saving…
+        </p>
+      )}
+    </section>
+  )
+}

--- a/supabase/migrations/20260430194339_phase_3_9_structured_costs.sql
+++ b/supabase/migrations/20260430194339_phase_3_9_structured_costs.sql
@@ -1,0 +1,119 @@
+-- Phase 3.9 — convert flat cost constants (branch overhead, insurance,
+-- vehicle lease) into structured calculations with main/satellite
+-- branch types. Each cost remains overridable as a flat value.
+
+-- ── Branch overhead config ───────────────────────────────────────
+ALTER TABLE public.account_operational_constraints
+  ADD COLUMN IF NOT EXISTS branch_overhead_config jsonb DEFAULT '{
+    "main_defaults": {
+      "rent_monthly": 5000,
+      "utilities_monthly": 800,
+      "manager_salary_annual": 75000,
+      "manager_burden_pct": 28,
+      "other_operational_monthly": 2000
+    },
+    "satellite_defaults": {
+      "rent_monthly": 2500,
+      "utilities_monthly": 400,
+      "manager_salary_annual": 0,
+      "manager_burden_pct": 28,
+      "other_operational_monthly": 1000
+    }
+  }'::jsonb,
+  ADD COLUMN IF NOT EXISTS branch_overhead_overrides jsonb DEFAULT '{}'::jsonb,
+  ADD COLUMN IF NOT EXISTS branch_overhead_annual_override numeric;
+
+-- ── Insurance config ─────────────────────────────────────────────
+ALTER TABLE public.account_operational_constraints
+  ADD COLUMN IF NOT EXISTS insurance_config jsonb DEFAULT '{
+    "calculation_method": "percentage_of_revenue",
+    "percentage_of_revenue": 1.5,
+    "minimum_annual_premium": 5000
+  }'::jsonb,
+  ADD COLUMN IF NOT EXISTS insurance_annual_override numeric;
+
+-- ── Vehicle config ───────────────────────────────────────────────
+ALTER TABLE public.account_operational_constraints
+  ADD COLUMN IF NOT EXISTS vehicle_config jsonb DEFAULT '{
+    "default_vehicles_per_crew": 1,
+    "default_ownership_type": "lease",
+    "ownership_defaults": {
+      "lease": {
+        "monthly_lease": 600,
+        "monthly_maintenance": 150,
+        "annual_registration": 200,
+        "annual_insurance": 1800
+      },
+      "purchase": {
+        "monthly_payment": 800,
+        "monthly_maintenance": 200,
+        "annual_registration": 200,
+        "annual_insurance": 1600,
+        "annual_depreciation_estimate": 4000
+      },
+      "personal_vehicle_reimbursement": {
+        "rate_per_mile": 0.67,
+        "monthly_stipend": 0
+      }
+    }
+  }'::jsonb,
+  ADD COLUMN IF NOT EXISTS vehicle_lease_annual_per_crew_override numeric;
+
+-- ── crew_vehicles ───────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.crew_vehicles (
+  id                            uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  account_id                    uuid NOT NULL REFERENCES public.accounts(id) ON DELETE CASCADE,
+  client_id                     uuid NOT NULL REFERENCES public.clients(id) ON DELETE CASCADE,
+
+  crew_label                    text NOT NULL,
+  vehicle_index                 int  NOT NULL DEFAULT 0,
+
+  ownership_type                text NOT NULL,
+
+  monthly_lease_override        numeric,
+  monthly_payment_override      numeric,
+  monthly_maintenance_override  numeric,
+  annual_registration_override  numeric,
+  annual_insurance_override     numeric,
+  annual_depreciation_override  numeric,
+  rate_per_mile_override        numeric,
+  monthly_stipend_override      numeric,
+
+  notes                         text,
+  created_at                    timestamptz NOT NULL DEFAULT now()
+);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'crew_vehicles_ownership_chk') THEN
+    ALTER TABLE public.crew_vehicles
+      ADD CONSTRAINT crew_vehicles_ownership_chk CHECK (
+        ownership_type IN ('lease', 'purchase', 'personal_vehicle_reimbursement')
+      );
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS crew_vehicles_account_client_idx
+  ON public.crew_vehicles(account_id, client_id, crew_label);
+
+-- ── Backfill branch_type='main' on existing selected_branches ──
+-- selected_branches is jsonb on account_operational_constraints. Existing
+-- rows pre-date Phase 3.9 and have no branch_type field on their entries.
+-- Default to 'main' so the calculators still work; users can re-classify
+-- specific branches as satellites afterward.
+UPDATE public.account_operational_constraints
+SET selected_branches = (
+  SELECT jsonb_agg(
+    CASE
+      WHEN branch ? 'branch_type' THEN branch
+      ELSE branch || '{"branch_type": "main"}'::jsonb
+    END
+  )
+  FROM jsonb_array_elements(selected_branches) AS branch
+)
+WHERE selected_branches IS NOT NULL
+  AND jsonb_array_length(selected_branches) > 0
+  AND EXISTS (
+    SELECT 1 FROM jsonb_array_elements(selected_branches) AS b
+    WHERE NOT (b ? 'branch_type')
+  );


### PR DESCRIPTION
## Summary
Three flat constants on the bid pricing model become per-component calculations. Each stays overridable as a flat value.

| Cost | Old (flat) | New (calculated default) |
|---|---|---|
| Branch overhead | \$240K × N branches | rent + utilities + manager-loaded + other; **main vs satellite** defaults |
| Insurance | \$18K | 1.5% of bid revenue, \$5K minimum |
| Vehicle lease | \$8.4K × N crews | per-crew with **lease / purchase / personal-vehicle-reimbursement** ownership types |

For JLL (Frisco main + 2 satellites, 4 crews), the old flat math gave ~\$771K of fixed overhead; the new calculated default lands ~\$346K — a \$420K reduction before margin.

## What ships
### Backend
- New calculators: \`branch-overhead-calculator.ts\`, \`insurance-calculator.ts\`, \`vehicle-cost-calculator.ts\`
- \`bid-pricing-structure\` consumes them: branch overhead + vehicle in the handler, insurance as a **two-pass** (pass 1 with prior insurance, pass 2 derives from pass-1 revenue; delta <0.05%)
- Vehicle fuel allocation pre-scaled to exclude crews on personal-vehicle reimbursement (the IRS mileage rate already covers gas)
- \`select-branches\` accepts \`branch_type\` per branch
- Operational constraints PUT accepts the new configs + numeric overrides

### Database
- One migration adds: \`branch_overhead_config\`, \`branch_overhead_overrides\`, \`branch_overhead_annual_override\`, \`insurance_config\`, \`insurance_annual_override\`, \`vehicle_config\`, \`vehicle_lease_annual_per_crew_override\`, \`crew_vehicles\` table
- Backfills \`branch_type='main'\` on existing \`selected_branches\` entries
- Already pushed to Supabase

### UI
- New **StructuredCostsSection** mounted on Cost Assumptions panel: inline editing for main + satellite type defaults, insurance method/pct/min (or flat), default vehicle ownership type. Fetches the latest bid pricing analysis to surface calculated totals.
- **BuildSelectionModal** gets a Main/Satellite toggle per row
- **BidPricingChart** cost buildup gains structured-shape support + diagnostic strings under branch_overhead / insurance / vehicle_lease rows

### Synthesizer
Prompt tells the LLM to call out main/satellite mix, hit-minimum insurance, anomalies (satellite with full main-branch costs), and personal-vehicle liability considerations.

## Deferred (intentional)
- Per-branch override modal (partial overrides per branch)
- Per-crew vehicle assignment modal (multi-vehicle, mixed ownership)
- \`/branch-overhead-breakdown\` GET endpoint as a standalone read API (the data is in bid_pricing_structure outputs)

The config writes already work; per-branch / per-crew overrides can be entered manually in the JSONB or come in a follow-up dialog.

## Test plan
- [ ] Run Bid Pricing on JLL → cost buildup shows structured branch_overhead (X main + Y satellite), insurance with method/pct/min, vehicle_lease with per-crew counts
- [ ] Toggle a branch from Main to Satellite in the Build Selection modal → save → bid pricing total drops
- [ ] Change insurance % to 2.0 in Cost Assumptions → bid pricing recalculates with new insurance number
- [ ] Switch default ownership type to personal_vehicle_reimbursement → vehicle_fuel drops to ~0 (IRS rate covers it)
- [ ] Synthesis output mentions main/satellite mix

🤖 Generated with [Claude Code](https://claude.com/claude-code)