### PR TITLE
Fix constraint-template toggles by switching to native label+input

### DIFF
--- a/src/components/property/ConstraintConfigEditor.tsx
+++ b/src/components/property/ConstraintConfigEditor.tsx
@@ -79,20 +79,23 @@ function DayOfWeekForm({
         {DAY_LABELS.map((label, i) => {
           const on = days.has(i)
           return (
-            <button
+            <label
               key={i}
-              type="button"
-              aria-pressed={on}
-              onClick={() => toggle(i)}
               className={cn(
-                'flex-1 rounded-md border-2 px-2 py-2 text-xs font-medium transition-colors',
+                'flex-1 text-center rounded-md border-2 px-2 py-2 text-xs font-medium transition-colors cursor-pointer',
                 on
                   ? 'border-accent bg-accent text-accent-fg'
                   : 'border-border bg-surface text-fg-subtle hover:border-border-strong hover:text-fg'
               )}
             >
+              <input
+                type="checkbox"
+                checked={on}
+                onChange={() => toggle(i)}
+                className="sr-only"
+              />
               {label}
-            </button>
+            </label>
           )
         })}
       </div>

--- a/src/components/property/EditTemplateDialog.tsx
+++ b/src/components/property/EditTemplateDialog.tsx
@@ -249,18 +249,23 @@ export default function EditTemplateDialog({
                 {(['hard', 'soft'] as const).map((opt) => {
                   const selected = draftEnforcement === opt
                   return (
-                    <button
+                    <label
                       key={opt}
-                      type="button"
-                      aria-pressed={selected}
-                      onClick={() => setDraftEnforcement(opt)}
                       className={cn(
-                        'flex-1 rounded-md border-2 px-3 py-2 text-sm transition-colors',
+                        'flex-1 rounded-md border-2 px-3 py-2 text-sm transition-colors cursor-pointer',
                         selected
                           ? 'border-accent bg-accent text-accent-fg'
                           : 'border-border bg-surface text-fg-muted hover:border-border-strong hover:text-fg'
                       )}
                     >
+                      <input
+                        type="radio"
+                        name="enforcement"
+                        value={opt}
+                        checked={selected}
+                        onChange={() => setDraftEnforcement(opt)}
+                        className="sr-only"
+                      />
                       <span className="font-medium capitalize">{opt}</span>
                       <span
                         className={cn(
@@ -270,7 +275,7 @@ export default function EditTemplateDialog({
                       >
                         {opt === 'hard' ? 'Must satisfy' : 'Preference'}
                       </span>
-                    </button>
+                    </label>
                   )
                 })}
               </div>


### PR DESCRIPTION
## Summary
The Hard/Soft enforcement toggle and the day-of-week toggle in the constraint-template dialog were custom \`<button onClick={...}>\` elements. User reports across two prior fix attempts that clicks on those buttons don't produce any state change at all (not a visual-feedback issue — actually nothing happens).

Switched both to **native** \`<label>\` wrapping a visually-hidden \`<input type="radio">\` (Hard/Soft) and \`<input type="checkbox">\` (day toggles). Clicking the label is a browser-native form-control activation — there's no React synthetic event for some other listener to swallow, no Radix portal to intercept it, no chance of a custom button being shadowed by another element. The visual language stays the same: solid indigo when selected, bordered neutral when not.

## Test plan
- [ ] Open Constraint templates → New template.
- [ ] Click Soft → fills indigo, Hard returns to neutral.
- [ ] Click Hard → flips back.
- [ ] In Allowed days, click any day → toggles independently.
- [ ] Add to template → constraint is added with the selected enforcement and selected days.

🤖 Generated with [Claude Code](https://claude.com/claude-code)