### PR TITLE
Fix anchor mismatches + Crew Strategy selection-flashing regression

### DIFF
--- a/src/components/analysis/BidPricingChart.tsx
+++ b/src/components/analysis/BidPricingChart.tsx
@@ -1014,7 +1014,7 @@ function renderRowDetail(
           {
             label: 'Drive miles',
             source: 'routing template',
-            link: { href: '#crew-strategy', label: 'Open Crew Strategy' },
+            link: { href: '#module-crew_strategy', label: 'Open Crew Strategy' },
           },
         ],
         editable: [
@@ -1036,7 +1036,7 @@ function renderRowDetail(
           {
             kind: 'navigate',
             label: 'Edit per-crew vehicle config',
-            href: '#cost-group-vehicle--fuel',
+            href: '#cost-group-vehicle-fuel',
           },
         ],
       }
@@ -1074,7 +1074,7 @@ function renderRowDetail(
           {
             label: 'Selected branches',
             source: 'Branch Decision',
-            link: { href: '#branch-decision', label: 'Edit branch selection' },
+            link: { href: '#module-branch_optimization', label: 'Edit branch selection' },
           },
         ],
         editable: [],
@@ -1082,7 +1082,7 @@ function renderRowDetail(
           {
             kind: 'navigate',
             label: 'Edit per-branch overhead config',
-            href: '#cost-group-branch--operational-costs',
+            href: '#cost-group-branch-operational-costs',
           },
         ],
       }
@@ -1154,7 +1154,7 @@ function renderRowDetail(
           {
             kind: 'navigate',
             label: 'Edit per-line margins (Service Line Pricing)',
-            href: '#cost-group-branch--operational-costs',
+            href: '#cost-group-service-line-pricing',
           },
         ],
       }

--- a/src/components/analysis/CrewStrategyChart.tsx
+++ b/src/components/analysis/CrewStrategyChart.tsx
@@ -210,7 +210,13 @@ export default function CrewStrategyChart({
   const saveSelection = async (opt: 'A' | 'B' | 'C') => {
     if (!accountId || !clientId) return
     setSavingSelection(opt)
-    // Optimistic update
+    // Optimistic update — keep this even after save completes so the
+    // ring stays on the chosen card. We deliberately do NOT call
+    // onAllocationsSaved here because that re-runs Crew Strategy,
+    // which remounts this chart and resets selectedOption to null
+    // while the GET races to refetch the saved value (the "flash"
+    // back to recommended). The selection only affects Bid Pricing,
+    // and Bid Pricing reads the value when it next runs.
     setSelectedOption(opt)
     try {
       const token = await getToken()
@@ -225,7 +231,6 @@ export default function CrewStrategyChart({
           body: JSON.stringify({ crew_strategy_selected_option: opt }),
         }
       )
-      onAllocationsSaved?.()
     } finally {
       setSavingSelection(null)
     }

--- a/src/components/analysis/ServiceLinePricingSection.tsx
+++ b/src/components/analysis/ServiceLinePricingSection.tsx
@@ -144,7 +144,10 @@ export default function ServiceLinePricingSection({
   }
 
   return (
-    <section className="space-y-3 mt-6">
+    <section
+      id="cost-group-service-line-pricing"
+      className="space-y-3 mt-6 scroll-mt-16"
+    >
       <header>
         <h3 className="text-sm font-semibold text-fg">Service line pricing</h3>
         <p className="text-xs text-fg-muted mt-0.5">


### PR DESCRIPTION
## Summary
Audit-found bugs + a user-reported regression:

1. **Crew Strategy Option A/B/C selection was flashing back to the recommended option** immediately after click. \`saveSelection\` was calling \`onAllocationsSaved\` (which re-runs the crew strategy module). Re-running remounts the chart and resets \`selectedOption\` to null while the GET races to refetch the saved value — that's the flash. Selection only ever affects Bid Pricing, so removed the callback. The PATCH still persists, and the optimistic update keeps the ring on the chosen card.

2. **BidPricingChart anchor mismatches** (introduced by Phase 4.2). \`CostAssumptionsPanel\`'s slug fn collapses non-alphanumerics to *single* hyphens, so "Vehicle & fuel" → \`cost-group-vehicle-fuel\` (one hyphen). The bid card was using double-hyphen variants which matched no element. Fixed three:
   - \`#cost-group-vehicle--fuel\` → \`#cost-group-vehicle-fuel\`
   - \`#cost-group-branch--operational-costs\` → \`#cost-group-branch-operational-costs\`
   - "Edit per-line margins" → new \`#cost-group-service-line-pricing\` (added id to ServiceLinePricingSection).
3. **Module-route anchors fixed**: "Open Crew Strategy" → \`#module-crew_strategy\`, "Edit branch selection" → \`#module-branch_optimization\`.

## Test plan
- [ ] Click Option A on Crew Strategy → indigo ring stays on A. Reload page → still on A.
- [ ] Re-run Bid Pricing → labor + vehicle costs reflect Option A's numbers.
- [ ] Bid Pricing → expand "Vehicle lease" → "Edit per-crew vehicle config" scrolls to the Vehicle & fuel section.
- [ ] Bid Pricing → expand "Branch overhead" → "Edit per-branch overhead config" scrolls to the Branch & operational costs section.
- [ ] Bid Pricing → expand "Margin" → "Edit per-line margins" scrolls to Service line pricing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)