### PR TITLE
Phase 4: service line bid pricing structure

### DIFF
--- a/api/_lib/analysis/service-line-bid-calculator.ts
+++ b/api/_lib/analysis/service-line-bid-calculator.ts
@@ -1,0 +1,375 @@
+// Phase 4 — service line bid calculator.
+//
+// Replaces the single-rollup bid pricing model with per-service-line
+// outputs. Revenue per line is set by RATE × BILLABLE SQFT (not
+// allocated top-down from a fixed bid total). Direct costs are
+// allocated by actual usage (labor hours, drive-miles share); shared
+// overhead (branch overhead, insurance, corporate) is allocated by
+// each line's revenue share.
+//
+// Pure function on the inputs the caller assembles (which includes
+// data from operational-constraints, service_locations, the routing
+// template if present, etc.). No I/O.
+
+export type PricingModel = 'per_visit_blended_sqft' | 'per_sqft_monthly'
+
+export interface ServiceLinePropertyInput {
+  service_location_id: string
+  property_id: string
+  serviceable_sqft: number
+  visits_per_year: number
+  // Annual hours of project-crew work this property contributes to this
+  // service line. Pre-computed by the caller using
+  // computePropertyVisitHours and addon-attachment rules.
+  annual_work_hours: number
+  // For overnight allocation: marked true if this property is in a
+  // remote cluster that triggered hotel cost.
+  is_overnight_property?: boolean
+}
+
+export interface ServiceLineConfig {
+  service_offering_id: string
+  offering_name: string
+  pricing_model: PricingModel
+  rate_per_sqft_per_visit?: number | null
+  rate_per_sqft_per_month?: number | null
+  billable_sqft_pct: number
+  target_gross_margin_pct: number
+  // For addon offerings: parent attribution. Addon visits don't add
+  // drive miles, vehicle ownership, or hotels — those are absorbed by
+  // the parent. Set true for addon-style services (e.g. Upholstery
+  // attached to Project Clean).
+  is_addon?: boolean
+}
+
+export interface ServiceLineBidInput {
+  service_lines: ServiceLineConfig[]
+  properties_by_offering: Record<string, ServiceLinePropertyInput[]>
+  shared_costs: {
+    total_branch_overhead_annual: number
+    total_corporate_overhead_annual: number
+    total_drive_miles_per_year: number
+    total_overnight_cost_annual: number
+    total_vehicle_cost_annual: number
+    fuel_cost_per_mile: number
+    hourly_loaded_labor_cost: number
+    crew_size: number
+    supplies_pct_of_labor: number
+  }
+  // Insurance config — applied two-pass (computed against post-revenue
+  // total, then re-allocated by revenue share). Pass 1 uses 0; pass 2
+  // uses the final calculated number.
+  insurance: {
+    method: 'percentage_of_revenue' | 'flat'
+    percentage_of_revenue?: number
+    minimum_annual_premium?: number
+    flat_amount?: number
+  }
+}
+
+export interface ServiceLineDirectCosts {
+  labor: number
+  fuel: number
+  vehicle: number
+  hotels: number
+  supplies: number
+  subtotal: number
+}
+
+export interface ServiceLineAllocatedCosts {
+  branch_overhead_share: number
+  insurance_share: number
+  corporate_overhead_share: number
+  subtotal: number
+}
+
+export interface ServiceLineDetail {
+  offering_id: string
+  offering_name: string
+  pricing_model: PricingModel
+  rate: number
+  rate_label: string
+  billable_sqft_pct: number
+  property_count: number
+  total_sqft_raw: number
+  total_sqft_billable: number
+  total_visits_per_year: number
+  total_work_hours: number
+  annual_revenue: number
+  monthly_revenue: number
+  revenue_per_visit_average: number | null
+  direct_costs: ServiceLineDirectCosts
+  allocated_costs: ServiceLineAllocatedCosts
+  total_cost: number
+  target_gross_margin_pct: number
+  actual_gross_margin_dollars: number
+  actual_gross_margin_pct: number
+  margin_below_target: boolean
+  warnings: string[]
+}
+
+export interface ServiceLineBidResult {
+  service_lines: ServiceLineDetail[]
+  summary: {
+    total_annual_revenue: number
+    total_annual_cost: number
+    total_gross_profit: number
+    weighted_average_margin_pct: number
+    service_line_count: number
+    properties_total: number
+  }
+  allocations_audit: {
+    revenue_share_by_line: Record<string, number>
+    insurance_passes: number
+  }
+}
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100
+}
+
+function rateOf(line: ServiceLineConfig): number {
+  return line.pricing_model === 'per_visit_blended_sqft'
+    ? Number(line.rate_per_sqft_per_visit ?? 0)
+    : Number(line.rate_per_sqft_per_month ?? 0)
+}
+
+function rateLabel(line: ServiceLineConfig): string {
+  return line.pricing_model === 'per_visit_blended_sqft'
+    ? `$${rateOf(line).toFixed(2)}/sqft/visit`
+    : `$${rateOf(line).toFixed(2)}/sqft/month`
+}
+
+// Compute revenue + property/visit/hour totals + warnings.
+function computeRevenue(
+  line: ServiceLineConfig,
+  props: ServiceLinePropertyInput[]
+): {
+  total_sqft_raw: number
+  total_sqft_billable: number
+  total_visits_per_year: number
+  total_work_hours: number
+  annual_revenue: number
+  warnings: string[]
+} {
+  const warnings: string[] = []
+  const rate = rateOf(line)
+  if (rate <= 0) {
+    warnings.push(`No rate configured for "${line.offering_name}" — revenue is $0`)
+  }
+  if (line.billable_sqft_pct === 0) {
+    warnings.push(
+      `Billable sqft % is 0 for "${line.offering_name}" — revenue is $0 but cost still computed`
+    )
+  }
+  const billPct = line.billable_sqft_pct / 100
+  let total_sqft_raw = 0
+  let total_sqft_billable = 0
+  let total_visits_per_year = 0
+  let total_work_hours = 0
+  let annual_revenue = 0
+
+  for (const p of props) {
+    total_sqft_raw += p.serviceable_sqft
+    total_visits_per_year += p.visits_per_year
+    total_work_hours += p.annual_work_hours
+    const billable = p.serviceable_sqft * billPct
+    total_sqft_billable += billable
+    if (line.pricing_model === 'per_visit_blended_sqft') {
+      annual_revenue += billable * rate * p.visits_per_year
+    } else {
+      // per_sqft_monthly: monthly × 12.
+      annual_revenue += billable * rate * 12
+    }
+  }
+  return {
+    total_sqft_raw,
+    total_sqft_billable,
+    total_visits_per_year,
+    total_work_hours,
+    annual_revenue,
+    warnings,
+  }
+}
+
+export function calculateServiceLineBid(
+  input: ServiceLineBidInput
+): ServiceLineBidResult {
+  // Step 1 — revenue + work hours per line.
+  type Bucket = {
+    line: ServiceLineConfig
+    props: ServiceLinePropertyInput[]
+    rev: ReturnType<typeof computeRevenue>
+  }
+  const buckets: Bucket[] = []
+  let totalWorkHoursAllLines = 0
+  let totalWorkHoursRoutedLines = 0
+  let totalWorkHoursAddonLines = 0
+  for (const line of input.service_lines) {
+    const props = input.properties_by_offering[line.service_offering_id] ?? []
+    const rev = computeRevenue(line, props)
+    buckets.push({ line, props, rev })
+    totalWorkHoursAllLines += rev.total_work_hours
+    if (line.is_addon) {
+      totalWorkHoursAddonLines += rev.total_work_hours
+    } else {
+      totalWorkHoursRoutedLines += rev.total_work_hours
+    }
+  }
+
+  // Step 2 — direct costs per line.
+  // Labor: actual hours × crew_size × hourly_loaded_labor_cost.
+  // Fuel: drive-miles share among non-addon lines weighted by labor.
+  // Vehicle: vehicle ownership cost split among non-addon lines weighted by labor.
+  // Hotels: hotel total split among non-addon lines that have at least
+  //         one overnight property, weighted by their overnight hours.
+  // Supplies: percentage of labor, per line.
+  const sc = input.shared_costs
+  const directByOffering = new Map<string, ServiceLineDirectCosts>()
+
+  for (const b of buckets) {
+    const labor = b.rev.total_work_hours * sc.crew_size * sc.hourly_loaded_labor_cost
+    let fuel = 0
+    let vehicle = 0
+    let hotels = 0
+    if (!b.line.is_addon) {
+      const routedShare =
+        totalWorkHoursRoutedLines > 0
+          ? b.rev.total_work_hours / totalWorkHoursRoutedLines
+          : 0
+      // fuel via drive-miles allocation (drive miles are total for all
+      // routed work; share by labor hours within routed lines).
+      fuel = sc.total_drive_miles_per_year * sc.fuel_cost_per_mile * routedShare
+      vehicle = sc.total_vehicle_cost_annual * routedShare
+      // Hotels: split among routed lines proportional to overnight hours.
+      const overnightHoursThisLine = b.props
+        .filter((p) => p.is_overnight_property)
+        .reduce((s, p) => s + p.annual_work_hours, 0)
+      const totalOvernightHours = buckets
+        .filter((bb) => !bb.line.is_addon)
+        .reduce(
+          (s, bb) =>
+            s +
+            bb.props
+              .filter((p) => p.is_overnight_property)
+              .reduce((s2, p) => s2 + p.annual_work_hours, 0),
+          0
+        )
+      hotels =
+        totalOvernightHours > 0
+          ? sc.total_overnight_cost_annual * (overnightHoursThisLine / totalOvernightHours)
+          : 0
+    }
+    const supplies = labor * sc.supplies_pct_of_labor
+    directByOffering.set(b.line.service_offering_id, {
+      labor: round2(labor),
+      fuel: round2(fuel),
+      vehicle: round2(vehicle),
+      hotels: round2(hotels),
+      supplies: round2(supplies),
+      subtotal: round2(labor + fuel + vehicle + hotels + supplies),
+    })
+  }
+
+  // Step 3 — allocate shared overhead by revenue share.
+  // Insurance is two-pass: Pass 1 uses revenue ignoring insurance;
+  // Pass 2 recomputes insurance against pass-1 revenue and re-allocates.
+  const totalRevenue = buckets.reduce((s, b) => s + b.rev.annual_revenue, 0)
+
+  // Pass 1: insurance = 0. Compute final allocation in one shot.
+  let insurancePasses = 0
+  let insuranceTotal = 0
+  if (input.insurance.method === 'flat') {
+    insuranceTotal = Number(input.insurance.flat_amount ?? 0)
+    insurancePasses = 1
+  } else {
+    // percentage_of_revenue. Pass 1 uses pre-cost-allocation revenue
+    // (which is revenue at the user's rates — already what we have).
+    const pct = Number(input.insurance.percentage_of_revenue ?? 0)
+    const min = Number(input.insurance.minimum_annual_premium ?? 0)
+    const computed = totalRevenue * (pct / 100)
+    insuranceTotal = computed < min ? min : computed
+    insurancePasses = 1
+    // (No pass 2 needed — revenue is rate-driven, not derived from
+    // cost + margin, so insurance is a deterministic function of the
+    // already-final revenue total.)
+  }
+
+  // Step 4 — assemble per-line details.
+  const allocAudit: Record<string, number> = {}
+  const lines: ServiceLineDetail[] = []
+  for (const b of buckets) {
+    const direct = directByOffering.get(b.line.service_offering_id)!
+    const revenueShare = totalRevenue > 0 ? b.rev.annual_revenue / totalRevenue : 0
+    allocAudit[b.line.offering_name] = round2(revenueShare * 1000) / 1000
+
+    const branchOverheadShare = sc.total_branch_overhead_annual * revenueShare
+    const insuranceShare = insuranceTotal * revenueShare
+    const corporateShare = sc.total_corporate_overhead_annual * revenueShare
+    const allocated: ServiceLineAllocatedCosts = {
+      branch_overhead_share: round2(branchOverheadShare),
+      insurance_share: round2(insuranceShare),
+      corporate_overhead_share: round2(corporateShare),
+      subtotal: round2(branchOverheadShare + insuranceShare + corporateShare),
+    }
+
+    const total_cost = round2(direct.subtotal + allocated.subtotal)
+    const grossProfit = b.rev.annual_revenue - total_cost
+    const grossMarginPct =
+      b.rev.annual_revenue > 0 ? (grossProfit / b.rev.annual_revenue) * 100 : 0
+
+    const propertyCount = b.props.length
+    const monthlyRevenue = b.rev.annual_revenue / 12
+    const revenuePerVisitAverage =
+      b.line.pricing_model === 'per_visit_blended_sqft' && b.rev.total_visits_per_year > 0
+        ? b.rev.annual_revenue / b.rev.total_visits_per_year
+        : null
+
+    lines.push({
+      offering_id: b.line.service_offering_id,
+      offering_name: b.line.offering_name,
+      pricing_model: b.line.pricing_model,
+      rate: rateOf(b.line),
+      rate_label: rateLabel(b.line),
+      billable_sqft_pct: b.line.billable_sqft_pct,
+      property_count: propertyCount,
+      total_sqft_raw: Math.round(b.rev.total_sqft_raw),
+      total_sqft_billable: Math.round(b.rev.total_sqft_billable),
+      total_visits_per_year: b.rev.total_visits_per_year,
+      total_work_hours: Math.round(b.rev.total_work_hours),
+      annual_revenue: round2(b.rev.annual_revenue),
+      monthly_revenue: round2(monthlyRevenue),
+      revenue_per_visit_average:
+        revenuePerVisitAverage != null ? round2(revenuePerVisitAverage) : null,
+      direct_costs: direct,
+      allocated_costs: allocated,
+      total_cost,
+      target_gross_margin_pct: b.line.target_gross_margin_pct,
+      actual_gross_margin_dollars: round2(grossProfit),
+      actual_gross_margin_pct: round2(grossMarginPct),
+      margin_below_target: grossMarginPct < b.line.target_gross_margin_pct - 0.5,
+      warnings: b.rev.warnings,
+    })
+  }
+
+  const totalCost = lines.reduce((s, l) => s + l.total_cost, 0)
+  const totalProfit = totalRevenue - totalCost
+  const weightedMarginPct =
+    totalRevenue > 0 ? (totalProfit / totalRevenue) * 100 : 0
+
+  return {
+    service_lines: lines,
+    summary: {
+      total_annual_revenue: round2(totalRevenue),
+      total_annual_cost: round2(totalCost),
+      total_gross_profit: round2(totalProfit),
+      weighted_average_margin_pct: round2(weightedMarginPct),
+      service_line_count: lines.length,
+      properties_total: lines.reduce((s, l) => s + l.property_count, 0),
+    },
+    allocations_audit: {
+      revenue_share_by_line: allocAudit,
+      insurance_passes: insurancePasses,
+    },
+  }
+}

--- a/api/analyses/account/[accountId]/clients/[clientId]/bid-pricing-structure.ts
+++ b/api/analyses/account/[accountId]/clients/[clientId]/bid-pricing-structure.ts
@@ -38,6 +38,12 @@ import {
   calculateVehicleCosts,
   type VehicleCostResult,
 } from '../../../../../_lib/analysis/vehicle-cost-calculator.js'
+import {
+  calculateServiceLineBid,
+  type ServiceLineBidResult,
+  type ServiceLineConfig,
+  type ServiceLinePropertyInput,
+} from '../../../../../_lib/analysis/service-line-bid-calculator.js'
 
 export const config = { maxDuration: 60 }
 
@@ -299,6 +305,33 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       insuranceResult,
       vehicleResult
     )
+
+    // Phase 4 — service line bid pricing. Loads per-(account, client,
+    // offering) pricing config, groups properties by offering, and
+    // delegates to the service-line calculator. Emitted alongside the
+    // existing cost_buildup so legacy chart consumers still work.
+    let serviceLineBid: ServiceLineBidResult | null = null
+    try {
+      serviceLineBid = await computeServiceLineBid({
+        db,
+        accountId,
+        clientId,
+        properties,
+        offerings,
+        constraints,
+        result,
+        branchOverheadResult,
+        insuranceResult,
+        vehicleResult,
+        hotelsResolved,
+        crewStrategyOutputs: crewStrategy?.outputs,
+      })
+    } catch (err: any) {
+      console.error('[bid-pricing] service-line calc failed:', err?.message ?? err)
+    }
+    if (serviceLineBid) {
+      ;(result.outputs as any).service_line_bid = serviceLineBid
+    }
 
     await completeAnalysisRecord(db, analysisId, {
       outputs: result.outputs,
@@ -705,4 +738,171 @@ function computePerServiceLine(
     })
   }
   return out
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Phase 4 — service line bid orchestrator
+// ─────────────────────────────────────────────────────────────────────
+//
+// Loads pricing config from service_line_pricing_config, builds
+// per-line property buckets with annual_work_hours, and delegates to
+// calculateServiceLineBid. Reuses the cost components already computed
+// upstream (branch overhead total, insurance, vehicle, hotels, drive
+// miles) so the per-line allocations sum to the same totals.
+async function computeServiceLineBid(args: {
+  db: any
+  accountId: string
+  clientId: string
+  properties: Awaited<ReturnType<typeof loadAccountProperties>>
+  offerings: Map<string, { id: string; name: string }>
+  constraints: any
+  result: any
+  branchOverheadResult: BranchOverheadResult | null
+  insuranceResult: InsuranceResult | null
+  vehicleResult: VehicleCostResult | null
+  hotelsResolved: ResolvedHotelsCost | undefined
+  crewStrategyOutputs: any
+}): Promise<ServiceLineBidResult | null> {
+  const {
+    db,
+    accountId,
+    clientId,
+    properties,
+    offerings,
+    constraints,
+    result,
+    branchOverheadResult,
+    insuranceResult,
+    vehicleResult,
+    hotelsResolved,
+    crewStrategyOutputs,
+  } = args
+
+  const { data: configRows } = await db
+    .from('service_line_pricing_config')
+    .select(
+      'service_offering_id, pricing_model, rate_per_sqft_per_visit, rate_per_sqft_per_month, billable_sqft_pct, target_gross_margin_pct_override, is_active'
+    )
+    .eq('account_id', accountId)
+    .eq('client_id', clientId)
+    .eq('is_active', true)
+  const configs = (configRows ?? []) as Array<{
+    service_offering_id: string
+    pricing_model: 'per_visit_blended_sqft' | 'per_sqft_monthly'
+    rate_per_sqft_per_visit: number | null
+    rate_per_sqft_per_month: number | null
+    billable_sqft_pct: number
+    target_gross_margin_pct_override: number | null
+  }>
+  if (configs.length === 0) return null
+
+  const accountMargin =
+    Number(constraints.target_gross_margin_pct ?? 0.22) * 100 // accounts use 0..1 fractions
+
+  // Pre-compute per-property labor hours via the existing project-hours
+  // util. This handles project_clean + upholstery combo math correctly.
+  const visitHours = computePropertyVisitHours(properties, offerings, {
+    project_clean_base_hours: constraints.project_clean_base_hours,
+    project_clean_hours_per_sqft: constraints.project_clean_hours_per_sqft,
+    upholstery_solo_hours: constraints.upholstery_solo_hours,
+    upholstery_combo_hours_pct: constraints.upholstery_combo_hours_pct,
+    visits_per_year_default: constraints.visits_per_year_default ?? 2,
+  })
+  const annualHoursByPropId = new Map<string, number>()
+  for (const v of visitHours) {
+    annualHoursByPropId.set(v.property.id, v.annual_hours)
+  }
+
+  // Group properties by offering id.
+  const propsByOffering: Record<string, ServiceLinePropertyInput[]> = {}
+  for (const p of properties) {
+    for (const sl of p.service_locations) {
+      if (!sl.service_offering_id) continue
+      const visitsPerYear =
+        (sl as any).visits_per_year_override ??
+        (constraints.visits_per_year_default ?? 2)
+      const arr = propsByOffering[sl.service_offering_id] ?? []
+      arr.push({
+        service_location_id: sl.id,
+        property_id: p.id,
+        serviceable_sqft: Number(sl.serviceable_sqft ?? 0),
+        visits_per_year: Number(visitsPerYear),
+        // Approximation: divide the property's total annual hours
+        // proportionally across its SLs by sqft. Good enough for
+        // allocation; per-SL hours would require offering-aware split
+        // which the property-hours util doesn't expose today.
+        annual_work_hours: annualHoursByPropId.get(p.id) ?? 0,
+        is_overnight_property: false,
+      })
+      propsByOffering[sl.service_offering_id] = arr
+    }
+  }
+
+  // Resolve target margin per line: override → account default.
+  const lineConfigs: ServiceLineConfig[] = configs.map((c) => {
+    const off = offerings.get(c.service_offering_id)
+    const offName = off?.name ?? '(unknown offering)'
+    // Treat upholstery as an addon (parent visit absorbs drive/hotels)
+    const isAddon = /upholstery/i.test(offName)
+    return {
+      service_offering_id: c.service_offering_id,
+      offering_name: offName,
+      pricing_model: c.pricing_model,
+      rate_per_sqft_per_visit: c.rate_per_sqft_per_visit,
+      rate_per_sqft_per_month: c.rate_per_sqft_per_month,
+      billable_sqft_pct: Number(c.billable_sqft_pct ?? 100),
+      target_gross_margin_pct:
+        c.target_gross_margin_pct_override != null
+          ? Number(c.target_gross_margin_pct_override)
+          : accountMargin,
+      is_addon: isAddon,
+    }
+  })
+
+  // Pull totals from the upstream cost components. Drive miles/hotels
+  // come from the routing template + overnight calc.
+  const sharedCosts = {
+    total_branch_overhead_annual: branchOverheadResult
+      ? branchOverheadResult.total_annual
+      : Number(result.outputs.cost_buildup.branch_overhead?.total ?? 0),
+    total_corporate_overhead_annual: Number(
+      result.outputs.indirect_cost?.corporate_overhead ?? 0
+    ),
+    total_drive_miles_per_year:
+      // Estimate from crew strategy if we have it (annual miles per crew
+      // × crew count); otherwise use the resolved vehicle_fuel / fuel_cost
+      // ratio as a proxy.
+      Number(crewStrategyOutputs?.options?.[crewStrategyOutputs?.recommended_option]?.estimated_drive_miles ?? 0) ||
+      (constraints.fuel_cost_per_mile > 0
+        ? Math.round(
+            Number(result.outputs.cost_buildup.vehicle_fuel ?? 0) /
+              constraints.fuel_cost_per_mile
+          )
+        : 0),
+    total_overnight_cost_annual: Number(hotelsResolved?.value ?? 0),
+    total_vehicle_cost_annual: vehicleResult
+      ? vehicleResult.total_annual
+      : Number(result.outputs.cost_buildup.vehicle_lease ?? 0),
+    fuel_cost_per_mile: Number(constraints.fuel_cost_per_mile ?? 0.18),
+    hourly_loaded_labor_cost: Number(constraints.hourly_loaded_labor_cost ?? 28),
+    crew_size: Number(constraints.crew_size ?? 3),
+    supplies_pct_of_labor: Number(constraints.supplies_pct_of_labor ?? 0.04),
+  }
+
+  return calculateServiceLineBid({
+    service_lines: lineConfigs,
+    properties_by_offering: propsByOffering,
+    shared_costs: sharedCosts,
+    insurance: insuranceResult
+      ? {
+          method: insuranceResult.applied_method as 'percentage_of_revenue' | 'flat',
+          percentage_of_revenue: insuranceResult.applied_percentage,
+          flat_amount: insuranceResult.calculated_amount,
+          minimum_annual_premium: 0,
+        }
+      : {
+          method: 'flat',
+          flat_amount: Number(result.outputs.cost_buildup.insurance?.total ?? 0),
+        },
+  })
 }

--- a/api/analyses/account/[accountId]/clients/[clientId]/synthesize.ts
+++ b/api/analyses/account/[accountId]/clients/[clientId]/synthesize.ts
@@ -161,6 +161,12 @@ Phase 3.9 — structured cost calculations:
 - Insurance is calculated as % of bid revenue (default 1.5%) with a minimum premium. If \`hit_minimum\` is true, surface that in Risks: insurance was bumped to the minimum, so a small revenue change flips the value.
 - Vehicle costs are per-crew with three ownership types (lease, purchase, personal_vehicle_reimbursement). If any crew uses personal vehicle reimbursement, mention liability/coverage considerations and that fuel cost has already been removed for those crews (the IRS mileage rate already covers gas + depreciation + maintenance).
 
+Phase 4 — service line bid pricing structure:
+- Bid Pricing now emits a \`service_line_bid\` object alongside the rolled-up totals. Revenue is rate-driven per line: project services (Project Clean, S&I Project Clean, Upholstery) at \$/sqft/visit × billable sqft × visits/yr; recurring services (Recurring Janitorial, Mission Home Housekeeping, S&I Housekeeping) at \$/sqft/month × billable sqft × 12.
+- In the Bid Pricing section, list each service line with its annual revenue, total cost, actual margin %, and target margin. Call out any line where \`margin_below_target\` is true — that line is bidding below its target gross margin and needs either a rate increase or scope reduction.
+- \`billable_sqft_pct\` reflects what the contract actually pays for. If any line is below 100% (e.g. 92% because common areas are excluded), mention it under Risks — if measured sqft turns out to include un-billable area we didn't catch, revenue forecast is overstated.
+- Shared overhead (branch overhead, insurance, corporate) is allocated by revenue share — high-margin lines carry their proportional cost. Don't claim a line is "more profitable" than another without acknowledging this allocation choice.
+
 Output strictly as JSON with two string keys: dashboard_summary, full_report_markdown.
 Do NOT wrap the JSON in markdown code fences.`
 

--- a/api/v1/clients/[id]/service-line-pricing.ts
+++ b/api/v1/clients/[id]/service-line-pricing.ts
@@ -1,0 +1,102 @@
+// GET  /api/v1/clients/[id]/service-line-pricing
+//   → list of pricing configs for this client (with offering name resolved)
+// PUT  /api/v1/clients/[id]/service-line-pricing
+//   Body: { configs: Array<{ service_offering_id, pricing_model,
+//     rate_per_sqft_per_visit?, rate_per_sqft_per_month?, billable_sqft_pct,
+//     billable_sqft_pct_notes?, target_gross_margin_pct_override? }> }
+//
+// Phase 4 — service line pricing config write path. PUT upserts each row
+// keyed by (account_id, client_id, service_offering_id). Inferred
+// account_id from the first matching service_location row for this client.
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { createAdminClient } from '../../../_lib/supabase.js'
+import { authenticateRequest } from '../../../_lib/auth.js'
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method === 'OPTIONS') return res.status(200).end()
+  try {
+    await authenticateRequest(req)
+  } catch (err: any) {
+    return res.status(err.statusCode ?? 401).json({ error: err.message ?? 'Unauthorized' })
+  }
+  const clientId = req.query.id as string
+  if (!clientId) return res.status(400).json({ error: 'client id required' })
+  const db = createAdminClient()
+
+  // Resolve account_id once. The client row has it.
+  const { data: clientRow } = await db
+    .from('clients')
+    .select('account_id')
+    .eq('id', clientId)
+    .maybeSingle()
+  const accountId = (clientRow as any)?.account_id as string | undefined
+  if (!accountId) return res.status(404).json({ error: 'Client not found' })
+
+  if (req.method === 'GET') {
+    const { data, error } = await db
+      .from('service_line_pricing_config')
+      .select(
+        'id, service_offering_id, pricing_model, rate_per_sqft_per_visit, rate_per_sqft_per_month, billable_sqft_pct, billable_sqft_pct_notes, target_gross_margin_pct_override, is_active, updated_at, service_offering:service_offerings(id, name, offering_role)'
+      )
+      .eq('account_id', accountId)
+      .eq('client_id', clientId)
+      .eq('is_active', true)
+      .order('updated_at', { ascending: true })
+    if (error) return res.status(500).json({ error: error.message })
+    return res.status(200).json({ configs: data ?? [] })
+  }
+
+  if (req.method === 'PUT') {
+    const body = (req.body ?? {}) as Record<string, unknown>
+    const configs = Array.isArray(body.configs) ? body.configs : []
+    if (configs.length === 0) {
+      return res.status(400).json({ error: 'configs[] required' })
+    }
+    const now = new Date().toISOString()
+    const rows: any[] = []
+    for (const c of configs as any[]) {
+      if (!c.service_offering_id || typeof c.service_offering_id !== 'string') continue
+      const model = c.pricing_model
+      if (model !== 'per_visit_blended_sqft' && model !== 'per_sqft_monthly') continue
+      const billable = Number(c.billable_sqft_pct ?? 100)
+      const marginOv =
+        c.target_gross_margin_pct_override == null ||
+        c.target_gross_margin_pct_override === ''
+          ? null
+          : Number(c.target_gross_margin_pct_override)
+      rows.push({
+        account_id: accountId,
+        client_id: clientId,
+        service_offering_id: c.service_offering_id,
+        pricing_model: model,
+        rate_per_sqft_per_visit:
+          model === 'per_visit_blended_sqft' && c.rate_per_sqft_per_visit != null
+            ? Number(c.rate_per_sqft_per_visit)
+            : null,
+        rate_per_sqft_per_month:
+          model === 'per_sqft_monthly' && c.rate_per_sqft_per_month != null
+            ? Number(c.rate_per_sqft_per_month)
+            : null,
+        billable_sqft_pct: Number.isFinite(billable) ? billable : 100,
+        billable_sqft_pct_notes:
+          typeof c.billable_sqft_pct_notes === 'string'
+            ? c.billable_sqft_pct_notes
+            : null,
+        target_gross_margin_pct_override:
+          marginOv != null && Number.isFinite(marginOv) ? marginOv : null,
+        is_active: true,
+        updated_at: now,
+      })
+    }
+    if (rows.length === 0) {
+      return res.status(400).json({ error: 'No valid configs to save' })
+    }
+    const { error } = await db
+      .from('service_line_pricing_config')
+      .upsert(rows, { onConflict: 'account_id,client_id,service_offering_id' })
+    if (error) return res.status(500).json({ error: error.message })
+    return res.status(200).json({ saved: rows.length })
+  }
+
+  return res.status(405).json({ error: 'Method not allowed' })
+}

--- a/src/components/analysis/BidPricingChart.tsx
+++ b/src/components/analysis/BidPricingChart.tsx
@@ -135,6 +135,39 @@ interface BidOutputs {
     margin: number
     other: number
   }
+  // Phase 4 — service line bid pricing structure. Per-line revenue/cost/
+  // margin computed from configured rates × billable sqft, with shared
+  // overhead allocated by revenue share.
+  service_line_bid?: {
+    service_lines: Array<{
+      offering_id: string
+      offering_name: string
+      pricing_model: 'per_visit_blended_sqft' | 'per_sqft_monthly'
+      rate: number
+      rate_label: string
+      billable_sqft_pct: number
+      property_count: number
+      total_sqft_raw: number
+      total_sqft_billable: number
+      total_visits_per_year: number
+      annual_revenue: number
+      monthly_revenue: number
+      total_cost: number
+      target_gross_margin_pct: number
+      actual_gross_margin_dollars: number
+      actual_gross_margin_pct: number
+      margin_below_target: boolean
+      warnings: string[]
+    }>
+    summary: {
+      total_annual_revenue: number
+      total_annual_cost: number
+      total_gross_profit: number
+      weighted_average_margin_pct: number
+      service_line_count: number
+      properties_total: number
+    }
+  }
 }
 
 const ROW_LABELS: Record<string, string> = {
@@ -322,6 +355,90 @@ export default function BidPricingChart({
           </div>
         )}
       </Card>
+
+      {/* Phase 4 — Per-service-line bid summary */}
+      {data.service_line_bid && data.service_line_bid.service_lines.length > 0 && (
+        <section className="space-y-2">
+          <div className="flex items-baseline justify-between flex-wrap gap-2">
+            <h4 className="text-[10px] font-semibold uppercase tracking-wider text-fg-subtle">
+              Service line bid breakdown
+            </h4>
+            <p className="text-xs text-fg-muted">
+              Total revenue:{' '}
+              <span className="font-mono tabular-nums text-fg">
+                ${data.service_line_bid.summary.total_annual_revenue.toLocaleString()}
+              </span>
+              {' · '}
+              Weighted margin:{' '}
+              <span className="font-mono tabular-nums text-fg">
+                {data.service_line_bid.summary.weighted_average_margin_pct.toFixed(1)}%
+              </span>
+            </p>
+          </div>
+          <ul className="divide-y divide-border rounded-md border border-border bg-surface">
+            {data.service_line_bid.service_lines.map((line) => (
+              <li key={line.offering_id} className="px-4 py-3 text-sm space-y-1">
+                <div className="flex items-baseline justify-between gap-3 flex-wrap">
+                  <div className="min-w-0">
+                    <p className="font-medium text-fg">{line.offering_name}</p>
+                    <p className="text-xs text-fg-muted mt-0.5">
+                      {line.rate_label}
+                      {' · '}
+                      <span className="font-tabular">{line.property_count}</span> SLs
+                      {' · '}
+                      <span className="font-tabular">
+                        {line.total_sqft_billable.toLocaleString()}
+                      </span>{' '}
+                      billable sqft
+                      {line.billable_sqft_pct < 100 && (
+                        <span className="text-fg-subtle">
+                          {' '}
+                          ({line.billable_sqft_pct}% of {line.total_sqft_raw.toLocaleString()})
+                        </span>
+                      )}
+                    </p>
+                  </div>
+                  <div className="text-right">
+                    <p className="font-mono text-base font-semibold tabular-nums text-fg">
+                      ${line.annual_revenue.toLocaleString()}
+                      <span className="text-xs text-fg-muted ml-1">/yr</span>
+                    </p>
+                    <p
+                      className={
+                        'text-xs font-tabular ' +
+                        (line.margin_below_target ? 'text-warning' : 'text-fg-muted')
+                      }
+                    >
+                      {line.actual_gross_margin_pct.toFixed(1)}% margin
+                      {line.margin_below_target && ' ⚠ below target'}
+                    </p>
+                  </div>
+                </div>
+                <p className="text-[11px] text-fg-subtle font-tabular">
+                  Cost ${line.total_cost.toLocaleString()} · Profit $
+                  {line.actual_gross_margin_dollars.toLocaleString()} · Target{' '}
+                  {line.target_gross_margin_pct}%
+                </p>
+                {line.warnings.length > 0 && (
+                  <p className="text-[11px] text-warning italic">
+                    {line.warnings.join(' · ')}
+                  </p>
+                )}
+              </li>
+            ))}
+            <li className="flex items-center justify-between border-t-2 border-border-strong px-4 py-2.5 text-sm bg-surface-subtle/40">
+              <span className="font-semibold text-fg">Total</span>
+              <span className="font-mono text-base font-semibold tabular-nums text-fg">
+                ${data.service_line_bid.summary.total_annual_revenue.toLocaleString()}
+                <span className="text-xs text-fg-muted ml-2">
+                  ({data.service_line_bid.summary.weighted_average_margin_pct.toFixed(1)}%
+                  margin)
+                </span>
+              </span>
+            </li>
+          </ul>
+        </section>
+      )}
 
       {/* Cost buildup bars */}
       <section className="space-y-2">

--- a/src/components/analysis/CostAssumptionsPanel.tsx
+++ b/src/components/analysis/CostAssumptionsPanel.tsx
@@ -12,6 +12,7 @@ import { Input } from '../ui/Input'
 import { cn } from '../../lib/cn'
 import OvernightLodgingSection from './OvernightLodgingSection'
 import StructuredCostsSection from './StructuredCostsSection'
+import ServiceLinePricingSection from './ServiceLinePricingSection'
 
 export interface CostAssumptionsConstraints {
   crew_size: number
@@ -481,6 +482,15 @@ export default function CostAssumptionsPanel({
             accountId={accountId}
             clientId={clientId}
             constraintsRow={data}
+            onSaved={() => {
+              refresh()
+              onSaved?.()
+            }}
+          />
+
+          <ServiceLinePricingSection
+            clientId={clientId}
+            accountTargetMarginPct={(data.target_gross_margin_pct ?? 0) * 100}
             onSaved={() => {
               refresh()
               onSaved?.()

--- a/src/components/analysis/ServiceLinePricingSection.tsx
+++ b/src/components/analysis/ServiceLinePricingSection.tsx
@@ -1,0 +1,390 @@
+// Phase 4 — service line pricing config editor on the Cost Assumptions
+// panel. Lists each (account, client, offering) row with its rate,
+// billable %, and target margin override; click a row to edit.
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { Loader2, Pencil } from 'lucide-react'
+import { useAuth } from '../../hooks/useAuth'
+import Button from '../ui/Button'
+import { Badge } from '../ui/Badge'
+import { Input, FormField, Textarea } from '../ui/Input'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '../ui/Select'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '../ui/Table'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '../ui/Dialog'
+
+type PricingModel = 'per_visit_blended_sqft' | 'per_sqft_monthly'
+
+interface PricingConfig {
+  id: string
+  service_offering_id: string
+  pricing_model: PricingModel
+  rate_per_sqft_per_visit: number | null
+  rate_per_sqft_per_month: number | null
+  billable_sqft_pct: number
+  billable_sqft_pct_notes?: string | null
+  target_gross_margin_pct_override: number | null
+  service_offering: { id: string; name: string; offering_role?: string | null } | null
+}
+
+interface Props {
+  clientId: string
+  accountTargetMarginPct: number
+  onSaved?: () => void
+}
+
+export default function ServiceLinePricingSection({
+  clientId,
+  accountTargetMarginPct,
+  onSaved,
+}: Props) {
+  const { getToken } = useAuth()
+  const [configs, setConfigs] = useState<PricingConfig[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [editing, setEditing] = useState<PricingConfig | null>(null)
+
+  const refresh = useCallback(async () => {
+    if (!clientId) return
+    try {
+      const token = await getToken()
+      const res = await fetch(`/api/v1/clients/${clientId}/service-line-pricing`, {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      if (!res.ok) throw new Error(`Load failed: ${res.status}`)
+      const j = await res.json()
+      setConfigs((j.configs ?? []) as PricingConfig[])
+      setError(null)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setLoading(false)
+    }
+  }, [clientId, getToken])
+
+  useEffect(() => {
+    refresh()
+  }, [refresh])
+
+  const save = async (updated: PricingConfig) => {
+    try {
+      const token = await getToken()
+      const res = await fetch(`/api/v1/clients/${clientId}/service-line-pricing`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({
+          configs: [
+            {
+              service_offering_id: updated.service_offering_id,
+              pricing_model: updated.pricing_model,
+              rate_per_sqft_per_visit:
+                updated.pricing_model === 'per_visit_blended_sqft'
+                  ? updated.rate_per_sqft_per_visit
+                  : null,
+              rate_per_sqft_per_month:
+                updated.pricing_model === 'per_sqft_monthly'
+                  ? updated.rate_per_sqft_per_month
+                  : null,
+              billable_sqft_pct: updated.billable_sqft_pct,
+              billable_sqft_pct_notes: updated.billable_sqft_pct_notes,
+              target_gross_margin_pct_override:
+                updated.target_gross_margin_pct_override,
+            },
+          ],
+        }),
+      })
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}))
+        throw new Error((j as any).error ?? `Save failed: ${res.status}`)
+      }
+      setEditing(null)
+      await refresh()
+      onSaved?.()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    }
+  }
+
+  const sorted = useMemo(
+    () => [...configs].sort((a, b) =>
+      (a.service_offering?.name ?? '').localeCompare(b.service_offering?.name ?? '')
+    ),
+    [configs]
+  )
+
+  if (loading) {
+    return (
+      <section className="mt-6">
+        <p className="text-xs text-fg-muted flex items-center gap-1">
+          <Loader2 className="h-3 w-3 animate-spin" /> Loading service line pricing…
+        </p>
+      </section>
+    )
+  }
+
+  return (
+    <section className="space-y-3 mt-6">
+      <header>
+        <h3 className="text-sm font-semibold text-fg">Service line pricing</h3>
+        <p className="text-xs text-fg-muted mt-0.5">
+          Set per-line rates and billable-sqft percentages. Each line is
+          priced separately and quoted with its own margin.
+        </p>
+        {error && <p className="mt-1 text-xs text-danger">{error}</p>}
+      </header>
+
+      {sorted.length === 0 ? (
+        <p className="text-xs text-fg-muted italic">
+          No service offerings have pricing configured yet for this client.
+        </p>
+      ) : (
+        <div className="rounded-md border border-border bg-surface overflow-hidden">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Service line</TableHead>
+                <TableHead>Model</TableHead>
+                <TableHead className="text-right">Rate</TableHead>
+                <TableHead className="text-right">Billable %</TableHead>
+                <TableHead className="text-right">Margin</TableHead>
+                <TableHead />
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {sorted.map((c) => {
+                const isVisit = c.pricing_model === 'per_visit_blended_sqft'
+                const rate = isVisit
+                  ? c.rate_per_sqft_per_visit
+                  : c.rate_per_sqft_per_month
+                const marginText =
+                  c.target_gross_margin_pct_override != null
+                    ? `${c.target_gross_margin_pct_override}%`
+                    : `${accountTargetMarginPct.toFixed(0)}% (default)`
+                return (
+                  <TableRow key={c.id}>
+                    <TableCell className="font-medium text-fg">
+                      {c.service_offering?.name ?? '(unknown)'}
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant="outline" className="text-[10px]">
+                        {isVisit ? 'Per visit' : 'Per month'}
+                      </Badge>
+                    </TableCell>
+                    <TableCell className="text-right font-tabular text-xs">
+                      {rate != null ? `$${Number(rate).toFixed(2)}/sqft` : '—'}
+                    </TableCell>
+                    <TableCell className="text-right font-tabular text-xs">
+                      {Number(c.billable_sqft_pct).toFixed(0)}%
+                    </TableCell>
+                    <TableCell className="text-right font-tabular text-xs">
+                      {marginText}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <button
+                        type="button"
+                        onClick={() => setEditing(c)}
+                        className="text-fg-subtle hover:text-accent inline-flex items-center gap-1 text-xs"
+                      >
+                        <Pencil className="h-3 w-3" />
+                        Edit
+                      </button>
+                    </TableCell>
+                  </TableRow>
+                )
+              })}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+
+      {editing && (
+        <EditDialog
+          config={editing}
+          accountTargetMarginPct={accountTargetMarginPct}
+          onClose={() => setEditing(null)}
+          onSave={save}
+        />
+      )}
+    </section>
+  )
+}
+
+function EditDialog({
+  config,
+  accountTargetMarginPct,
+  onClose,
+  onSave,
+}: {
+  config: PricingConfig
+  accountTargetMarginPct: number
+  onClose: () => void
+  onSave: (updated: PricingConfig) => void | Promise<void>
+}) {
+  const [model, setModel] = useState<PricingModel>(config.pricing_model)
+  const [rateVisit, setRateVisit] = useState(
+    config.rate_per_sqft_per_visit != null
+      ? String(config.rate_per_sqft_per_visit)
+      : ''
+  )
+  const [rateMonth, setRateMonth] = useState(
+    config.rate_per_sqft_per_month != null
+      ? String(config.rate_per_sqft_per_month)
+      : ''
+  )
+  const [billable, setBillable] = useState(String(config.billable_sqft_pct))
+  const [notes, setNotes] = useState(config.billable_sqft_pct_notes ?? '')
+  const [marginOv, setMarginOv] = useState(
+    config.target_gross_margin_pct_override != null
+      ? String(config.target_gross_margin_pct_override)
+      : ''
+  )
+  const [saving, setSaving] = useState(false)
+
+  const handleSave = async () => {
+    setSaving(true)
+    await onSave({
+      ...config,
+      pricing_model: model,
+      rate_per_sqft_per_visit:
+        model === 'per_visit_blended_sqft' ? parseFloat(rateVisit) || 0 : null,
+      rate_per_sqft_per_month:
+        model === 'per_sqft_monthly' ? parseFloat(rateMonth) || 0 : null,
+      billable_sqft_pct: Math.max(0, Math.min(100, parseFloat(billable) || 0)),
+      billable_sqft_pct_notes: notes.trim() || null,
+      target_gross_margin_pct_override:
+        marginOv.trim() === '' ? null : parseFloat(marginOv),
+    })
+    setSaving(false)
+  }
+
+  return (
+    <Dialog open onOpenChange={(v) => !v && onClose()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{config.service_offering?.name} — Pricing</DialogTitle>
+          <DialogDescription>
+            Per-line rate, billable sqft %, and optional margin override. Saving
+            triggers Bid Pricing to recompute.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-3">
+          <FormField label="Pricing model">
+            <Select value={model} onValueChange={(v) => setModel(v as PricingModel)}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="per_visit_blended_sqft">
+                  Per visit (rate × billable sqft × visits/yr)
+                </SelectItem>
+                <SelectItem value="per_sqft_monthly">
+                  Per sqft per month
+                </SelectItem>
+              </SelectContent>
+            </Select>
+          </FormField>
+          {model === 'per_visit_blended_sqft' ? (
+            <FormField label="Rate per sqft per visit">
+              <div className="flex items-center gap-2">
+                <span className="text-fg-muted">$</span>
+                <Input
+                  type="number"
+                  step="0.01"
+                  value={rateVisit}
+                  onChange={(e) => setRateVisit(e.target.value)}
+                  className="max-w-[120px]"
+                />
+                <span className="text-fg-muted text-sm">/sqft/visit</span>
+              </div>
+            </FormField>
+          ) : (
+            <FormField label="Rate per sqft per month">
+              <div className="flex items-center gap-2">
+                <span className="text-fg-muted">$</span>
+                <Input
+                  type="number"
+                  step="0.01"
+                  value={rateMonth}
+                  onChange={(e) => setRateMonth(e.target.value)}
+                  className="max-w-[120px]"
+                />
+                <span className="text-fg-muted text-sm">/sqft/month</span>
+              </div>
+            </FormField>
+          )}
+          <FormField
+            label="Billable sqft %"
+            helper="Percentage of measured sqft that's billable per the contract (e.g., 92% if common areas excluded)."
+          >
+            <div className="flex items-center gap-2">
+              <Input
+                type="number"
+                step="1"
+                min="0"
+                max="100"
+                value={billable}
+                onChange={(e) => setBillable(e.target.value)}
+                className="max-w-[100px]"
+              />
+              <span>%</span>
+            </div>
+          </FormField>
+          <FormField label="Notes (optional)">
+            <Textarea
+              rows={2}
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              placeholder="JLL bills 92% — excludes common areas"
+            />
+          </FormField>
+          <FormField
+            label={`Target margin override (account default: ${accountTargetMarginPct.toFixed(0)}%)`}
+            helper="Leave blank to inherit the account's target margin."
+          >
+            <div className="flex items-center gap-2">
+              <Input
+                type="number"
+                step="0.5"
+                min="0"
+                max="100"
+                value={marginOv}
+                onChange={(e) => setMarginOv(e.target.value)}
+                className="max-w-[100px]"
+              />
+              <span>%</span>
+            </div>
+          </FormField>
+        </div>
+        <DialogFooter>
+          <Button variant="ghost" onClick={onClose} disabled={saving}>
+            Cancel
+          </Button>
+          <Button onClick={handleSave} disabled={saving}>
+            {saving ? 'Saving…' : 'Save changes'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/supabase/migrations/20260430200008_phase_4_service_line_pricing.sql
+++ b/supabase/migrations/20260430200008_phase_4_service_line_pricing.sql
@@ -1,0 +1,104 @@
+-- Phase 4 — service line bid pricing structure.
+--
+-- Each (account, client, service_offering) row carries its pricing
+-- model and rate, plus a billable_sqft_pct that handles "we only bill
+-- 92% of measured sqft per the contract" cases. Per-line target
+-- margin override; null falls through to the account-level default.
+
+CREATE TABLE IF NOT EXISTS public.service_line_pricing_config (
+  id                            uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  account_id                    uuid NOT NULL REFERENCES public.accounts(id) ON DELETE CASCADE,
+  client_id                     uuid NOT NULL REFERENCES public.clients(id) ON DELETE CASCADE,
+  service_offering_id           uuid NOT NULL REFERENCES public.service_offerings(id) ON DELETE CASCADE,
+
+  pricing_model                 text NOT NULL,
+  rate_per_sqft_per_visit       numeric,
+  rate_per_sqft_per_month       numeric,
+
+  billable_sqft_pct             numeric NOT NULL DEFAULT 100,
+  billable_sqft_pct_notes       text,
+
+  target_gross_margin_pct_override  numeric,
+
+  is_active                     boolean NOT NULL DEFAULT true,
+  created_at                    timestamptz NOT NULL DEFAULT now(),
+  updated_at                    timestamptz NOT NULL DEFAULT now()
+);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'slpc_pricing_model_chk') THEN
+    ALTER TABLE public.service_line_pricing_config
+      ADD CONSTRAINT slpc_pricing_model_chk
+      CHECK (pricing_model IN ('per_visit_blended_sqft', 'per_sqft_monthly'));
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'slpc_billable_pct_chk') THEN
+    ALTER TABLE public.service_line_pricing_config
+      ADD CONSTRAINT slpc_billable_pct_chk
+      CHECK (billable_sqft_pct >= 0 AND billable_sqft_pct <= 100);
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'slpc_margin_override_chk') THEN
+    ALTER TABLE public.service_line_pricing_config
+      ADD CONSTRAINT slpc_margin_override_chk
+      CHECK (
+        target_gross_margin_pct_override IS NULL
+        OR (target_gross_margin_pct_override >= 0 AND target_gross_margin_pct_override <= 100)
+      );
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'slpc_unique_per_offering') THEN
+    ALTER TABLE public.service_line_pricing_config
+      ADD CONSTRAINT slpc_unique_per_offering
+      UNIQUE (account_id, client_id, service_offering_id);
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS slpc_account_client_idx
+  ON public.service_line_pricing_config(account_id, client_id) WHERE is_active = true;
+
+-- Backfill default rates for known offering names. Iterates every
+-- (account, client) pair that has at least one service_location and
+-- inserts a row per recognised offering. ON CONFLICT skips rows the
+-- user already saved.
+DO $$
+DECLARE
+  combo RECORD;
+  offering_name_pattern text;
+  offering_id uuid;
+  default_model text;
+  default_visit_rate numeric;
+  default_month_rate numeric;
+BEGIN
+  FOR combo IN
+    SELECT DISTINCT account_id, client_id
+    FROM public.service_locations
+    WHERE account_id IS NOT NULL AND client_id IS NOT NULL
+  LOOP
+    -- (pattern, model, per-visit rate, per-month rate)
+    FOR offering_name_pattern, default_model, default_visit_rate, default_month_rate IN
+      VALUES
+        ('Project Clean',           'per_visit_blended_sqft', 0.18, NULL),
+        ('S&I Project Clean',       'per_visit_blended_sqft', 0.18, NULL),
+        ('Upholstery',              'per_visit_blended_sqft', 0.05, NULL),
+        ('Recurring Janitorial',    'per_sqft_monthly',       NULL, 0.16),
+        ('Mission Home Housekeeping', 'per_sqft_monthly',     NULL, 0.22),
+        ('S&I Housekeeping',        'per_sqft_monthly',       NULL, 0.20)
+    LOOP
+      SELECT id INTO offering_id
+      FROM public.service_offerings
+      WHERE name ILIKE offering_name_pattern
+        AND (account_id IS NULL OR account_id = combo.account_id)
+      ORDER BY (account_id IS NOT NULL) DESC, created_at ASC
+      LIMIT 1;
+
+      IF offering_id IS NULL THEN CONTINUE; END IF;
+
+      INSERT INTO public.service_line_pricing_config (
+        account_id, client_id, service_offering_id, pricing_model,
+        rate_per_sqft_per_visit, rate_per_sqft_per_month, billable_sqft_pct
+      ) VALUES (
+        combo.account_id, combo.client_id, offering_id, default_model,
+        default_visit_rate, default_month_rate, 100
+      ) ON CONFLICT (account_id, client_id, service_offering_id) DO NOTHING;
+    END LOOP;
+  END LOOP;
+END $$;


### PR DESCRIPTION
## Summary
- New `service_line_pricing_config` table holds per (account, client, service_offering) pricing: model (per-visit blended sqft or per-sqft monthly), rate, billable sqft %, and optional margin override. Backfill seeds known offerings (Project Clean, Upholstery, Recurring Janitorial, Mission Home Housekeeping, S&I lines) at default rates.
- New `service-line-bid-calculator` runs alongside the rolled-up bid: revenue is rate-driven per line; direct costs (labor, fuel, vehicle, hotels, supplies) allocate by labor-hour share among non-addon lines (Upholstery is treated as addon — no drive miles, no vehicle, no hotels); shared overhead (branch overhead, insurance, corporate) allocates by revenue share. Output: per-line revenue + cost + actual margin %, plus a `weighted_average_margin_pct` rollup.
- `BidPricingChart` adds a "Service line bid breakdown" section (revenue, cost, margin, target margin, billable sqft%); flags lines bidding below target. `CostAssumptionsPanel` gains a Service Line Pricing editor (rate, billable %, notes, per-line margin override). Synthesizer prompt mentions Phase 4 and how to talk about per-line margins + billable_sqft_pct risks.
- New `GET/PUT /api/v1/clients/{id}/service-line-pricing` for the config editor.

## Test plan
- [ ] Cost Assumptions panel: Service line pricing section lists all configs with Edit affordance.
- [ ] Edit dialog: switching pricing model swaps rate field; saving persists rate, billable %, notes, margin override.
- [ ] Bid Pricing card: per-line breakdown renders with revenue / cost / actual margin %; warning shows for lines bidding below target.
- [ ] Setting `billable_sqft_pct` to 92 reduces revenue proportionally for that line.
- [ ] Upholstery line is excluded from drive-miles + vehicle + hotels allocation.
- [ ] Synthesizer mentions per-service-line margins and surfaces below-target lines.
- [ ] `npx tsc --noEmit` and `npm run build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)