### PR TITLE
Fix branch allocations property loading + make crew-strategy A/B/C clickable

### DIFF
--- a/api/accounts/[accountId]/clients/[clientId]/operational-constraints.ts
+++ b/api/accounts/[accountId]/clients/[clientId]/operational-constraints.ts
@@ -232,6 +232,9 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method === 'PATCH') {
     const body = (req.body ?? {}) as Record<string, unknown>
 
+    const ALLOWED_TEXT = new Set<string>([
+      'crew_strategy_selected_option',
+    ])
     const ALLOWED_NUMERIC = new Set<string>([
       'crew_size',
       'hours_per_day',
@@ -287,6 +290,9 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         }
       } else if (ALLOWED_JSONB.has(k)) {
         if (v == null || typeof v === 'object') patch[k] = v
+      } else if (ALLOWED_TEXT.has(k)) {
+        if (v == null || v === '') patch[k] = null
+        else if (typeof v === 'string') patch[k] = v
       }
     }
 

--- a/api/analyses/account/[accountId]/clients/[clientId]/bid-pricing-structure.ts
+++ b/api/analyses/account/[accountId]/clients/[clientId]/bid-pricing-structure.ts
@@ -61,6 +61,10 @@ export interface BidInputs {
   target_gross_margin_pct: number
   branch_count: number | null
   crew_count: number | null
+  // Phase 4.2 — user-picked crew strategy option (overrides the
+  // analysis's recommended_option). Falls back to recommended when
+  // null.
+  crew_strategy_selected_option?: 'A' | 'B' | 'C' | null
 }
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
@@ -101,6 +105,10 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       body.target_gross_margin_pct ?? constraints.target_gross_margin_pct,
     branch_count: body.branch_count ?? null,
     crew_count: body.crew_count ?? null,
+    crew_strategy_selected_option:
+      ((constraints as any).crew_strategy_selected_option as
+        | 'A' | 'B' | 'C' | null
+        | undefined) ?? null,
   }
 
   let analysisId: string
@@ -401,7 +409,14 @@ export function computeBidPricing(
   }
 
   if (crewStrategyOutputs) {
-    recommendedOption = crewStrategyOutputs.recommended_option
+    // Phase 4.2 — user can override the analysis's recommended_option
+    // by clicking a card in CrewStrategyChart. Selection arrives via
+    // inputs.crew_strategy_selected_option (passed through from
+    // account_operational_constraints).
+    const userSelected = inputs.crew_strategy_selected_option
+    recommendedOption = (userSelected && ['A', 'B', 'C'].includes(userSelected))
+      ? userSelected
+      : crewStrategyOutputs.recommended_option
     const opt = crewStrategyOutputs.options?.[recommendedOption ?? '']
     if (opt) {
       if (resolvedLabor == null) resolvedLabor = opt.annual_labor_cost

--- a/src/components/analysis/BranchAllocationDialog.tsx
+++ b/src/components/analysis/BranchAllocationDialog.tsx
@@ -129,14 +129,31 @@ export default function BranchAllocationDialog({
       setError(null)
       try {
         const token = await getToken()
-        const res = await fetch(
-          `/api/v1/properties?client_id=${clientId}&pageSize=2000`,
-          { headers: { Authorization: `Bearer ${token}` } }
-        )
-        if (!res.ok) throw new Error(`Load failed: ${res.status}`)
-        const data = (await res.json()) as { items?: PropertyRow[] }
+        // Endpoint returns { properties, total_count, has_more } and the
+        // page-size param is `limit` (capped at 2000 server-side). Loop
+        // pages so clients with thousands of properties all show up.
+        const PAGE = 2000
+        let offset = 0
+        const all: PropertyRow[] = []
+        while (true) {
+          const res = await fetch(
+            `/api/v1/properties?client_id=${clientId}&limit=${PAGE}&offset=${offset}`,
+            { headers: { Authorization: `Bearer ${token}` } }
+          )
+          if (!res.ok) throw new Error(`Load failed: ${res.status}`)
+          const data = (await res.json()) as {
+            properties?: PropertyRow[]
+            has_more?: boolean
+          }
+          const batch = data.properties ?? []
+          all.push(...batch)
+          if (!data.has_more || batch.length === 0) break
+          offset += batch.length
+          // Safety stop in case has_more never flips false.
+          if (offset > 50_000) break
+        }
         if (!cancelled) {
-          setProperties(data.items ?? [])
+          setProperties(all)
           setPending(new Map())
           setSelected(new Set())
         }
@@ -413,6 +430,14 @@ export default function BranchAllocationDialog({
             <div className="flex items-center justify-center p-12 text-fg-muted">
               <Loader2 className="h-4 w-4 animate-spin mr-2" />
               Loading properties…
+            </div>
+          ) : resolved.length === 0 ? (
+            <div className="flex items-center justify-center p-12 text-fg-muted text-sm">
+              No properties found for this client.
+            </div>
+          ) : filtered.length === 0 ? (
+            <div className="flex items-center justify-center p-12 text-fg-muted text-sm">
+              No properties match the current filter.
             </div>
           ) : (
             <Table>

--- a/src/components/analysis/CrewStrategyChart.tsx
+++ b/src/components/analysis/CrewStrategyChart.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import {
   BarChart,
   Bar,
@@ -10,10 +10,11 @@ import {
   Legend,
   CartesianGrid,
 } from 'recharts'
-import { TriangleAlert, Settings2 } from 'lucide-react'
+import { Check, TriangleAlert, Settings2 } from 'lucide-react'
 import { Badge } from '../ui/Badge'
 import Button from '../ui/Button'
 import { Card } from '../ui/Card'
+import { useAuth } from '../../hooks/useAuth'
 import BranchAllocationDialog from './BranchAllocationDialog'
 import {
   Table,
@@ -173,7 +174,64 @@ export default function CrewStrategyChart({
   onAllocationsSaved,
 }: CrewStrategyChartProps) {
   const theme = useChartTheme()
+  const { getToken } = useAuth()
   const [allocOpen, setAllocOpen] = useState(false)
+  // Phase 4.2 — user-selected option (overrides recommended_option in
+  // Bid Pricing). null while loading; falls back to recommended_option
+  // if the user hasn't picked one.
+  const [selectedOption, setSelectedOption] = useState<'A' | 'B' | 'C' | null>(null)
+  const [savingSelection, setSavingSelection] = useState<'A' | 'B' | 'C' | null>(null)
+
+  useEffect(() => {
+    if (!accountId || !clientId) return
+    let cancelled = false
+    ;(async () => {
+      try {
+        const token = await getToken()
+        const res = await fetch(
+          `/api/accounts/${accountId}/clients/${clientId}/operational-constraints`,
+          { headers: { Authorization: `Bearer ${token}` } }
+        )
+        if (!res.ok) return
+        const j = await res.json()
+        if (!cancelled) {
+          const v = j?.crew_strategy_selected_option
+          setSelectedOption(v === 'A' || v === 'B' || v === 'C' ? v : null)
+        }
+      } catch {
+        // non-fatal — fall back to recommended_option
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [accountId, clientId, getToken])
+
+  const saveSelection = async (opt: 'A' | 'B' | 'C') => {
+    if (!accountId || !clientId) return
+    setSavingSelection(opt)
+    // Optimistic update
+    setSelectedOption(opt)
+    try {
+      const token = await getToken()
+      await fetch(
+        `/api/accounts/${accountId}/clients/${clientId}/operational-constraints`,
+        {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({ crew_strategy_selected_option: opt }),
+        }
+      )
+      onAllocationsSaved?.()
+    } finally {
+      setSavingSelection(null)
+    }
+  }
+
+  const activeOption: 'A' | 'B' | 'C' = selectedOption ?? data.recommended_option
   // Per-branch breakdown comes from Option B but applies to any allocation
   // discussion; surface it as a dedicated panel above the option cards.
   const branchBreakdown = data.options.B.utilization_breakdown?.per_branch
@@ -197,15 +255,21 @@ export default function CrewStrategyChart({
 
   return (
     <div className="space-y-6">
-      {/* Recommendation banner — quiet accent-subtle, no gradient. */}
+      {/* Recommendation + active selection banner. */}
       <div className="rounded-md border border-accent/20 bg-accent-subtle px-4 py-3">
         <p className="text-[10px] font-semibold uppercase tracking-wider text-fg-subtle">
-          Recommended
+          {selectedOption && selectedOption !== data.recommended_option
+            ? 'Active (your selection)'
+            : 'Recommended'}
         </p>
         <p className="mt-0.5 text-base font-semibold text-fg">
-          Option {data.recommended_option}: {data.options[data.recommended_option].label}
+          Option {activeOption}: {data.options[activeOption].label}
         </p>
-        <p className="mt-1 text-sm text-fg-muted">{data.recommended_rationale}</p>
+        <p className="mt-1 text-sm text-fg-muted">
+          {selectedOption && selectedOption !== data.recommended_option
+            ? `You picked Option ${selectedOption}. The analysis recommended Option ${data.recommended_option}: ${data.options[data.recommended_option].label}.`
+            : data.recommended_rationale}
+        </p>
       </div>
 
       {/* Phase 3.8 — Building-count math summary */}
@@ -409,15 +473,28 @@ export default function CrewStrategyChart({
         </div>
       </section>
 
-      {/* 3-card option comparison */}
+      {/* 3-card option comparison — click to choose which option flows
+          into Bid Pricing. */}
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-3">
-        {opts.map((o) => (
-          <Card
+        {opts.map((o) => {
+          const isActive = o.key === activeOption
+          const isRecommended = o.key === data.recommended_option
+          const isSaving = savingSelection === o.key
+          return (
+          <button
             key={o.key}
-            padding="md"
-            className={
-              o.key === data.recommended_option ? 'ring-1 ring-accent' : undefined
-            }
+            type="button"
+            onClick={() => saveSelection(o.key)}
+            disabled={isSaving}
+            aria-pressed={isActive}
+            className={cn(
+              'text-left rounded-lg border bg-surface p-4 transition-all',
+              'hover:border-accent/60 hover:shadow-sm',
+              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1',
+              isActive
+                ? 'border-accent ring-2 ring-accent shadow-sm'
+                : 'border-border'
+            )}
           >
             <div className="flex items-start justify-between gap-2">
               <div>
@@ -426,9 +503,17 @@ export default function CrewStrategyChart({
                 </p>
                 <p className="mt-0.5 font-semibold text-fg">{o.label}</p>
               </div>
-              {o.key === data.recommended_option && (
-                <Badge variant="success">Recommended</Badge>
-              )}
+              <div className="flex flex-col items-end gap-1">
+                {isActive && (
+                  <Badge variant="accent" className="inline-flex items-center gap-1">
+                    <Check className="h-3 w-3" />
+                    {selectedOption === o.key ? 'Selected' : 'Active'}
+                  </Badge>
+                )}
+                {isRecommended && !isActive && (
+                  <Badge variant="success">Recommended</Badge>
+                )}
+              </div>
             </div>
 
             <dl className="my-3 grid grid-cols-2 gap-3 border-y border-border py-3 text-sm">
@@ -469,8 +554,14 @@ export default function CrewStrategyChart({
             <p className="mt-3 border-t border-border pt-2 text-xs italic text-fg-subtle">
               Best for: {o.recommended_use_case}
             </p>
-          </Card>
-        ))}
+            <p className="mt-2 text-[10px] text-fg-subtle">
+              {isActive
+                ? 'Used by Bid Pricing.'
+                : 'Click to use this option in Bid Pricing.'}
+            </p>
+          </button>
+          )
+        })}
       </div>
 
       {/* Utilization breakdown for Option B (driven by user-selected scope) */}

--- a/supabase/migrations/20260430215825_phase_4_2_crew_strategy_selected_option.sql
+++ b/supabase/migrations/20260430215825_phase_4_2_crew_strategy_selected_option.sql
@@ -1,0 +1,21 @@
+-- Phase 4.2 — let the user pick which Crew Strategy option (A/B/C)
+-- flows into Bid Pricing instead of always using the analysis's
+-- recommended_option.
+
+ALTER TABLE public.account_operational_constraints
+  ADD COLUMN IF NOT EXISTS crew_strategy_selected_option text;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'aoc_crew_strategy_selected_option_chk'
+  ) THEN
+    ALTER TABLE public.account_operational_constraints
+      ADD CONSTRAINT aoc_crew_strategy_selected_option_chk
+      CHECK (
+        crew_strategy_selected_option IS NULL
+        OR crew_strategy_selected_option IN ('A', 'B', 'C')
+      );
+  END IF;
+END $$;


### PR DESCRIPTION
## Summary
Two fixes from the user's Crew Strategy session:

**1. Branch Allocation dialog showed no properties.** Real bug: the dialog called \`data.items\` with \`pageSize=2000\`, but the endpoint returns \`{ properties, total_count, has_more }\` with \`limit=\` as the param. Fixed both, added a paginating loop so accounts with thousands of properties all load, and added an explicit empty-state message.

**2. Crew Strategy A/B/C cards were not clickable.** They were pure display; no way to override the analysis's \`recommended_option\` for Bid Pricing.
   - New \`account_operational_constraints.crew_strategy_selected_option\` text column (CHECK in 'A','B','C').
   - PATCH endpoint accepts the new field.
   - CrewStrategyChart cards are now buttons. Click one to mark it active. Saves to backend, shows solid indigo ring + "Selected" badge.
   - Bid Pricing reads \`inputs.crew_strategy_selected_option\` and prefers it over \`recommended_option\`.

## Test plan
- [ ] Open Smart Analysis → Crew Strategy → click "Manage assignments" → list of properties loads (was empty before).
- [ ] Filter / select properties / move to a branch → preview updates → Apply works.
- [ ] On the Crew Strategy page, click Option A, B, or C card.
- [ ] Card fills with indigo ring, "Selected" badge appears (or "Active" if it was already the recommendation).
- [ ] Re-run Bid Pricing → cost numbers reflect the selected option's labor + vehicle costs.
- [ ] Reload page → selection persists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)