### PR TITLE
Constrain dialog height: switch base layout from grid to flex-col

### DIFF
--- a/src/components/ui/Dialog.tsx
+++ b/src/components/ui/Dialog.tsx
@@ -56,8 +56,12 @@ export const DialogContent = forwardRef<
         opacity: 1,
         ...style,
       }}
+      // flex flex-col (not grid) so consumers can mark a child as
+      // flex-1 min-h-0 overflow-y-auto and have the list scroll inside
+      // the dialog. grid + a min-content child grows the dialog to fit
+      // the content (the bug behind 1000-item lists overflowing).
       className={cn(
-        'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%]',
+        'fixed left-[50%] top-[50%] z-50 flex flex-col w-full max-w-lg max-h-[90vh] translate-x-[-50%] translate-y-[-50%]',
         'gap-4 border border-border p-6 shadow-2xl rounded-lg',
         'data-[state=open]:animate-in data-[state=closed]:animate-out',
         'data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',


### PR DESCRIPTION
## Summary
The Apply Template dialog with 1000 service locations grew past the viewport — the list filled with all 1000 rows and the dialog footer (with the Apply button) was off-screen and unreachable.

Root cause is the same Tailwind class-merge ordering issue that bit the EditTemplateDialog earlier: the base \`<DialogContent>\` uses \`display: grid\`. ApplyTemplateDialog passes \`flex flex-col\` on the className to enable a flex-1 scroll region, but \`grid\` wins the class-merge race (Tailwind emits flex utilities before grid in the stylesheet). With grid layout, the child \`flex-1 min-h-0 overflow-y-auto\` wrapper never got a bounded height, so it expanded to fit all 1000 list items.

Switched the base DialogContent from \`grid\` to \`flex flex-col max-h-[90vh]\`. Visually identical for the simple stacked-children case (header + body + footer with gap-4), but consumers can now mark a child \`flex-1 min-h-0 overflow-y-auto\` and have it actually scroll inside the dialog.

## Test plan
- [ ] Open Constraint templates → click "Apply to properties" on any template.
- [ ] List of service locations renders inside a scrollable region; the dialog itself fits within the viewport.
- [ ] Footer with "Close" and "Apply to N" buttons is visible without page scrolling.
- [ ] Filter input + select-all checkbox stay pinned above the list.
- [ ] Other existing dialogs (delete confirmations, account edit, etc.) look unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)