### PR TITLE
Fix invisible click feedback on constraint-template enforcement + day buttons

### DIFF
--- a/src/components/property/ConstraintConfigEditor.tsx
+++ b/src/components/property/ConstraintConfigEditor.tsx
@@ -82,12 +82,13 @@ function DayOfWeekForm({
             <button
               key={i}
               type="button"
+              aria-pressed={on}
               onClick={() => toggle(i)}
               className={cn(
-                'flex-1 rounded-md border px-2 py-2 text-xs font-medium transition-colors',
+                'flex-1 rounded-md border-2 px-2 py-2 text-xs font-medium transition-colors',
                 on
-                  ? 'border-accent bg-accent/10 text-fg'
-                  : 'border-border bg-surface text-fg-subtle hover:text-fg'
+                  ? 'border-accent bg-accent text-accent-fg'
+                  : 'border-border bg-surface text-fg-subtle hover:border-border-strong hover:text-fg'
               )}
             >
               {label}

--- a/src/components/property/EditTemplateDialog.tsx
+++ b/src/components/property/EditTemplateDialog.tsx
@@ -154,15 +154,15 @@ export default function EditTemplateDialog({
 
   return (
     <Dialog open={open} onOpenChange={(o) => { if (!o) onClose() }}>
-      <DialogContent className="max-w-2xl max-h-[90vh] flex flex-col gap-4 p-0">
-        <DialogHeader className="px-6 pt-6">
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
           <DialogTitle>{template ? 'Edit template' : 'New template'}</DialogTitle>
           <DialogDescription>
             Bundle constraints into a template, then apply it to many service locations in one go.
           </DialogDescription>
         </DialogHeader>
 
-        <div className="space-y-5 overflow-y-auto px-6 flex-1 min-h-0">
+        <div className="space-y-5 max-h-[60vh] overflow-y-auto pr-1 -mr-1">
           <FormField label="Name" htmlFor="tpl-name">
             <Input
               id="tpl-name"
@@ -246,24 +246,33 @@ export default function EditTemplateDialog({
 
             <FormField label="Enforcement">
               <div className="flex gap-2">
-                {(['hard', 'soft'] as const).map((opt) => (
-                  <button
-                    key={opt}
-                    type="button"
-                    onClick={() => setDraftEnforcement(opt)}
-                    className={cn(
-                      'flex-1 rounded-md border px-3 py-2 text-sm transition-colors',
-                      draftEnforcement === opt
-                        ? 'border-accent bg-accent/10 text-fg'
-                        : 'border-border bg-surface text-fg-muted hover:text-fg'
-                    )}
-                  >
-                    <span className="font-medium capitalize">{opt}</span>
-                    <span className="block text-[11px] text-fg-subtle mt-0.5">
-                      {opt === 'hard' ? 'Must satisfy' : 'Preference'}
-                    </span>
-                  </button>
-                ))}
+                {(['hard', 'soft'] as const).map((opt) => {
+                  const selected = draftEnforcement === opt
+                  return (
+                    <button
+                      key={opt}
+                      type="button"
+                      aria-pressed={selected}
+                      onClick={() => setDraftEnforcement(opt)}
+                      className={cn(
+                        'flex-1 rounded-md border-2 px-3 py-2 text-sm transition-colors',
+                        selected
+                          ? 'border-accent bg-accent text-accent-fg'
+                          : 'border-border bg-surface text-fg-muted hover:border-border-strong hover:text-fg'
+                      )}
+                    >
+                      <span className="font-medium capitalize">{opt}</span>
+                      <span
+                        className={cn(
+                          'block text-[11px] mt-0.5',
+                          selected ? 'text-accent-fg/80' : 'text-fg-subtle'
+                        )}
+                      >
+                        {opt === 'hard' ? 'Must satisfy' : 'Preference'}
+                      </span>
+                    </button>
+                  )
+                })}
               </div>
             </FormField>
 
@@ -281,9 +290,9 @@ export default function EditTemplateDialog({
 
         </div>
 
-        <DialogFooter className="px-6 pb-6 pt-3 border-t border-border">
+        <DialogFooter>
           {error && (
-            <p className="text-xs text-danger flex-1 sm:text-left text-center">
+            <p className="text-xs text-danger flex-1 sm:text-left text-center self-center">
               {error}
             </p>
           )}


### PR DESCRIPTION
## Summary
The Hard/Soft and day-of-week toggle buttons were using \`bg-accent/10\` (10% indigo) for the selected state against \`bg-surface\` (white) inside a \`bg-surface-subtle\` (#fafafa) panel — three near-white shades stacked. Clicks were registering and state was updating, but the visual delta was tiny enough that users read it as "nothing happened." Day-of-week made it worse: the default has Mon–Fri pre-selected, so the first click *removes* a day, which feels like nothing changed.

Switched the selected state to **solid \`bg-accent\` with white text and a thicker border** so the active state is unambiguous, and added \`aria-pressed\` for assistive tech.

Also reverted the previous PR's \`flex flex-col p-0\` override on DialogContent. \`clsx\` doesn't tailwind-merge, so those classes lost to the base \`grid\` / \`p-6\` that Tailwind emits later in the stylesheet — the "footer always visible" claim wasn't actually working. Replaced with a simple \`max-h-[60vh] overflow-y-auto\` on the form body, leaving DialogContent's natural grid layout intact.

## Test plan
- [ ] Open Constraint templates → New template.
- [ ] Click Soft → button visibly fills indigo with white text.
- [ ] Click Hard → indigo flips back to Hard, Soft returns to neutral.
- [ ] In Allowed days, click any day → toggles between filled indigo and outlined neutral with no ambiguity.
- [ ] Footer stays visible while form body scrolls when many constraints are added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)