### PR TITLE
Phase 4.1: overnight cost transparency + per-cluster overrides

### DIFF
--- a/api/_lib/analysis/cluster-id.ts
+++ b/api/_lib/analysis/cluster-id.ts
@@ -1,0 +1,12 @@
+// Phase 4.1 — stable cluster ID for overnight cluster overrides.
+//
+// The same set of property IDs always hashes to the same id. If a
+// property gets added or removed from the cluster, the id shifts and
+// any saved override is treated as stale. Used by the overnight
+// calculator and the cluster-override API.
+import crypto from 'crypto'
+
+export function computeClusterId(propertyIds: string[]): string {
+  const sorted = [...propertyIds].sort()
+  return crypto.createHash('sha256').update(sorted.join('|')).digest('hex').slice(0, 12)
+}

--- a/api/_lib/analysis/overnight-calculator.ts
+++ b/api/_lib/analysis/overnight-calculator.ts
@@ -1,4 +1,6 @@
 // Phase 3.7 — Calculated overnight & hotel costs.
+// Phase 4.1 — Per-cluster overrides + borderline detection +
+//             stable cluster IDs + calculation_text.
 //
 // Replaces the flat $35K hotels_annual constant with a calculation driven
 // by which properties are >3hr from their assigned branch, geographically
@@ -6,9 +8,12 @@
 // per year.
 //
 // Pure function. Caller provides properties (with hours_per_visit +
-// visits_per_year), branches, and config. Returns total cost + per-trip
-// breakdown.
+// visits_per_year), branches, config, and optional per-cluster overrides
+// loaded from `overnight_cluster_overrides`. Returns total cost +
+// per-trip breakdown including override status and a human-readable
+// calculation_text the UI can render verbatim.
 import { haversineMiles, driveTimeMinutes, centroid, type LatLng } from './haversine.js'
+import { computeClusterId } from './cluster-id.js'
 
 export interface OvernightProperty {
   id: string
@@ -36,9 +41,22 @@ export interface OvernightConfig {
   include_per_diem: boolean
 }
 
+export interface OvernightClusterOverride {
+  nights_per_trip_override?: number | null
+  trips_per_year_override?: number | null
+  cost_per_night_override?: number | null
+  per_diem_per_night_override?: number | null
+  skip_overnight?: boolean | null
+  skip_overnight_reason?: string | null
+}
+
 export interface OvernightTrip {
   branch_name: string
+  // Stable id: sha256 prefix of sorted property_ids in this cluster.
+  // Survives re-runs as long as the same set of properties cluster
+  // together; changes if a property is added or removed.
   cluster_id: string
+  cluster_label: string
   cluster_centroid: LatLng
   properties_in_cluster: Array<{
     property_id: string
@@ -47,14 +65,36 @@ export interface OvernightTrip {
     visits_per_year: number
   }>
   drive_hours_one_way: number
+  drive_distance_miles_one_way: number
   total_work_hours_per_visit: number
   work_days_per_trip: number
+
+  // Calculated values (algorithm output).
+  nights_per_trip_calculated: number
+  trips_per_year_calculated: number
+  cost_per_night_default: number
+  per_diem_per_night_default: number
+
+  // Used values (= calculated unless override applied).
   nights_per_trip: number
   trips_per_year: number
+  cost_per_night_used: number
+  per_diem_per_night_used: number
+
   annual_nights: number
   annual_hotel_cost: number
   annual_per_diem_cost: number
   annual_total_cost: number
+
+  // Phase 4.1 flags.
+  is_borderline: boolean
+  borderline_reason: string | null
+  has_overrides: boolean
+  override_fields: string[]
+  is_skipped: boolean
+  skip_reason: string | null
+
+  calculation_text: string
 }
 
 export interface OvernightResult {
@@ -67,15 +107,31 @@ export interface OvernightResult {
   avg_drive_hours_to_overnight_property: number
   largest_cluster_size: number
   properties_requiring_overnight: number
+  // Phase 4.1 — aggregate counts surfaced in summary card.
+  cluster_count: number
+  cluster_count_with_overrides: number
+  cluster_count_skipped: number
+  cluster_count_borderline: number
+  // Cluster IDs from the saved override table that no longer match any
+  // current cluster (usually because property contents shifted). UI can
+  // surface these as "stale, review or clear".
+  stale_override_cluster_ids: string[]
   config_used: OvernightConfig
 }
+
+// Borderline drive window — clusters in this range are still treated as
+// overnight by the algorithm but flagged so users can review whether a
+// crew could realistically handle it as a long day trip.
+const BORDERLINE_DRIVE_HOURS_LOWER = 3.0
+const BORDERLINE_DRIVE_HOURS_UPPER = 3.5
 
 const CLUSTER_RADIUS_MILES = 30
 
 export function calculateOvernights(
   properties: OvernightProperty[],
   branches: OvernightBranch[],
-  config: OvernightConfig
+  config: OvernightConfig,
+  clusterOverrides: Record<string, OvernightClusterOverride> = {}
 ): OvernightResult {
   // Empty result for "no branches selected" — caller decides whether to
   // 400. We don't throw here because the dashboard wants to show this
@@ -137,6 +193,8 @@ export function calculateOvernights(
   let totalDriveCount = 0
   let largestCluster = 0
 
+  const matchedOverrideIds = new Set<string>()
+
   for (const [branchIdx, props] of byBranch) {
     const clusters = densityCluster(props, CLUSTER_RADIUS_MILES)
     for (let ci = 0; ci < clusters.length; ci++) {
@@ -145,45 +203,100 @@ export function calculateOvernights(
       if (cluster.length > largestCluster) largestCluster = cluster.length
 
       const center = centroid(cluster.map((p) => ({ lat: p.lat, lng: p.lng })))
-      // One-way drive from the branch to the cluster centroid (uses the same
-      // drive_speed assumption as the rest of the system).
       const distToCenterMi = haversineMiles(
         { lat: branches[branchIdx].lat, lng: branches[branchIdx].lng },
         center
       )
       const driveHoursOneWay = driveTimeMinutes(distToCenterMi, config.drive_speed_mph) / 60
 
-      // Work hours per single visit to the cluster = sum of hours_per_visit
-      // across all properties in the cluster.
       const workHoursPerVisit = cluster.reduce((sum, p) => sum + p.hours_per_visit, 0)
 
-      // Per-day work cap is the user's configured max (default 8 of 10).
       const workDaysPerTrip = Math.max(
         1,
         Math.ceil(workHoursPerVisit / config.max_work_hours_per_crew_day)
       )
       // Nights = work_days. Crew arrives the night before day 1, sleeps
       // night between each work day, drives home after the last work day.
-      // (1 work day → 1 night; 3 work days → 3 nights.)
-      const nightsPerTrip = workDaysPerTrip
+      const nightsPerTripCalc = workDaysPerTrip
+      const tripsPerYearCalc = cluster.reduce((m, p) => Math.max(m, p.visits_per_year), 0)
 
-      // Trips per year — operational simplification: max visits_per_year
-      // across cluster props, with the lower-freq props bundled into the
-      // higher-freq trip cadence.
-      const tripsPerYear = cluster.reduce((m, p) => Math.max(m, p.visits_per_year), 0)
-      const annualNights = nightsPerTrip * tripsPerYear
+      // Stable cluster id from sorted property IDs in this cluster.
+      const clusterId = computeClusterId(cluster.map((p) => p.id))
+      const clusterLabel = labelForCluster(cluster, branches[branchIdx].name)
+      const ovr = clusterOverrides[clusterId]
+      if (ovr) matchedOverrideIds.add(clusterId)
 
-      const annualHotelCost = annualNights * config.cost_per_night
+      // Apply overrides. null/undefined fields fall through to calculated.
+      const isSkipped = !!ovr?.skip_overnight
+      const nightsPerTripUsed = isSkipped
+        ? 0
+        : ovr?.nights_per_trip_override != null
+          ? ovr.nights_per_trip_override
+          : nightsPerTripCalc
+      const tripsPerYearUsed = isSkipped
+        ? 0
+        : ovr?.trips_per_year_override != null
+          ? ovr.trips_per_year_override
+          : tripsPerYearCalc
+      const costPerNightUsed =
+        ovr?.cost_per_night_override != null
+          ? ovr.cost_per_night_override
+          : config.cost_per_night
+      const perDiemPerNightUsed =
+        ovr?.per_diem_per_night_override != null
+          ? ovr.per_diem_per_night_override
+          : config.per_diem_per_night
+
+      const annualNights = nightsPerTripUsed * tripsPerYearUsed
+      const annualHotelCost = annualNights * costPerNightUsed
       const annualPerDiemCost = config.include_per_diem
-        ? annualNights * config.per_diem_per_night * config.crew_size
+        ? annualNights * perDiemPerNightUsed * config.crew_size
         : 0
+
+      // Borderline detection: drive in the 3.0–3.5 hr window AND not
+      // explicitly marked as a day trip. Skipped clusters aren't
+      // "borderline" — the user already decided.
+      const isBorderline =
+        !isSkipped &&
+        driveHoursOneWay >= BORDERLINE_DRIVE_HOURS_LOWER &&
+        driveHoursOneWay <= BORDERLINE_DRIVE_HOURS_UPPER
+      const borderlineReason = isBorderline
+        ? `${round2(driveHoursOneWay)} hours one-way — close to overnight threshold; consider whether crew can do day trip`
+        : null
+
+      // Override status — list which fields the user actually overrode
+      // (excluding "skip" which has its own flag).
+      const overrideFields: string[] = []
+      if (ovr?.nights_per_trip_override != null) overrideFields.push('nights_per_trip')
+      if (ovr?.trips_per_year_override != null) overrideFields.push('trips_per_year')
+      if (ovr?.cost_per_night_override != null) overrideFields.push('cost_per_night')
+      if (ovr?.per_diem_per_night_override != null) overrideFields.push('per_diem_per_night')
 
       for (const p of cluster) totalDriveSum += p.one_way_drive_hours
       totalDriveCount += cluster.length
 
+      const calculationText = buildCalculationText({
+        isSkipped,
+        skipReason: ovr?.skip_overnight_reason ?? null,
+        nightsCalc: nightsPerTripCalc,
+        nightsUsed: nightsPerTripUsed,
+        tripsCalc: tripsPerYearCalc,
+        tripsUsed: tripsPerYearUsed,
+        costPerNightDefault: config.cost_per_night,
+        costPerNightUsed,
+        perDiemDefault: config.per_diem_per_night,
+        perDiemUsed: perDiemPerNightUsed,
+        crewSize: config.crew_size,
+        includePerDiem: config.include_per_diem,
+        annualHotelCost,
+        annualPerDiemCost,
+        overrideFields,
+      })
+
       trips.push({
         branch_name: branches[branchIdx].name,
-        cluster_id: `${branches[branchIdx].name}-c${ci}`,
+        cluster_id: clusterId,
+        cluster_label: clusterLabel,
         cluster_centroid: center,
         properties_in_cluster: cluster.map((p) => ({
           property_id: p.id,
@@ -192,17 +305,37 @@ export function calculateOvernights(
           visits_per_year: p.visits_per_year,
         })),
         drive_hours_one_way: round2(driveHoursOneWay),
+        drive_distance_miles_one_way: Math.round(distToCenterMi),
         total_work_hours_per_visit: round2(workHoursPerVisit),
         work_days_per_trip: workDaysPerTrip,
-        nights_per_trip: nightsPerTrip,
-        trips_per_year: tripsPerYear,
+        nights_per_trip_calculated: nightsPerTripCalc,
+        trips_per_year_calculated: tripsPerYearCalc,
+        cost_per_night_default: config.cost_per_night,
+        per_diem_per_night_default: config.per_diem_per_night,
+        nights_per_trip: nightsPerTripUsed,
+        trips_per_year: tripsPerYearUsed,
+        cost_per_night_used: costPerNightUsed,
+        per_diem_per_night_used: perDiemPerNightUsed,
         annual_nights: annualNights,
         annual_hotel_cost: Math.round(annualHotelCost),
         annual_per_diem_cost: Math.round(annualPerDiemCost),
         annual_total_cost: Math.round(annualHotelCost + annualPerDiemCost),
+        is_borderline: isBorderline,
+        borderline_reason: borderlineReason,
+        has_overrides: overrideFields.length > 0,
+        override_fields: overrideFields,
+        is_skipped: isSkipped,
+        skip_reason: ovr?.skip_overnight_reason ?? null,
+        calculation_text: calculationText,
       })
     }
   }
+
+  // Stale overrides — cluster IDs in the table that don't match any
+  // current cluster. Surface for UI cleanup.
+  const staleOverrideClusterIds = Object.keys(clusterOverrides).filter(
+    (id) => !matchedOverrideIds.has(id)
+  )
 
   const totalNights = trips.reduce((s, t) => s + t.annual_nights, 0)
   const totalHotelCost = trips.reduce((s, t) => s + t.annual_hotel_cost, 0)
@@ -220,6 +353,11 @@ export function calculateOvernights(
     avg_drive_hours_to_overnight_property: avgDriveHours,
     largest_cluster_size: largestCluster,
     properties_requiring_overnight: overnightProps.length,
+    cluster_count: trips.length,
+    cluster_count_with_overrides: trips.filter((t) => t.has_overrides || t.is_skipped).length,
+    cluster_count_skipped: trips.filter((t) => t.is_skipped).length,
+    cluster_count_borderline: trips.filter((t) => t.is_borderline).length,
+    stale_override_cluster_ids: staleOverrideClusterIds,
     config_used: config,
   }
 }
@@ -235,8 +373,86 @@ function emptyResult(config: OvernightConfig): OvernightResult {
     avg_drive_hours_to_overnight_property: 0,
     largest_cluster_size: 0,
     properties_requiring_overnight: 0,
+    cluster_count: 0,
+    cluster_count_with_overrides: 0,
+    cluster_count_skipped: 0,
+    cluster_count_borderline: 0,
+    stale_override_cluster_ids: [],
     config_used: config,
   }
+}
+
+// Generate a human-readable label for the cluster: "Cluster of N
+// properties near {first address}". The address comes from the property
+// closest to the centroid (rough proxy for "city" without a city/state
+// field on the input). Saved to DB on override and shown in UI; doesn't
+// participate in the stable cluster_id hash.
+function labelForCluster(
+  cluster: Array<OvernightProperty & { lat: number; lng: number }>,
+  branchName: string
+): string {
+  if (cluster.length === 0) return `Cluster from ${branchName}`
+  const center = centroid(cluster.map((p) => ({ lat: p.lat, lng: p.lng })))
+  let nearest = cluster[0]
+  let nearestDist = Infinity
+  for (const p of cluster) {
+    const d = haversineMiles(center, { lat: p.lat, lng: p.lng })
+    if (d < nearestDist) {
+      nearestDist = d
+      nearest = p
+    }
+  }
+  const addr = nearest.address?.trim() || `${nearest.lat.toFixed(2)}, ${nearest.lng.toFixed(2)}`
+  const short = addr.length > 50 ? addr.slice(0, 47) + '…' : addr
+  return `${cluster.length} ${cluster.length === 1 ? 'property' : 'properties'} near ${short}`
+}
+
+function buildCalculationText(args: {
+  isSkipped: boolean
+  skipReason: string | null
+  nightsCalc: number
+  nightsUsed: number
+  tripsCalc: number
+  tripsUsed: number
+  costPerNightDefault: number
+  costPerNightUsed: number
+  perDiemDefault: number
+  perDiemUsed: number
+  crewSize: number
+  includePerDiem: boolean
+  annualHotelCost: number
+  annualPerDiemCost: number
+  overrideFields: string[]
+}): string {
+  if (args.isSkipped) {
+    const reason = args.skipReason ? ` Reason: ${args.skipReason}` : ''
+    return `Marked as day-trip (no overnight) — costs set to $0.${reason}`
+  }
+  const annualNights = args.nightsUsed * args.tripsUsed
+  const overridden = args.overrideFields.length > 0
+  const prefix = overridden ? '**Overridden:** ' : ''
+  const nightsBit =
+    args.nightsUsed === args.nightsCalc
+      ? `${args.nightsUsed} nights/trip`
+      : `${args.nightsUsed} nights/trip (was ${args.nightsCalc})`
+  const tripsBit =
+    args.tripsUsed === args.tripsCalc
+      ? `${args.tripsUsed} trips/yr`
+      : `${args.tripsUsed} trips/yr (was ${args.tripsCalc})`
+  const costBit =
+    args.costPerNightUsed === args.costPerNightDefault
+      ? `$${args.costPerNightUsed}/night`
+      : `$${args.costPerNightUsed}/night (was $${args.costPerNightDefault})`
+  const perDiemBit =
+    args.perDiemUsed === args.perDiemDefault
+      ? `$${args.perDiemUsed}/diem`
+      : `$${args.perDiemUsed}/diem (was $${args.perDiemDefault})`
+  const hotelLine = `Hotel: ${nightsBit} × ${tripsBit} × ${costBit} = $${Math.round(args.annualHotelCost).toLocaleString()}`
+  const perDiemLine = args.includePerDiem
+    ? `Per diem: ${annualNights} nights × ${args.crewSize} crew × ${perDiemBit} = $${Math.round(args.annualPerDiemCost).toLocaleString()}`
+    : 'Per diem: not included'
+  const total = `Total: $${Math.round(args.annualHotelCost + args.annualPerDiemCost).toLocaleString()}`
+  return `${prefix}${hotelLine}; ${perDiemLine}; ${total}`
 }
 
 // Density clustering — single-link agglomerative within a fixed radius.

--- a/api/analyses/account/[accountId]/clients/[clientId]/cluster-override.ts
+++ b/api/analyses/account/[accountId]/clients/[clientId]/cluster-override.ts
@@ -1,0 +1,126 @@
+// Phase 4.1 — POST cluster override for the overnight calculator.
+//
+//   POST /api/analyses/account/[accountId]/clients/[clientId]/cluster-override
+//   body: {
+//     cluster_id, cluster_label,
+//     nights_per_trip_override?, trips_per_year_override?,
+//     cost_per_night_override?, per_diem_per_night_override?,
+//     skip_overnight?, skip_overnight_reason?,
+//     override_reason?
+//   }
+//
+// Behavior:
+// - If every override field is null/undefined and skip_overnight is
+//   false, the saved row is deleted (clear).
+// - Otherwise upsert by (account_id, client_id, cluster_id).
+// - Returns { ok: true, cleared: boolean }.
+//
+// Pre-validation (does the cluster_id exist in the current calc) is
+// the UI's job — saving an override against a stale id is allowed
+// because property contents change frequently and we don't want to
+// drop user intent.
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { createAdminClient } from '../../../../../_lib/supabase.js'
+import { authenticateRequest } from '../../../../../_lib/auth.js'
+
+export const config = { maxDuration: 10 }
+
+interface Body {
+  cluster_id?: string
+  cluster_label?: string
+  nights_per_trip_override?: number | null
+  trips_per_year_override?: number | null
+  cost_per_night_override?: number | null
+  per_diem_per_night_override?: number | null
+  skip_overnight?: boolean
+  skip_overnight_reason?: string | null
+  override_reason?: string | null
+}
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method === 'OPTIONS') return res.status(200).end()
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+
+  let userEmail: string | null = null
+  try {
+    const auth = await authenticateRequest(req)
+    userEmail = auth.email ?? null
+  } catch (err: any) {
+    return res.status(err.statusCode ?? 401).json({ error: err.message ?? 'Unauthorized' })
+  }
+
+  const accountId = req.query.accountId as string
+  const clientId = req.query.clientId as string
+  if (!accountId || !clientId) {
+    return res.status(400).json({ error: 'accountId and clientId required' })
+  }
+
+  const body = (req.body ?? {}) as Body
+  if (!body.cluster_id || typeof body.cluster_id !== 'string') {
+    return res.status(400).json({ error: 'cluster_id is required' })
+  }
+  if (!body.cluster_label || typeof body.cluster_label !== 'string') {
+    return res.status(400).json({ error: 'cluster_label is required' })
+  }
+
+  // Validation
+  if (body.cost_per_night_override != null && body.cost_per_night_override < 0) {
+    return res.status(400).json({ error: 'cost_per_night_override must be >= 0' })
+  }
+  if (body.per_diem_per_night_override != null && body.per_diem_per_night_override < 0) {
+    return res.status(400).json({ error: 'per_diem_per_night_override must be >= 0' })
+  }
+  if (body.nights_per_trip_override != null && body.nights_per_trip_override < 0) {
+    return res.status(400).json({ error: 'nights_per_trip_override must be >= 0' })
+  }
+  if (body.trips_per_year_override != null && body.trips_per_year_override < 0) {
+    return res.status(400).json({ error: 'trips_per_year_override must be >= 0' })
+  }
+
+  const db = createAdminClient()
+
+  // Treat the row as a clear if no field is set AND skip is false.
+  const isClear =
+    !body.skip_overnight &&
+    body.nights_per_trip_override == null &&
+    body.trips_per_year_override == null &&
+    body.cost_per_night_override == null &&
+    body.per_diem_per_night_override == null
+
+  if (isClear) {
+    const { error } = await db
+      .from('overnight_cluster_overrides')
+      .delete()
+      .eq('account_id', accountId)
+      .eq('client_id', clientId)
+      .eq('cluster_id', body.cluster_id)
+    if (error) return res.status(500).json({ error: error.message })
+    return res.status(200).json({ ok: true, cleared: true })
+  }
+
+  const { error } = await db
+    .from('overnight_cluster_overrides')
+    .upsert(
+      {
+        account_id: accountId,
+        client_id: clientId,
+        cluster_id: body.cluster_id,
+        cluster_label: body.cluster_label,
+        nights_per_trip_override: body.nights_per_trip_override ?? null,
+        trips_per_year_override: body.trips_per_year_override ?? null,
+        cost_per_night_override: body.cost_per_night_override ?? null,
+        per_diem_per_night_override: body.per_diem_per_night_override ?? null,
+        skip_overnight: !!body.skip_overnight,
+        skip_overnight_reason: body.skip_overnight_reason ?? null,
+        override_reason: body.override_reason ?? null,
+        overridden_by: userEmail,
+        overridden_at: new Date().toISOString(),
+      },
+      { onConflict: 'account_id,client_id,cluster_id' }
+    )
+  if (error) return res.status(500).json({ error: error.message })
+
+  return res.status(200).json({ ok: true, cleared: false })
+}

--- a/api/analyses/account/[accountId]/clients/[clientId]/overnight-breakdown.ts
+++ b/api/analyses/account/[accountId]/clients/[clientId]/overnight-breakdown.ts
@@ -21,6 +21,7 @@ import {
   resolveHotelsCost,
   type OvernightConfig,
   type OvernightBranch,
+  type OvernightClusterOverride,
 } from '../../../../../_lib/analysis/overnight-calculator.js'
 
 export const config = { maxDuration: 30 }
@@ -96,6 +97,42 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     visits_per_year_default: constraints.visits_per_year_default ?? 2,
   })
 
+  // Phase 4.1 — load any per-cluster overrides for this client.
+  const { data: overrideRows } = await db
+    .from('overnight_cluster_overrides')
+    .select(
+      'cluster_id, cluster_label, nights_per_trip_override, trips_per_year_override, cost_per_night_override, per_diem_per_night_override, skip_overnight, skip_overnight_reason, override_reason, overridden_by, overridden_at'
+    )
+    .eq('account_id', accountId)
+    .eq('client_id', clientId)
+  const clusterOverrides: Record<string, OvernightClusterOverride> = {}
+  const overrideMeta: Record<
+    string,
+    {
+      cluster_label: string
+      override_reason: string | null
+      overridden_by: string | null
+      overridden_at: string
+    }
+  > = {}
+  for (const r of overrideRows ?? []) {
+    clusterOverrides[r.cluster_id] = {
+      nights_per_trip_override: r.nights_per_trip_override,
+      trips_per_year_override: r.trips_per_year_override,
+      cost_per_night_override: r.cost_per_night_override != null ? Number(r.cost_per_night_override) : null,
+      per_diem_per_night_override:
+        r.per_diem_per_night_override != null ? Number(r.per_diem_per_night_override) : null,
+      skip_overnight: r.skip_overnight,
+      skip_overnight_reason: r.skip_overnight_reason,
+    }
+    overrideMeta[r.cluster_id] = {
+      cluster_label: r.cluster_label,
+      override_reason: r.override_reason ?? null,
+      overridden_by: r.overridden_by ?? null,
+      overridden_at: r.overridden_at,
+    }
+  }
+
   const calc = calculateOvernights(
     visits
       .filter(
@@ -113,7 +150,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         hours_per_visit: v.hours_per_visit,
       })),
     branches,
-    overnightConfig
+    overnightConfig,
+    clusterOverrides
   )
 
   const resolved = resolveHotelsCost(
@@ -128,5 +166,6 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     resolved,
     config: mergedConfig,
     override: constraints.hotels_annual_override,
+    cluster_override_meta: overrideMeta,
   })
 }

--- a/src/components/analysis/OvernightBreakdownDrawer.tsx
+++ b/src/components/analysis/OvernightBreakdownDrawer.tsx
@@ -1,28 +1,52 @@
 // Overnight breakdown drawer — opens from the Cost Assumptions panel and
 // shows cluster-by-cluster detail (which properties go on which trips,
-// how many nights, annual cost). Built fresh on design tokens rather than
-// reusing SlideOver because we need a wider panel + tabular data layout.
-import { useEffect, useState } from 'react'
-import { Loader2, RotateCcw, X } from 'lucide-react'
+// how many nights, annual cost). Phase 4.1 adds borderline/override/skip
+// badges, the calculation explainer string, and a per-cluster override
+// editor modal.
+import { useEffect, useMemo, useState } from 'react'
+import { AlertTriangle, Ban, Loader2, Pencil, RotateCcw, Settings2, X } from 'lucide-react'
 import { useAuth } from '../../hooks/useAuth'
 import { Badge } from '../ui/Badge'
 import Button from '../ui/Button'
-import { Input } from '../ui/Input'
+import { Input, FormField, Textarea } from '../ui/Input'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '../ui/Dialog'
 import { cn } from '../../lib/cn'
 
 interface Trip {
   branch_name: string
   cluster_id: string
+  cluster_label: string
   cluster_centroid: { lat: number; lng: number }
   drive_hours_one_way: number
+  drive_distance_miles_one_way: number
   total_work_hours_per_visit: number
   work_days_per_trip: number
+  nights_per_trip_calculated: number
+  trips_per_year_calculated: number
+  cost_per_night_default: number
+  per_diem_per_night_default: number
   nights_per_trip: number
   trips_per_year: number
+  cost_per_night_used: number
+  per_diem_per_night_used: number
   annual_nights: number
   annual_hotel_cost: number
   annual_per_diem_cost: number
   annual_total_cost: number
+  is_borderline: boolean
+  borderline_reason: string | null
+  has_overrides: boolean
+  override_fields: string[]
+  is_skipped: boolean
+  skip_reason: string | null
+  calculation_text: string
   properties_in_cluster: Array<{
     property_id: string
     address: string | null
@@ -41,12 +65,26 @@ interface BreakdownData {
     properties_requiring_overnight: number
     day_trip_property_count: number
     avg_drive_hours_to_overnight_property: number
+    cluster_count: number
+    cluster_count_with_overrides: number
+    cluster_count_skipped: number
+    cluster_count_borderline: number
+    stale_override_cluster_ids: string[]
   }
   resolved: {
     value: number
     basis: 'override' | 'calculated' | 'flat_fallback'
     calculated_value: number
   }
+  cluster_override_meta?: Record<
+    string,
+    {
+      cluster_label: string
+      override_reason: string | null
+      overridden_by: string | null
+      overridden_at: string
+    }
+  >
 }
 
 interface Props {
@@ -79,6 +117,12 @@ export default function OvernightBreakdownDrawer({
   const [overrideEditing, setOverrideEditing] = useState(false)
   const [savingOverride, setSavingOverride] = useState(false)
   const [overrideError, setOverrideError] = useState<string | null>(null)
+  const [editingClusterId, setEditingClusterId] = useState<string | null>(null)
+
+  const editingTrip = useMemo(() => {
+    if (!data || !editingClusterId) return null
+    return data.result.trips.find((t) => t.cluster_id === editingClusterId) ?? null
+  }, [data, editingClusterId])
 
   useEffect(() => {
     if (!open) return
@@ -227,6 +271,13 @@ export default function OvernightBreakdownDrawer({
                 saving={savingOverride}
                 error={overrideError}
               />
+              {data.result.stale_override_cluster_ids.length > 0 && (
+                <div className="rounded-md border border-warning/30 bg-warning/5 px-3 py-2 text-xs text-warning">
+                  ⚠ {data.result.stale_override_cluster_ids.length} override
+                  {data.result.stale_override_cluster_ids.length === 1 ? ' is' : 's are'} stale
+                  (cluster contents changed). Open the cluster to clear or re-apply.
+                </div>
+              )}
               {data.result.trips.length === 0 ? (
                 <div className="rounded-md border border-border bg-surface-subtle px-4 py-6 text-sm text-fg-muted text-center">
                   No overnight stays required — all properties are within{' '}
@@ -237,21 +288,66 @@ export default function OvernightBreakdownDrawer({
                   {data.result.trips.map((trip) => (
                     <li
                       key={trip.cluster_id}
-                      className="rounded-md border border-border bg-surface p-4"
+                      className={cn(
+                        'rounded-md border bg-surface p-4',
+                        trip.is_skipped
+                          ? 'border-fg-subtle/30 opacity-80'
+                          : trip.is_borderline
+                            ? 'border-warning/30'
+                            : trip.has_overrides
+                              ? 'border-accent/30'
+                              : 'border-border'
+                      )}
                     >
                       <div className="flex items-start justify-between gap-3 flex-wrap">
                         <div className="space-y-0.5 min-w-0">
-                          <p className="text-sm font-semibold text-fg">
-                            {trip.cluster_id}
-                          </p>
+                          <div className="flex items-center gap-2 flex-wrap">
+                            <p className="text-sm font-semibold text-fg">
+                              {trip.cluster_label}
+                            </p>
+                            {trip.is_skipped && (
+                              <Badge variant="outline" className="text-[10px]">
+                                <Ban className="h-3 w-3 mr-0.5" />
+                                Skipped
+                              </Badge>
+                            )}
+                            {trip.is_borderline && (
+                              <Badge variant="outline" className="text-[10px] text-warning border-warning/40">
+                                <AlertTriangle className="h-3 w-3 mr-0.5" />
+                                Borderline
+                              </Badge>
+                            )}
+                            {trip.has_overrides && (
+                              <Badge variant="outline" className="text-[10px] text-accent border-accent/40">
+                                <Settings2 className="h-3 w-3 mr-0.5" />
+                                Overridden
+                              </Badge>
+                            )}
+                          </div>
                           <p className="text-xs text-fg-muted">
                             from <span className="text-fg">{trip.branch_name}</span> ·{' '}
-                            <span className="font-tabular">{trip.drive_hours_one_way}</span> hr one-way
+                            <span className="font-tabular">{trip.drive_hours_one_way}</span> hr one-way ·{' '}
+                            <span className="font-tabular">{trip.drive_distance_miles_one_way}</span> mi
                           </p>
+                          {trip.is_borderline && trip.borderline_reason && (
+                            <p className="text-[11px] text-warning italic mt-0.5">
+                              {trip.borderline_reason}
+                            </p>
+                          )}
                         </div>
-                        <Badge variant="accent">
-                          ${trip.annual_total_cost.toLocaleString()}/yr
-                        </Badge>
+                        <div className="flex flex-col items-end gap-1">
+                          <Badge variant="accent">
+                            ${trip.annual_total_cost.toLocaleString()}/yr
+                          </Badge>
+                          <button
+                            type="button"
+                            onClick={() => setEditingClusterId(trip.cluster_id)}
+                            className="text-fg-subtle hover:text-accent inline-flex items-center gap-1 text-xs"
+                          >
+                            <Pencil className="h-3 w-3" />
+                            Edit
+                          </button>
+                        </div>
                       </div>
 
                       <dl className="mt-3 grid grid-cols-2 sm:grid-cols-4 gap-3 text-xs">
@@ -270,6 +366,10 @@ export default function OvernightBreakdownDrawer({
                           value={`$${trip.annual_per_diem_cost.toLocaleString()}`}
                         />
                       </dl>
+
+                      <p className="mt-2 text-[11px] text-fg-subtle font-tabular leading-relaxed">
+                        {trip.calculation_text}
+                      </p>
 
                       <details className="mt-3 group">
                         <summary className="cursor-pointer text-xs text-accent hover:underline">
@@ -300,6 +400,21 @@ export default function OvernightBreakdownDrawer({
           )}
         </div>
       </div>
+
+      {editingTrip && (
+        <ClusterOverrideModal
+          trip={editingTrip}
+          accountId={accountId}
+          clientId={clientId}
+          getToken={getToken}
+          onClose={() => setEditingClusterId(null)}
+          onSaved={async () => {
+            await refresh()
+            onOverrideSaved?.()
+            setEditingClusterId(null)
+          }}
+        />
+      )}
     </>
   )
 }
@@ -360,6 +475,31 @@ function SummaryStrip({
           value={`${data.result.avg_drive_hours_to_overnight_property} hr`}
         />
       </dl>
+      {(data.result.cluster_count_borderline > 0 ||
+        data.result.cluster_count_with_overrides > 0 ||
+        data.result.cluster_count_skipped > 0) && (
+        <p className="mt-2 text-[11px] text-fg-muted flex flex-wrap items-center gap-x-3">
+          {data.result.cluster_count_borderline > 0 && (
+            <span className="inline-flex items-center gap-1 text-warning">
+              <AlertTriangle className="h-3 w-3" />
+              {data.result.cluster_count_borderline} borderline
+            </span>
+          )}
+          {data.result.cluster_count_with_overrides > 0 && (
+            <span className="inline-flex items-center gap-1 text-accent">
+              <Settings2 className="h-3 w-3" />
+              {data.result.cluster_count_with_overrides} override
+              {data.result.cluster_count_with_overrides === 1 ? '' : 's'} applied
+            </span>
+          )}
+          {data.result.cluster_count_skipped > 0 && (
+            <span className="inline-flex items-center gap-1">
+              <Ban className="h-3 w-3" />
+              {data.result.cluster_count_skipped} skipped
+            </span>
+          )}
+        </p>
+      )}
 
       {allowOverride && (
         <div className="mt-3 pt-3 border-t border-border space-y-1.5">
@@ -430,5 +570,349 @@ function Stat({ label, value }: { label: string; value: string | number }) {
         {typeof value === 'number' ? value.toLocaleString() : value}
       </dd>
     </div>
+  )
+}
+
+// Per-cluster override editor. Renders a preview of the resulting
+// annual cost as the user edits, so the "what does this change" math
+// is visible before save. Skip mode disables the rate fields and
+// requires a reason.
+function ClusterOverrideModal({
+  trip,
+  accountId,
+  clientId,
+  getToken,
+  onClose,
+  onSaved,
+}: {
+  trip: Trip
+  accountId: string
+  clientId: string
+  getToken: () => Promise<string | null>
+  onClose: () => void
+  onSaved: () => void | Promise<void>
+}) {
+  const initialNights =
+    trip.nights_per_trip !== trip.nights_per_trip_calculated
+      ? String(trip.nights_per_trip)
+      : ''
+  const initialTrips =
+    trip.trips_per_year !== trip.trips_per_year_calculated
+      ? String(trip.trips_per_year)
+      : ''
+  const initialCost =
+    trip.cost_per_night_used !== trip.cost_per_night_default
+      ? String(trip.cost_per_night_used)
+      : ''
+  const initialPerDiem =
+    trip.per_diem_per_night_used !== trip.per_diem_per_night_default
+      ? String(trip.per_diem_per_night_used)
+      : ''
+
+  const [skip, setSkip] = useState<boolean>(trip.is_skipped)
+  const [skipReason, setSkipReason] = useState<string>(trip.skip_reason ?? '')
+  const [nights, setNights] = useState<string>(initialNights)
+  const [trips, setTrips] = useState<string>(initialTrips)
+  const [costPerNight, setCostPerNight] = useState<string>(initialCost)
+  const [perDiem, setPerDiem] = useState<string>(initialPerDiem)
+  const [reason, setReason] = useState<string>('')
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  // Live preview using the same arithmetic as the backend calculator.
+  // crew_size + include_per_diem aren't in the trip — derive include
+  // by whether per-diem cost was non-zero in the saved trip.
+  const includePerDiem = trip.annual_per_diem_cost > 0 || trip.per_diem_per_night_default > 0
+  const crewSizeFromTrip =
+    trip.annual_per_diem_cost > 0 && trip.per_diem_per_night_used > 0 && trip.annual_nights > 0
+      ? Math.round(
+          trip.annual_per_diem_cost / (trip.annual_nights * trip.per_diem_per_night_used)
+        )
+      : 3
+  const previewNights = skip
+    ? 0
+    : nights.trim() === ''
+      ? trip.nights_per_trip_calculated
+      : Math.max(0, Number(nights))
+  const previewTrips = skip
+    ? 0
+    : trips.trim() === ''
+      ? trip.trips_per_year_calculated
+      : Math.max(0, Number(trips))
+  const previewCost =
+    costPerNight.trim() === '' ? trip.cost_per_night_default : Number(costPerNight)
+  const previewPerDiem = perDiem.trim() === '' ? trip.per_diem_per_night_default : Number(perDiem)
+  const previewAnnualNights = previewNights * previewTrips
+  const previewHotel = previewAnnualNights * previewCost
+  const previewPerDiemCost = includePerDiem
+    ? previewAnnualNights * previewPerDiem * crewSizeFromTrip
+    : 0
+  const previewTotal = previewHotel + previewPerDiemCost
+  const delta = previewTotal - trip.annual_total_cost
+
+  const handleSave = async () => {
+    if (skip && !skipReason.trim()) {
+      setError('Reason is required when marking cluster as day-trip')
+      return
+    }
+    setError(null)
+    setSaving(true)
+    try {
+      const token = await getToken()
+      const res = await fetch(
+        `/api/analyses/account/${accountId}/clients/${clientId}/cluster-override`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({
+            cluster_id: trip.cluster_id,
+            cluster_label: trip.cluster_label,
+            skip_overnight: skip,
+            skip_overnight_reason: skip ? skipReason.trim() : null,
+            nights_per_trip_override:
+              !skip && nights.trim() !== '' ? Math.max(0, Number(nights)) : null,
+            trips_per_year_override:
+              !skip && trips.trim() !== '' ? Math.max(0, Number(trips)) : null,
+            cost_per_night_override:
+              !skip && costPerNight.trim() !== '' ? Number(costPerNight) : null,
+            per_diem_per_night_override:
+              !skip && perDiem.trim() !== '' ? Number(perDiem) : null,
+            override_reason: reason.trim() || null,
+          }),
+        }
+      )
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}))
+        throw new Error((j as any).error ?? `HTTP ${res.status}`)
+      }
+      await onSaved()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleClear = async () => {
+    setSaving(true)
+    setError(null)
+    try {
+      const token = await getToken()
+      const res = await fetch(
+        `/api/analyses/account/${accountId}/clients/${clientId}/cluster-override`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({
+            cluster_id: trip.cluster_id,
+            cluster_label: trip.cluster_label,
+            skip_overnight: false,
+            nights_per_trip_override: null,
+            trips_per_year_override: null,
+            cost_per_night_override: null,
+            per_diem_per_night_override: null,
+          }),
+        }
+      )
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}))
+        throw new Error((j as any).error ?? `HTTP ${res.status}`)
+      }
+      await onSaved()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <Dialog open onOpenChange={(v) => !v && !saving && onClose()}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>{trip.cluster_label}</DialogTitle>
+          <DialogDescription>
+            From {trip.branch_name} · {trip.drive_hours_one_way} hr ·{' '}
+            {trip.drive_distance_miles_one_way} mi one-way ·{' '}
+            {trip.properties_in_cluster.length} propert
+            {trip.properties_in_cluster.length === 1 ? 'y' : 'ies'}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="rounded-md border border-border bg-surface-subtle p-3 text-xs space-y-1">
+            <p className="text-[10px] uppercase tracking-wider text-fg-subtle font-semibold">
+              Calculated baseline
+            </p>
+            <p className="text-fg font-tabular leading-relaxed">
+              {trip.calculation_text}
+            </p>
+          </div>
+
+          <div className="space-y-2">
+            <label className="flex items-start gap-2 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={skip}
+                onChange={(e) => setSkip(e.target.checked)}
+                className="mt-1 rounded border-border accent-accent"
+                disabled={saving}
+              />
+              <div>
+                <p className="text-sm font-medium text-fg">
+                  Mark cluster as day-trip (no overnight)
+                </p>
+                <p className="text-xs text-fg-muted">
+                  All overnight + per diem costs go to $0 for this cluster.
+                </p>
+              </div>
+            </label>
+            {skip && (
+              <FormField label="Reason (required)">
+                <Input
+                  value={skipReason}
+                  onChange={(e) => setSkipReason(e.target.value)}
+                  placeholder="e.g. crew can do it as a long day trip"
+                  disabled={saving}
+                />
+              </FormField>
+            )}
+          </div>
+
+          <div className={skip ? 'opacity-50 pointer-events-none' : ''}>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              <FormField
+                label="Nights per trip"
+                helper={`Calculated: ${trip.nights_per_trip_calculated}`}
+              >
+                <Input
+                  type="number"
+                  min="0"
+                  step="1"
+                  value={nights}
+                  onChange={(e) => setNights(e.target.value)}
+                  placeholder={String(trip.nights_per_trip_calculated)}
+                  disabled={saving || skip}
+                />
+              </FormField>
+              <FormField
+                label="Trips per year"
+                helper={`Calculated: ${trip.trips_per_year_calculated}`}
+              >
+                <Input
+                  type="number"
+                  min="0"
+                  step="1"
+                  value={trips}
+                  onChange={(e) => setTrips(e.target.value)}
+                  placeholder={String(trip.trips_per_year_calculated)}
+                  disabled={saving || skip}
+                />
+              </FormField>
+              <FormField
+                label="Cost per night ($)"
+                helper={`Default: $${trip.cost_per_night_default}`}
+              >
+                <Input
+                  type="number"
+                  min="0"
+                  step="any"
+                  value={costPerNight}
+                  onChange={(e) => setCostPerNight(e.target.value)}
+                  placeholder={String(trip.cost_per_night_default)}
+                  disabled={saving || skip}
+                />
+              </FormField>
+              <FormField
+                label="Per diem per night ($)"
+                helper={`Default: $${trip.per_diem_per_night_default}`}
+              >
+                <Input
+                  type="number"
+                  min="0"
+                  step="any"
+                  value={perDiem}
+                  onChange={(e) => setPerDiem(e.target.value)}
+                  placeholder={String(trip.per_diem_per_night_default)}
+                  disabled={saving || skip}
+                />
+              </FormField>
+            </div>
+          </div>
+
+          <FormField label="Reason (optional)">
+            <Textarea
+              rows={2}
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+              placeholder="Why is this overridden?"
+              disabled={saving}
+            />
+          </FormField>
+
+          <div className="rounded-md border border-accent/30 bg-accent/5 p-3 text-xs space-y-1">
+            <p className="text-[10px] uppercase tracking-wider text-fg-subtle font-semibold">
+              Preview with overrides
+            </p>
+            {skip ? (
+              <p className="text-fg font-tabular">
+                $0 — cluster will be served as day trips
+              </p>
+            ) : (
+              <>
+                <p className="text-fg font-tabular">
+                  Annual nights: {previewAnnualNights} · Annual cost: $
+                  {Math.round(previewTotal).toLocaleString()}{' '}
+                  <span
+                    className={delta === 0 ? 'text-fg-subtle' : delta > 0 ? 'text-danger' : 'text-success'}
+                  >
+                    ({delta === 0 ? 'no change' : `${delta > 0 ? '+' : '−'}$${Math.abs(Math.round(delta)).toLocaleString()}`})
+                  </span>
+                </p>
+                <p className="text-fg-muted font-tabular">
+                  Hotel: {previewAnnualNights} × ${previewCost.toFixed(0)} = $
+                  {Math.round(previewHotel).toLocaleString()}
+                </p>
+                <p className="text-fg-muted font-tabular">
+                  Per diem: {previewAnnualNights} × {crewSizeFromTrip} crew × $
+                  {previewPerDiem.toFixed(0)} = $
+                  {Math.round(previewPerDiemCost).toLocaleString()}
+                </p>
+              </>
+            )}
+          </div>
+
+          {error && <p className="text-xs text-danger">{error}</p>}
+        </div>
+
+        <DialogFooter>
+          <Button variant="ghost" onClick={onClose} disabled={saving}>
+            Cancel
+          </Button>
+          {trip.has_overrides || trip.is_skipped ? (
+            <Button variant="ghost" onClick={handleClear} disabled={saving}>
+              <RotateCcw className="h-3 w-3 mr-1" />
+              Clear overrides
+            </Button>
+          ) : null}
+          <Button onClick={handleSave} disabled={saving}>
+            {saving ? (
+              <>
+                <Loader2 className="h-3 w-3 mr-1 animate-spin" />
+                Saving…
+              </>
+            ) : (
+              'Save'
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   )
 }

--- a/src/components/analysis/OvernightLodgingSection.tsx
+++ b/src/components/analysis/OvernightLodgingSection.tsx
@@ -27,6 +27,9 @@ interface BreakdownResponse {
     trips: any[]
     properties_requiring_overnight: number
     day_trip_property_count: number
+    cluster_count_with_overrides?: number
+    cluster_count_skipped?: number
+    cluster_count_borderline?: number
   }
   resolved: {
     value: number
@@ -317,6 +320,28 @@ export default function OvernightLodgingSection({
                 </>
               )}
             </p>
+            {((breakdown.result.cluster_count_borderline ?? 0) > 0 ||
+              (breakdown.result.cluster_count_with_overrides ?? 0) > 0 ||
+              (breakdown.result.cluster_count_skipped ?? 0) > 0) && (
+              <p className="mt-1 text-[11px] text-fg-muted flex flex-wrap items-center gap-x-3">
+                {(breakdown.result.cluster_count_borderline ?? 0) > 0 && (
+                  <span className="text-warning">
+                    ⚠ {breakdown.result.cluster_count_borderline} borderline
+                  </span>
+                )}
+                {(breakdown.result.cluster_count_with_overrides ?? 0) > 0 && (
+                  <span className="text-accent">
+                    ⚙ {breakdown.result.cluster_count_with_overrides} override
+                    {breakdown.result.cluster_count_with_overrides === 1 ? '' : 's'} applied
+                  </span>
+                )}
+                {(breakdown.result.cluster_count_skipped ?? 0) > 0 && (
+                  <span>
+                    ⊘ {breakdown.result.cluster_count_skipped} skipped
+                  </span>
+                )}
+              </p>
+            )}
             <div className="mt-3 flex flex-wrap items-center gap-2">
               <Button
                 size="sm"

--- a/supabase/migrations/20260430201409_phase_4_1_overnight_cluster_overrides.sql
+++ b/supabase/migrations/20260430201409_phase_4_1_overnight_cluster_overrides.sql
@@ -1,0 +1,60 @@
+-- Phase 4.1 — overnight cost transparency.
+--
+-- Per-cluster overrides for overnight calculation. cluster_id is a
+-- stable sha256 prefix of the sorted property_ids in the cluster, so
+-- the same set of properties produces the same id across re-runs and
+-- the override survives. If properties move between clusters, the id
+-- shifts and the override is treated as stale.
+
+CREATE TABLE IF NOT EXISTS public.overnight_cluster_overrides (
+  id                                uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  account_id                        uuid NOT NULL REFERENCES public.accounts(id) ON DELETE CASCADE,
+  client_id                         uuid NOT NULL REFERENCES public.clients(id) ON DELETE CASCADE,
+
+  cluster_id                        text NOT NULL,
+  cluster_label                     text NOT NULL,
+
+  nights_per_trip_override          int,
+  trips_per_year_override           int,
+  cost_per_night_override           numeric,
+  per_diem_per_night_override       numeric,
+
+  skip_overnight                    boolean NOT NULL DEFAULT false,
+  skip_overnight_reason             text,
+
+  override_reason                   text,
+  overridden_by                     text,
+  overridden_at                     timestamptz NOT NULL DEFAULT now()
+);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'oco_unique_per_cluster') THEN
+    ALTER TABLE public.overnight_cluster_overrides
+      ADD CONSTRAINT oco_unique_per_cluster
+      UNIQUE (account_id, client_id, cluster_id);
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'oco_nights_chk') THEN
+    ALTER TABLE public.overnight_cluster_overrides
+      ADD CONSTRAINT oco_nights_chk
+      CHECK (nights_per_trip_override IS NULL OR nights_per_trip_override >= 0);
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'oco_trips_chk') THEN
+    ALTER TABLE public.overnight_cluster_overrides
+      ADD CONSTRAINT oco_trips_chk
+      CHECK (trips_per_year_override IS NULL OR trips_per_year_override >= 0);
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'oco_cost_per_night_chk') THEN
+    ALTER TABLE public.overnight_cluster_overrides
+      ADD CONSTRAINT oco_cost_per_night_chk
+      CHECK (cost_per_night_override IS NULL OR cost_per_night_override >= 0);
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'oco_per_diem_chk') THEN
+    ALTER TABLE public.overnight_cluster_overrides
+      ADD CONSTRAINT oco_per_diem_chk
+      CHECK (per_diem_per_night_override IS NULL OR per_diem_per_night_override >= 0);
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS oco_account_client_idx
+  ON public.overnight_cluster_overrides(account_id, client_id);


### PR DESCRIPTION
## Summary
- New \`overnight_cluster_overrides\` table; cluster_id is a stable sha256 prefix of sorted property IDs so saved overrides persist across analysis re-runs. If property contents shift, the id changes and the override is surfaced as stale.
- Calculator (\`overnight-calculator.ts\`) now applies per-cluster overrides (nights/trip, trips/year, cost/night, per-diem, or full skip), generates a human-readable \`calculation_text\`, and flags clusters with one-way drive 3.0-3.5 hr as borderline. New aggregate counts (cluster_count_borderline / _with_overrides / _skipped, stale_override_cluster_ids).
- New endpoint \`POST /api/analyses/account/[accountId]/clients/[clientId]/cluster-override\` upserts (or clears, if all values are null and skip is false). \`overnight-breakdown\` GET loads overrides and applies them server-side.
- UI: drawer renders borderline / override / skipped badges per cluster card, the \`calculation_text\` explainer, and an "Edit" affordance per cluster that opens a modal with the override editor and a live cost-delta preview. Cost Assumptions summary card surfaces the new aggregate counts.

## Test plan
- [ ] Open Cost Assumptions → Overnight & lodging → "View detailed breakdown".
- [ ] Each cluster card shows the calculation explainer + drive distance + miles.
- [ ] Cluster with drive 3.0-3.5 hr gets the borderline badge.
- [ ] Click "Edit" on a cluster: modal opens with calculated baseline and override fields.
- [ ] Change "Nights per trip" → preview Annual nights and cost shift correctly with delta indicator.
- [ ] Mark "Skip overnight" → other fields disable, preview shows \$0 with reason required.
- [ ] Save → drawer refreshes, override badge appears, summary card "X overrides applied" increments.
- [ ] Clear overrides → row removed, baseline values return.
- [ ] Re-run analysis with same property set → cluster_id stable, override still applied.
- [ ] \`npx tsc --noEmit\` and \`npm run build\` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)