### PR TITLE
Add manual per-branch crew count override

### DIFF
--- a/api/accounts/[accountId]/clients/[clientId]/operational-constraints.ts
+++ b/api/accounts/[accountId]/clients/[clientId]/operational-constraints.ts
@@ -274,6 +274,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       'labor_burden_breakdown',
       'population_constraint',
       'utilization_constraint',
+      'crew_count_per_branch_override',
     ])
 
     const patch: Record<string, unknown> = {

--- a/api/analyses/account/[accountId]/clients/[clientId]/bid-pricing-structure.ts
+++ b/api/analyses/account/[accountId]/clients/[clientId]/bid-pricing-structure.ts
@@ -65,6 +65,10 @@ export interface BidInputs {
   // analysis's recommended_option). Falls back to recommended when
   // null.
   crew_strategy_selected_option?: 'A' | 'B' | 'C' | null
+  // Phase 4.2 — manual per-branch crew count override. When set with
+  // any non-zero values, bid pricing ignores A/B/C and uses these
+  // counts directly. Total crews = sum of values. Keyed by branch name.
+  crew_count_per_branch_override?: Record<string, number> | null
 }
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
@@ -108,6 +112,11 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     crew_strategy_selected_option:
       ((constraints as any).crew_strategy_selected_option as
         | 'A' | 'B' | 'C' | null
+        | undefined) ?? null,
+    crew_count_per_branch_override:
+      ((constraints as any).crew_count_per_branch_override as
+        | Record<string, number>
+        | null
         | undefined) ?? null,
   }
 
@@ -391,12 +400,31 @@ export function computeBidPricing(
   let resolvedVehicleFuel = inputs.total_annual_vehicle_cost
   let resolvedCrewCount = inputs.crew_count
   let recommendedOption: string | null = null
+
+  // Phase 4.2 — manual per-branch crew override. When the user has
+  // entered explicit crew counts per branch, sum them for the total
+  // crew count and treat this as the highest-priority source. Labor
+  // is then recomputed proportionally from the override total using
+  // the original Option B (or A if A is selected) per-crew rate so
+  // working_days_per_year / hours_per_day / hourly_loaded_labor_cost
+  // assumptions remain consistent with the analysis.
+  const perBranchOverride = inputs.crew_count_per_branch_override
+  const overrideTotalCrews =
+    perBranchOverride && typeof perBranchOverride === 'object'
+      ? Object.values(perBranchOverride).reduce(
+          (s, v) => s + (Number.isFinite(Number(v)) ? Math.max(0, Math.floor(Number(v))) : 0),
+          0
+        )
+      : 0
+  const hasOverride = overrideTotalCrews > 0
+
   // Phase 3.8 — track where each number actually came from. Manual
   // overrides win, then scheduler template, then crew_strategy estimate.
   const manualOverride =
     inputs.crew_count != null ||
     inputs.total_annual_labor_cost != null ||
-    inputs.total_annual_vehicle_cost != null
+    inputs.total_annual_vehicle_cost != null ||
+    hasOverride
   let source: BidPricingSource = manualOverride
     ? 'manual_override'
     : schedulerTemplate
@@ -426,6 +454,22 @@ export function computeBidPricing(
           (opt.crew_count ?? 0) +
           (recommendedOption === 'C' ? opt.surge_crew_count ?? 0 : 0)
       }
+    }
+
+    // If the user supplied a per-branch override, replace crew count
+    // and rescale labor + vehicle from the option's per-crew unit cost.
+    // We use option B (the dedicated-per-branch option) as the unit
+    // basis since it's the most apples-to-apples for "N crews".
+    if (hasOverride) {
+      const baseOpt = crewStrategyOutputs.options?.B ?? opt
+      const baseCrews = Number(baseOpt?.crew_count ?? 0)
+      const perCrewLabor =
+        baseCrews > 0 ? Number(baseOpt?.annual_labor_cost ?? 0) / baseCrews : 0
+      const perCrewVehicle =
+        baseCrews > 0 ? Number(baseOpt?.annual_vehicle_cost ?? 0) / baseCrews : 0
+      resolvedCrewCount = overrideTotalCrews
+      resolvedLabor = Math.round(perCrewLabor * overrideTotalCrews)
+      resolvedVehicleFuel = Math.round(perCrewVehicle * overrideTotalCrews)
     }
   }
 

--- a/src/components/analysis/CrewStrategyChart.tsx
+++ b/src/components/analysis/CrewStrategyChart.tsx
@@ -181,6 +181,11 @@ export default function CrewStrategyChart({
   // if the user hasn't picked one.
   const [selectedOption, setSelectedOption] = useState<'A' | 'B' | 'C' | null>(null)
   const [savingSelection, setSavingSelection] = useState<'A' | 'B' | 'C' | null>(null)
+  // Phase 4.2 — manual per-branch crew override. Empty object = no
+  // override; non-empty = bid pricing uses these counts.
+  const [crewOverride, setCrewOverride] = useState<Record<string, number>>({})
+  const [overrideEnabled, setOverrideEnabled] = useState(false)
+  const [savingOverride, setSavingOverride] = useState(false)
 
   useEffect(() => {
     if (!accountId || !clientId) return
@@ -197,6 +202,16 @@ export default function CrewStrategyChart({
         if (!cancelled) {
           const v = j?.crew_strategy_selected_option
           setSelectedOption(v === 'A' || v === 'B' || v === 'C' ? v : null)
+          const ov = j?.crew_count_per_branch_override
+          if (ov && typeof ov === 'object') {
+            const cleaned: Record<string, number> = {}
+            for (const [k, val] of Object.entries(ov)) {
+              const n = Number(val)
+              if (Number.isFinite(n) && n > 0) cleaned[k] = Math.floor(n)
+            }
+            setCrewOverride(cleaned)
+            setOverrideEnabled(Object.keys(cleaned).length > 0)
+          }
         }
       } catch {
         // non-fatal — fall back to recommended_option
@@ -236,6 +251,37 @@ export default function CrewStrategyChart({
     }
   }
 
+  const saveOverride = async (
+    nextOverride: Record<string, number>,
+    enabled: boolean
+  ) => {
+    if (!accountId || !clientId) return
+    setSavingOverride(true)
+    try {
+      const token = await getToken()
+      const body = enabled && Object.keys(nextOverride).length > 0
+        ? { crew_count_per_branch_override: nextOverride }
+        : { crew_count_per_branch_override: null }
+      await fetch(
+        `/api/accounts/${accountId}/clients/${clientId}/operational-constraints`,
+        {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify(body),
+        }
+      )
+    } finally {
+      setSavingOverride(false)
+    }
+  }
+
+  const overrideTotal = Object.values(crewOverride).reduce(
+    (s, v) => s + (Number.isFinite(v) ? Math.max(0, Math.floor(v)) : 0),
+    0
+  )
   const activeOption: 'A' | 'B' | 'C' = selectedOption ?? data.recommended_option
   // Per-branch breakdown comes from Option B but applies to any allocation
   // discussion; surface it as a dedicated panel above the option cards.
@@ -568,6 +614,117 @@ export default function CrewStrategyChart({
           )
         })}
       </div>
+
+      {/* Phase 4.2 — Manual per-branch crew override. Beats A/B/C
+          selection in Bid Pricing when toggled on. */}
+      {(data.branches?.length ?? 0) > 0 && (
+        <Card padding="md" className={overrideEnabled ? 'border-accent ring-1 ring-accent' : undefined}>
+          <div className="flex items-start justify-between gap-3 flex-wrap">
+            <div>
+              <p className="text-[10px] font-semibold uppercase tracking-wider text-fg-subtle">
+                Manual crew override
+              </p>
+              <p className="mt-1 text-sm text-fg">
+                Set the exact number of crews per branch. When on,
+                Bid Pricing uses these counts instead of Option {activeOption}.
+              </p>
+            </div>
+            <label className="inline-flex items-center gap-2 text-sm cursor-pointer self-center">
+              <input
+                type="checkbox"
+                checked={overrideEnabled}
+                onChange={(e) => {
+                  const enabled = e.target.checked
+                  setOverrideEnabled(enabled)
+                  // Auto-seed inputs from Option B branch breakdown so the user
+                  // has a starting point on first enable.
+                  if (enabled && Object.keys(crewOverride).length === 0) {
+                    const seed: Record<string, number> = {}
+                    for (const b of branchBreakdown) {
+                      seed[b.branch_name] = b.crew_count
+                    }
+                    setCrewOverride(seed)
+                    void saveOverride(seed, true)
+                  } else {
+                    void saveOverride(crewOverride, enabled)
+                  }
+                }}
+                className="rounded border-border accent-accent"
+              />
+              <span className="font-medium text-fg">
+                {overrideEnabled ? 'Override active' : 'Use Option ' + activeOption}
+              </span>
+            </label>
+          </div>
+
+          {overrideEnabled && (
+            <div className="mt-4 space-y-3">
+              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2">
+                {(data.branches ?? []).map((b) => {
+                  const value = crewOverride[b.name] ?? 0
+                  const breakdown = branchBreakdown.find(
+                    (bb) => bb.branch_name === b.name
+                  )
+                  return (
+                    <div
+                      key={b.name}
+                      className="rounded-md border border-border bg-surface-subtle/40 p-3"
+                    >
+                      <p className="text-sm font-semibold text-fg truncate">
+                        {b.city_state || b.name}
+                      </p>
+                      {breakdown && (
+                        <p className="text-[10px] text-fg-subtle mt-0.5">
+                          {breakdown.property_count} properties ·{' '}
+                          {breakdown.work_hours.toLocaleString()} hr/yr · rec:{' '}
+                          <span className="font-tabular">{breakdown.crew_count}</span> crews
+                        </p>
+                      )}
+                      <div className="mt-2 flex items-center gap-2">
+                        <label className="text-xs text-fg-muted">Crews:</label>
+                        <input
+                          type="number"
+                          min={0}
+                          step={1}
+                          value={value}
+                          onChange={(e) => {
+                            const raw = e.target.value
+                            const n = raw === '' ? 0 : Math.max(0, Math.floor(Number(raw)))
+                            setCrewOverride((prev) => {
+                              const next = { ...prev, [b.name]: n }
+                              return next
+                            })
+                          }}
+                          onBlur={() => void saveOverride(crewOverride, true)}
+                          className="w-20 h-8 rounded-md border border-border bg-surface px-2 text-sm font-mono text-fg focus-visible:outline-none focus-visible:border-border-focus focus-visible:ring-2 focus-visible:ring-accent"
+                        />
+                      </div>
+                    </div>
+                  )
+                })}
+              </div>
+              <div className="flex items-center justify-between pt-2 border-t border-border">
+                <p className="text-sm text-fg">
+                  Total crews:{' '}
+                  <span className="font-mono font-semibold tabular-nums">
+                    {overrideTotal}
+                  </span>
+                  <span className="text-xs text-fg-muted ml-2">
+                    (vs Option {activeOption}:{' '}
+                    <span className="font-tabular">
+                      {data.options[activeOption].crew_count}
+                    </span>
+                    )
+                  </span>
+                </p>
+                <p className="text-xs text-fg-subtle">
+                  {savingOverride ? 'Saving…' : 'Auto-saves on blur. Re-run Bid Pricing to apply.'}
+                </p>
+              </div>
+            </div>
+          )}
+        </Card>
+      )}
 
       {/* Utilization breakdown for Option B (driven by user-selected scope) */}
       {data.options.B.utilization_breakdown && (

--- a/supabase/migrations/20260430221607_phase_4_2_manual_crew_count_override.sql
+++ b/supabase/migrations/20260430221607_phase_4_2_manual_crew_count_override.sql
@@ -1,0 +1,8 @@
+-- Phase 4.2 — let the user override crew counts directly per branch
+-- instead of accepting whatever Option A/B/C dictates. Shape:
+--   { "Frisco TX": 2, "Sugar Land TX": 1, "Albuquerque NM": 1 }
+-- Keys are branch names matching selected_branches[].name. Total
+-- crew_count = sum of values. Null / empty object = no override.
+
+ALTER TABLE public.account_operational_constraints
+  ADD COLUMN IF NOT EXISTS crew_count_per_branch_override jsonb;


### PR DESCRIPTION
## Summary
User asked to bypass Option A/B/C and directly specify crew counts per branch — e.g. "4 total: 2 in branch 1, 1 in branch 2, 1 in branch 3."

- New jsonb column \`crew_count_per_branch_override\` on \`account_operational_constraints\`. Shape: \`{ "Frisco TX": 2, "Sugar Land TX": 1, "Albuquerque NM": 1 }\`. Null or empty object = no override.
- \`PATCH /operational-constraints\` accepts the new field.
- Bid Pricing reads it via \`inputs.crew_count_per_branch_override\`. When set with any non-zero values:
  - Total \`crew_count\` = sum of values.
  - \`annual_labor_cost\` and \`annual_vehicle_cost\` are rescaled from Option B's per-crew unit cost (so working_days_per_year, hours_per_day, and hourly_loaded_labor_cost assumptions stay consistent with the analysis).
  - Source flips to \`manual_override\`.
- New "Manual crew override" card on Crew Strategy. Checkbox toggles on/off. Inputs auto-seed from Option B's per-branch counts as a starting point. Each input saves on blur. Live total displayed against the selected option's recommended count.

## Test plan
- [ ] Open Crew Strategy. Below the A/B/C cards is a "Manual crew override" card.
- [ ] Toggle "Override active" on → inputs appear, pre-populated with the Option B per-branch counts.
- [ ] Change any input (e.g., set Frisco to 2) → blur → "Saving…" briefly, then settles. Total crews updates live.
- [ ] Re-run Bid Pricing → crew count = override sum, labor/vehicle costs scale accordingly.
- [ ] Reload page → override values persist, toggle is still on.
- [ ] Toggle off → returns to using A/B/C selection. Re-run Bid Pricing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)