### PR TITLE
Fix constraint-template dialog visibility + sticky footer

### DIFF
--- a/src/components/property/EditTemplateDialog.tsx
+++ b/src/components/property/EditTemplateDialog.tsx
@@ -154,15 +154,15 @@ export default function EditTemplateDialog({
 
   return (
     <Dialog open={open} onOpenChange={(o) => { if (!o) onClose() }}>
-      <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
-        <DialogHeader>
+      <DialogContent className="max-w-2xl max-h-[90vh] flex flex-col gap-4 p-0">
+        <DialogHeader className="px-6 pt-6">
           <DialogTitle>{template ? 'Edit template' : 'New template'}</DialogTitle>
           <DialogDescription>
             Bundle constraints into a template, then apply it to many service locations in one go.
           </DialogDescription>
         </DialogHeader>
 
-        <div className="space-y-5">
+        <div className="space-y-5 overflow-y-auto px-6 flex-1 min-h-0">
           <FormField label="Name" htmlFor="tpl-name">
             <Input
               id="tpl-name"
@@ -279,10 +279,14 @@ export default function EditTemplateDialog({
             </Button>
           </div>
 
-          {error && <p className="text-xs text-danger">{error}</p>}
         </div>
 
-        <DialogFooter>
+        <DialogFooter className="px-6 pb-6 pt-3 border-t border-border">
+          {error && (
+            <p className="text-xs text-danger flex-1 sm:text-left text-center">
+              {error}
+            </p>
+          )}
           <Button variant="ghost" onClick={onClose}>Cancel</Button>
           <Button onClick={handleSave} loading={submitting}>
             {template ? 'Save changes' : 'Create template'}

--- a/src/components/ui/Dialog.tsx
+++ b/src/components/ui/Dialog.tsx
@@ -22,7 +22,9 @@ export const DialogOverlay = forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      'fixed inset-0 z-50 bg-fg/30 backdrop-blur-sm',
+      // Stronger backdrop than before — at fg/30 the page bled through
+      // enough that the elevated surface looked translucent in dark mode.
+      'fixed inset-0 z-50 bg-fg/60 backdrop-blur-md',
       'data-[state=open]:animate-in data-[state=open]:fade-in-0',
       'data-[state=closed]:animate-out data-[state=closed]:fade-out-0',
       className


### PR DESCRIPTION
## Summary
- New-template dialog had the scrollable body and the action footer (Cancel / Create template) inside the same overflow region — on a tall form the buttons scrolled below the fold and looked unresponsive. Restructured DialogContent as a flex column so the header pins to top, body scrolls in the middle, footer stays anchored.
- Validation error message moved into the footer next to the action buttons so users see immediately why "Create template" did nothing (e.g. missing name or empty constraint list).
- Bumped global modal backdrop from \`bg-fg/30 backdrop-blur-sm\` to \`bg-fg/60 backdrop-blur-md\` so the elevated surface stops looking translucent against the page below — particularly noticeable on dark mode where \`bg-elevated\` (#18181b) is only one zinc step above \`bg\` (#09090b).

## Test plan
- [ ] Open Constraint templates page → click New template.
- [ ] Cancel and Create template buttons are visible without scrolling, even when the form has many constraints.
- [ ] Click Create template with empty name → red error appears next to the button.
- [ ] Backdrop noticeably darkens the page; the dialog looks clearly elevated, not washed out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)