### PR TITLE
Fix popup transparency and constraint-template toggle clicks

### DIFF
--- a/src/components/property/ConstraintConfigEditor.tsx
+++ b/src/components/property/ConstraintConfigEditor.tsx
@@ -79,20 +79,23 @@ function DayOfWeekForm({
         {DAY_LABELS.map((label, i) => {
           const on = days.has(i)
           return (
-            <button
+            <label
               key={i}
-              type="button"
-              aria-pressed={on}
-              onClick={() => toggle(i)}
               className={cn(
-                'flex-1 rounded-md border-2 px-2 py-2 text-xs font-medium transition-colors',
+                'flex-1 text-center rounded-md border-2 px-2 py-2 text-xs font-medium transition-colors cursor-pointer',
                 on
                   ? 'border-accent bg-accent text-accent-fg'
                   : 'border-border bg-surface text-fg-subtle hover:border-border-strong hover:text-fg'
               )}
             >
+              <input
+                type="checkbox"
+                checked={on}
+                onChange={() => toggle(i)}
+                className="sr-only"
+              />
               {label}
-            </button>
+            </label>
           )
         })}
       </div>

--- a/src/components/property/EditTemplateDialog.tsx
+++ b/src/components/property/EditTemplateDialog.tsx
@@ -249,18 +249,23 @@ export default function EditTemplateDialog({
                 {(['hard', 'soft'] as const).map((opt) => {
                   const selected = draftEnforcement === opt
                   return (
-                    <button
+                    <label
                       key={opt}
-                      type="button"
-                      aria-pressed={selected}
-                      onClick={() => setDraftEnforcement(opt)}
                       className={cn(
-                        'flex-1 rounded-md border-2 px-3 py-2 text-sm transition-colors',
+                        'flex-1 rounded-md border-2 px-3 py-2 text-sm transition-colors cursor-pointer',
                         selected
                           ? 'border-accent bg-accent text-accent-fg'
                           : 'border-border bg-surface text-fg-muted hover:border-border-strong hover:text-fg'
                       )}
                     >
+                      <input
+                        type="radio"
+                        name="enforcement"
+                        value={opt}
+                        checked={selected}
+                        onChange={() => setDraftEnforcement(opt)}
+                        className="sr-only"
+                      />
                       <span className="font-medium capitalize">{opt}</span>
                       <span
                         className={cn(
@@ -270,7 +275,7 @@ export default function EditTemplateDialog({
                       >
                         {opt === 'hard' ? 'Must satisfy' : 'Preference'}
                       </span>
-                    </button>
+                    </label>
                   )
                 })}
               </div>

--- a/src/components/ui/Dialog.tsx
+++ b/src/components/ui/Dialog.tsx
@@ -48,11 +48,13 @@ export const DialogContent = forwardRef<
     <DialogOverlay />
     <DialogPrimitive.Content
       ref={ref}
+      // No fade-in — the user reported the open animation made the
+      // dialog briefly transparent enough to read content underneath.
+      // Keep the gentle scale (zoom-in-95) but skip opacity entirely.
       className={cn(
         'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%]',
         'gap-4 border border-border bg-surface-elevated p-6 shadow-lg rounded-lg',
         'data-[state=open]:animate-in data-[state=closed]:animate-out',
-        'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
         'data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
         className
       )}

--- a/src/components/ui/DropdownMenu.tsx
+++ b/src/components/ui/DropdownMenu.tsx
@@ -19,11 +19,12 @@ export const DropdownMenuContent = forwardRef<
     <DropdownMenuPrimitive.Content
       ref={ref}
       sideOffset={sideOffset}
+      // No fade-in — popups must be solid from the moment they appear so
+      // labels behind them can never be read through.
       className={cn(
         'z-50 min-w-[12rem] overflow-hidden rounded-md border border-border bg-surface-elevated p-1',
         'shadow-md text-fg',
         'data-[state=open]:animate-in data-[state=closed]:animate-out',
-        'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
         'data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
         'data-[side=bottom]:slide-in-from-top-2 data-[side=top]:slide-in-from-bottom-2',
         className

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -43,11 +43,13 @@ export const SelectContent = forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       position={position}
+      // No fade-in — user reported the open animation showed content
+      // through the dropdown. Skip the opacity transition; keep the
+      // subtle scale.
       className={cn(
         'relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border border-border bg-surface-elevated text-fg',
         'shadow-md',
         'data-[state=open]:animate-in data-[state=closed]:animate-out',
-        'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
         'data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
         position === 'popper' &&
           'data-[side=bottom]:translate-y-1 data-[side=top]:-translate-y-1',


### PR DESCRIPTION
## Summary
Two issues fixed:

1. **Popup transparency.** Dialog content, Select dropdowns, and DropdownMenu content all used a fade-in animation (\`opacity 0 → 1\`). For the duration of that fade, the user could read content through the popup. The user explicitly banned transparent popups. Removed the \`fade-in-0\` / \`fade-out-0\` classes from all three primitives. Popups now appear opaque the instant they render. Kept the subtle \`zoom-in-95\` scale for a touch of motion polish.

2. **Constraint-template toggle clicks.** Hard/Soft enforcement and day-of-week toggles were custom \`<button onClick={...}>\` elements. User reported clicks produced no state change at all (not a visual-feedback issue — actually nothing happens). Replaced with native \`<label>\` wrapping a visually-hidden \`<input type="radio">\` (Hard/Soft) and \`<input type="checkbox">\` (day toggles). Clicking the label is browser-native form activation — there's no React onClick for anything to intercept or swallow. Same indigo-fill / bordered-neutral visual.

## Test plan
- [ ] Open Constraint templates → New template.
- [ ] Click the Type dropdown → it appears solid (no transparency, can't read form fields through it).
- [ ] Click "Soft" → the box fills indigo with white text, "Hard" returns to neutral.
- [ ] Click "Hard" → flips back, identical responsiveness to typing in the Name field.
- [ ] In Allowed days, click Tue (currently selected by default) → it deselects (indigo → neutral).
- [ ] Click Tue again → it reselects (neutral → indigo).
- [ ] Add a constraint, then save the template → the saved template reflects the selections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)