### PR TITLE
Flow crew count override into Workforce Sizing + Seasonality; always-visible inputs

### DIFF
--- a/api/_lib/analysis/crew-resolution.ts
+++ b/api/_lib/analysis/crew-resolution.ts
@@ -1,0 +1,119 @@
+// Phase 4.2 — single source of truth for "how many crews" + which
+// option/source. Every downstream module (bid_pricing, workforce_sizing,
+// seasonality_capacity, synthesize, chat) used to read
+// crewStrategyOutputs.recommended_option directly. That meant the
+// user's manual override (per-branch counts) and selected option
+// (A/B/C) only flowed into bid_pricing, leaving FTE counts and
+// surge/seasonality math wrong.
+//
+// Resolution order (highest priority first):
+//   1. manual override — sum of crew_count_per_branch_override values
+//   2. user-selected option (A/B/C) from crew_strategy_selected_option
+//   3. analysis's recommended_option
+
+export type CrewSource =
+  | 'manual_override'
+  | 'user_selected_option'
+  | 'recommended_option'
+
+export interface ResolvedCrews {
+  /** Effective option key — A/B/C — even when override is active.
+   *  Used to look up labor / vehicle / utilization estimates. */
+  effective_option: 'A' | 'B' | 'C'
+  /** Total crew count after resolution. */
+  crew_count: number
+  /** Per-branch breakdown (override values when present, else option's). */
+  per_branch: Record<string, number>
+  /** Surge crew count from the option (only relevant for Option C and
+   *  when no manual override is in play). */
+  surge_crew_count: number
+  /** Where the count came from. */
+  source: CrewSource
+}
+
+interface ConstraintsLike {
+  crew_strategy_selected_option?: 'A' | 'B' | 'C' | null
+  crew_count_per_branch_override?: Record<string, number> | null
+}
+
+interface OptionLike {
+  crew_count?: number
+  surge_crew_count?: number
+  branch_breakdown?: Array<{ branch_name: string; crew_count: number }>
+  utilization_breakdown?: {
+    per_branch?: Array<{ branch_name: string; crew_count: number }>
+  }
+}
+
+interface CrewStrategyOutputsLike {
+  recommended_option?: 'A' | 'B' | 'C'
+  options?: Record<string, OptionLike | undefined>
+}
+
+function sumOverride(
+  override: Record<string, number> | null | undefined
+): { total: number; cleaned: Record<string, number> } {
+  if (!override || typeof override !== 'object') {
+    return { total: 0, cleaned: {} }
+  }
+  let total = 0
+  const cleaned: Record<string, number> = {}
+  for (const [k, v] of Object.entries(override)) {
+    const n = Number(v)
+    if (Number.isFinite(n) && n > 0) {
+      const i = Math.max(0, Math.floor(n))
+      cleaned[k] = i
+      total += i
+    }
+  }
+  return { total, cleaned }
+}
+
+function perBranchFromOption(opt: OptionLike | undefined): Record<string, number> {
+  if (!opt) return {}
+  const breakdown =
+    opt.utilization_breakdown?.per_branch ?? opt.branch_breakdown ?? []
+  const out: Record<string, number> = {}
+  for (const b of breakdown) {
+    if (b.branch_name) out[b.branch_name] = Number(b.crew_count) || 0
+  }
+  return out
+}
+
+export function resolveCrews(
+  crewStrategyOutputs: CrewStrategyOutputsLike | null | undefined,
+  constraints: ConstraintsLike
+): ResolvedCrews {
+  const recommended = crewStrategyOutputs?.recommended_option ?? 'B'
+  const userSelected = constraints.crew_strategy_selected_option
+  const effective: 'A' | 'B' | 'C' =
+    userSelected === 'A' || userSelected === 'B' || userSelected === 'C'
+      ? userSelected
+      : recommended
+
+  const opt = crewStrategyOutputs?.options?.[effective]
+  const surge = effective === 'C' ? Number(opt?.surge_crew_count ?? 0) : 0
+
+  const { total: overrideTotal, cleaned: overridePerBranch } = sumOverride(
+    constraints.crew_count_per_branch_override
+  )
+
+  if (overrideTotal > 0) {
+    return {
+      effective_option: effective,
+      crew_count: overrideTotal,
+      per_branch: overridePerBranch,
+      surge_crew_count: 0,
+      source: 'manual_override',
+    }
+  }
+
+  const baseCrews = Number(opt?.crew_count ?? 0)
+  return {
+    effective_option: effective,
+    crew_count: baseCrews + surge,
+    per_branch: perBranchFromOption(opt),
+    surge_crew_count: surge,
+    source: userSelected ? 'user_selected_option' : 'recommended_option',
+  }
+}

--- a/api/_lib/analysis/operational-constraints.ts
+++ b/api/_lib/analysis/operational-constraints.ts
@@ -197,6 +197,15 @@ export interface OperationalConstraints {
     scope: 'per_branch' | 'per_region' | 'portfolio'
   }
 
+  // Phase 4.2 — user picks one of A/B/C from Crew Strategy as the
+  // "active" option flowed into Bid Pricing, Workforce Sizing, and
+  // Seasonality. Null = use analysis's recommended_option.
+  crew_strategy_selected_option: 'A' | 'B' | 'C' | null
+  // Phase 4.2 — manual per-branch crew count override. When non-null
+  // with at least one positive value, supersedes A/B/C selection
+  // entirely. Total crew count = sum of values. Keys = branch names.
+  crew_count_per_branch_override: Record<string, number> | null
+
   // Metadata
   updated_at: string | null
   updated_by: string | null
@@ -465,6 +474,18 @@ export async function loadConstraints(
           | 'per_region'
           | 'portfolio') ?? 'per_branch',
     },
+
+    crew_strategy_selected_option:
+      r?.crew_strategy_selected_option === 'A' ||
+      r?.crew_strategy_selected_option === 'B' ||
+      r?.crew_strategy_selected_option === 'C'
+        ? r.crew_strategy_selected_option
+        : null,
+    crew_count_per_branch_override:
+      r?.crew_count_per_branch_override &&
+      typeof r.crew_count_per_branch_override === 'object'
+        ? (r.crew_count_per_branch_override as Record<string, number>)
+        : null,
 
     updated_at: r?.updated_at ?? null,
     updated_by: r?.updated_by ?? null,

--- a/api/analyses/account/[accountId]/clients/[clientId]/bid-pricing-structure.ts
+++ b/api/analyses/account/[accountId]/clients/[clientId]/bid-pricing-structure.ts
@@ -19,6 +19,7 @@ import {
   NO_SELECTION_ERROR,
 } from '../../../../../_lib/analysis/operational-constraints.js'
 import { loadAccountOfferings, classifyOffering } from '../../../../../_lib/analysis/service-offerings.js'
+import { resolveCrews } from '../../../../../_lib/analysis/crew-resolution.js'
 import { computePropertyVisitHours } from '../../../../../_lib/analysis/property-hours.js'
 import {
   calculateOvernights,
@@ -109,15 +110,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       body.target_gross_margin_pct ?? constraints.target_gross_margin_pct,
     branch_count: body.branch_count ?? null,
     crew_count: body.crew_count ?? null,
-    crew_strategy_selected_option:
-      ((constraints as any).crew_strategy_selected_option as
-        | 'A' | 'B' | 'C' | null
-        | undefined) ?? null,
-    crew_count_per_branch_override:
-      ((constraints as any).crew_count_per_branch_override as
-        | Record<string, number>
-        | null
-        | undefined) ?? null,
+    crew_strategy_selected_option: constraints.crew_strategy_selected_option,
+    crew_count_per_branch_override: constraints.crew_count_per_branch_override,
   }
 
   let analysisId: string
@@ -401,22 +395,13 @@ export function computeBidPricing(
   let resolvedCrewCount = inputs.crew_count
   let recommendedOption: string | null = null
 
-  // Phase 4.2 — manual per-branch crew override. When the user has
-  // entered explicit crew counts per branch, sum them for the total
-  // crew count and treat this as the highest-priority source. Labor
-  // is then recomputed proportionally from the override total using
-  // the original Option B (or A if A is selected) per-crew rate so
-  // working_days_per_year / hours_per_day / hourly_loaded_labor_cost
-  // assumptions remain consistent with the analysis.
-  const perBranchOverride = inputs.crew_count_per_branch_override
-  const overrideTotalCrews =
-    perBranchOverride && typeof perBranchOverride === 'object'
-      ? Object.values(perBranchOverride).reduce(
-          (s, v) => s + (Number.isFinite(Number(v)) ? Math.max(0, Math.floor(Number(v))) : 0),
-          0
-        )
-      : 0
-  const hasOverride = overrideTotalCrews > 0
+  // Phase 4.2 — single source of truth for crew counts.
+  const crewResolution = resolveCrews(crewStrategyOutputs, {
+    crew_strategy_selected_option: inputs.crew_strategy_selected_option ?? null,
+    crew_count_per_branch_override: inputs.crew_count_per_branch_override ?? null,
+  })
+  const hasOverride = crewResolution.source === 'manual_override'
+  const overrideTotalCrews = hasOverride ? crewResolution.crew_count : 0
 
   // Phase 3.8 — track where each number actually came from. Manual
   // overrides win, then scheduler template, then crew_strategy estimate.

--- a/api/analyses/account/[accountId]/clients/[clientId]/seasonality-capacity.ts
+++ b/api/analyses/account/[accountId]/clients/[clientId]/seasonality-capacity.ts
@@ -23,6 +23,7 @@ import {
   requireSelectedBranches,
   NO_SELECTION_ERROR,
 } from '../../../../../_lib/analysis/operational-constraints.js'
+import { resolveCrews } from '../../../../../_lib/analysis/crew-resolution.js'
 
 export const config = { maxDuration: 60 }
 
@@ -132,7 +133,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     const properties = applyExclusions(allProperties, constraints.excluded_property_ids)
     const offerings = await loadAccountOfferings(db, accountId, clientId)
     const crewStrategy = await fetchLatestCompletedAnalysis(db, accountId, clientId, 'crew_strategy')
-    const result = computeSeasonality(properties, offerings, crewStrategy?.outputs, inputs)
+    const result = computeSeasonality(properties, offerings, crewStrategy?.outputs, inputs, constraints)
 
     await completeAnalysisRecord(db, analysisId, {
       outputs: result.outputs,
@@ -151,7 +152,11 @@ export function computeSeasonality(
   properties: AccountProperty[],
   offerings: Map<string, { id: string; name: string }>,
   crewStrategyOutputs: any,
-  inputs: SeasonalityInputs
+  inputs: SeasonalityInputs,
+  constraints?: {
+    crew_strategy_selected_option?: 'A' | 'B' | 'C' | null
+    crew_count_per_branch_override?: Record<string, number> | null
+  }
 ) {
   // ── Per-service-location: hours per visit + window classification ─────────
   type SLEntry = {
@@ -214,14 +219,12 @@ export function computeSeasonality(
     'winter_break',
   ]
 
-  // Derive baseline crew capacity from latest Crew Strategy if available
+  // Derive baseline crew capacity from latest Crew Strategy if available.
+  // Phase 4.2 — honor user's selected option + manual per-branch override.
   let baselineCrews = 4
   if (crewStrategyOutputs?.options) {
-    const recKey = crewStrategyOutputs.recommended_option as 'A' | 'B' | 'C'
-    const opt = crewStrategyOutputs.options[recKey]
-    if (opt) {
-      baselineCrews = opt.crew_count ?? 4
-    }
+    const resolved = resolveCrews(crewStrategyOutputs, constraints ?? {})
+    baselineCrews = resolved.crew_count || 4
   }
 
   const windowResults = windowKeys.map((key) => {

--- a/api/analyses/account/[accountId]/clients/[clientId]/workforce-sizing.ts
+++ b/api/analyses/account/[accountId]/clients/[clientId]/workforce-sizing.ts
@@ -22,6 +22,7 @@ import {
   requireSelectedBranches,
   NO_SELECTION_ERROR,
 } from '../../../../../_lib/analysis/operational-constraints.js'
+import { resolveCrews } from '../../../../../_lib/analysis/crew-resolution.js'
 
 export const config = { maxDuration: 60 }
 
@@ -83,7 +84,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     const properties = applyExclusions(allProperties, constraints.excluded_property_ids)
     const offerings = await loadAccountOfferings(db, accountId, clientId)
     const crewStrategy = await fetchLatestCompletedAnalysis(db, accountId, clientId, 'crew_strategy')
-    const result = computeWorkforceSizing(properties, offerings, crewStrategy?.outputs, inputs)
+    const result = computeWorkforceSizing(properties, offerings, crewStrategy?.outputs, inputs, constraints)
 
     await completeAnalysisRecord(db, analysisId, {
       outputs: result.outputs,
@@ -102,7 +103,11 @@ export function computeWorkforceSizing(
   properties: Awaited<ReturnType<typeof loadAccountProperties>>,
   offerings: Map<string, { id: string; name: string }>,
   crewStrategyOutputs: any,
-  inputs: WorkforceInputs
+  inputs: WorkforceInputs,
+  constraints?: {
+    crew_strategy_selected_option?: 'A' | 'B' | 'C' | null
+    crew_count_per_branch_override?: Record<string, number> | null
+  }
 ) {
   const wbOfferingIds = new Set<string>()
   const overrideNameSet = inputs.workforce_b_offerings
@@ -149,15 +154,17 @@ export function computeWorkforceSizing(
   let workforceAFteEquivalent = 0
   let workforceANote = 'Run Crew Strategy first to size the project crew workforce.'
   if (crewStrategyOutputs) {
-    const recommendedKey = crewStrategyOutputs.recommended_option as 'A' | 'B' | 'C'
-    const opt = crewStrategyOutputs.options?.[recommendedKey]
-    if (opt) {
-      const crewCount =
-        (opt.crew_count ?? 0) + (recommendedKey === 'C' ? opt.surge_crew_count ?? 0 : 0)
-      const crewSize = crewStrategyOutputs.inputs?.crew_size ?? 3
-      workforceAFteEquivalent = crewCount * crewSize
-      workforceANote = `Per Crew Strategy (Option ${recommendedKey}): ${crewCount} crew${crewCount === 1 ? '' : 's'} × ~${crewSize} workers ≈ ${workforceAFteEquivalent} FTE equivalent.`
-    }
+    // Phase 4.2 — honor user's selected option + manual per-branch
+    // override, not just analysis recommended_option.
+    const resolved = resolveCrews(crewStrategyOutputs, constraints ?? {})
+    const crewCount = resolved.crew_count
+    const crewSize = crewStrategyOutputs.inputs?.crew_size ?? 3
+    workforceAFteEquivalent = crewCount * crewSize
+    const sourceLabel =
+      resolved.source === 'manual_override'
+        ? 'manual per-branch override'
+        : `Option ${resolved.effective_option}${resolved.source === 'user_selected_option' ? ' (your selection)' : ''}`
+    workforceANote = `Per Crew Strategy (${sourceLabel}): ${crewCount} crew${crewCount === 1 ? '' : 's'} × ~${crewSize} workers ≈ ${workforceAFteEquivalent} FTE equivalent.`
   }
 
   const totalFte = workforceAFteEquivalent + fteCount

--- a/src/components/analysis/CrewStrategyChart.tsx
+++ b/src/components/analysis/CrewStrategyChart.tsx
@@ -615,114 +615,140 @@ export default function CrewStrategyChart({
         })}
       </div>
 
-      {/* Phase 4.2 — Manual per-branch crew override. Beats A/B/C
-          selection in Bid Pricing when toggled on. */}
+      {/* Phase 4.2 — Manual per-branch crew override. Inputs are
+          always visible so the user can directly type. Override is
+          ACTIVE whenever the sum of inputs > 0; clearing all inputs
+          (or pressing "Use Option {activeOption}") falls back to the
+          A/B/C selection. */}
       {(data.branches?.length ?? 0) > 0 && (
-        <Card padding="md" className={overrideEnabled ? 'border-accent ring-1 ring-accent' : undefined}>
+        <Card
+          padding="md"
+          className={overrideEnabled && overrideTotal > 0 ? 'border-accent ring-1 ring-accent' : undefined}
+        >
           <div className="flex items-start justify-between gap-3 flex-wrap">
             <div>
               <p className="text-[10px] font-semibold uppercase tracking-wider text-fg-subtle">
                 Manual crew override
               </p>
               <p className="mt-1 text-sm text-fg">
-                Set the exact number of crews per branch. When on,
-                Bid Pricing uses these counts instead of Option {activeOption}.
+                Type the number of crews you want at each branch. Any
+                non-zero entry switches Bid Pricing, Workforce Sizing,
+                and Seasonality off Option {activeOption} and onto your
+                numbers.
               </p>
             </div>
-            <label className="inline-flex items-center gap-2 text-sm cursor-pointer self-center">
-              <input
-                type="checkbox"
-                checked={overrideEnabled}
-                onChange={(e) => {
-                  const enabled = e.target.checked
-                  setOverrideEnabled(enabled)
-                  // Auto-seed inputs from Option B branch breakdown so the user
-                  // has a starting point on first enable.
-                  if (enabled && Object.keys(crewOverride).length === 0) {
-                    const seed: Record<string, number> = {}
-                    for (const b of branchBreakdown) {
-                      seed[b.branch_name] = b.crew_count
-                    }
-                    setCrewOverride(seed)
-                    void saveOverride(seed, true)
-                  } else {
-                    void saveOverride(crewOverride, enabled)
-                  }
+            {overrideEnabled && overrideTotal > 0 && (
+              <Button
+                size="sm"
+                variant="secondary"
+                onClick={() => {
+                  setCrewOverride({})
+                  setOverrideEnabled(false)
+                  void saveOverride({}, false)
                 }}
-                className="rounded border-border accent-accent"
-              />
-              <span className="font-medium text-fg">
-                {overrideEnabled ? 'Override active' : 'Use Option ' + activeOption}
-              </span>
-            </label>
+              >
+                Use Option {activeOption} instead
+              </Button>
+            )}
           </div>
 
-          {overrideEnabled && (
-            <div className="mt-4 space-y-3">
-              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2">
-                {(data.branches ?? []).map((b) => {
-                  const value = crewOverride[b.name] ?? 0
-                  const breakdown = branchBreakdown.find(
-                    (bb) => bb.branch_name === b.name
-                  )
-                  return (
-                    <div
-                      key={b.name}
-                      className="rounded-md border border-border bg-surface-subtle/40 p-3"
-                    >
-                      <p className="text-sm font-semibold text-fg truncate">
-                        {b.city_state || b.name}
+          <div className="mt-4 space-y-3">
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2">
+              {(data.branches ?? []).map((b) => {
+                // Default the input to whatever the active option
+                // assigns to this branch — that way the field shows
+                // a real starting number and any edit is a clear
+                // override.
+                const breakdown = branchBreakdown.find(
+                  (bb) => bb.branch_name === b.name
+                )
+                const recommended = breakdown?.crew_count ?? 0
+                const userValue = crewOverride[b.name]
+                const value = userValue ?? recommended
+                const isDirty = userValue != null && userValue !== recommended
+                return (
+                  <div
+                    key={b.name}
+                    className={cn(
+                      'rounded-md border bg-surface-subtle/40 p-3',
+                      isDirty ? 'border-accent' : 'border-border'
+                    )}
+                  >
+                    <p className="text-sm font-semibold text-fg truncate">
+                      {b.city_state || b.name}
+                    </p>
+                    {breakdown && (
+                      <p className="text-[10px] text-fg-subtle mt-0.5">
+                        {breakdown.property_count} properties ·{' '}
+                        {breakdown.work_hours.toLocaleString()} hr/yr · Option{' '}
+                        {activeOption} rec:{' '}
+                        <span className="font-tabular">{recommended}</span>{' '}
+                        crews
                       </p>
-                      {breakdown && (
-                        <p className="text-[10px] text-fg-subtle mt-0.5">
-                          {breakdown.property_count} properties ·{' '}
-                          {breakdown.work_hours.toLocaleString()} hr/yr · rec:{' '}
-                          <span className="font-tabular">{breakdown.crew_count}</span> crews
-                        </p>
+                    )}
+                    <div className="mt-2 flex items-center gap-2">
+                      <label className="text-xs text-fg-muted">Crews:</label>
+                      <input
+                        type="number"
+                        min={0}
+                        step={1}
+                        value={value}
+                        onChange={(e) => {
+                          const raw = e.target.value
+                          const n = raw === '' ? 0 : Math.max(0, Math.floor(Number(raw)))
+                          setCrewOverride((prev) => ({ ...prev, [b.name]: n }))
+                          // Override is implicitly enabled the moment
+                          // the user types anything. Keep state in sync.
+                          if (!overrideEnabled) setOverrideEnabled(true)
+                        }}
+                        onBlur={() => {
+                          // Snapshot current state at blur time and
+                          // save. Empty / all-zero override clears.
+                          const snapshot = { ...crewOverride }
+                          const total = Object.values(snapshot).reduce(
+                            (s, v) =>
+                              s + (Number.isFinite(v) ? Math.max(0, Math.floor(v)) : 0),
+                            0
+                          )
+                          void saveOverride(snapshot, total > 0)
+                        }}
+                        className="w-20 h-8 rounded-md border border-border bg-surface px-2 text-sm font-mono text-fg focus-visible:outline-none focus-visible:border-border-focus focus-visible:ring-2 focus-visible:ring-accent"
+                      />
+                      {isDirty && (
+                        <span className="text-[10px] text-accent">overridden</span>
                       )}
-                      <div className="mt-2 flex items-center gap-2">
-                        <label className="text-xs text-fg-muted">Crews:</label>
-                        <input
-                          type="number"
-                          min={0}
-                          step={1}
-                          value={value}
-                          onChange={(e) => {
-                            const raw = e.target.value
-                            const n = raw === '' ? 0 : Math.max(0, Math.floor(Number(raw)))
-                            setCrewOverride((prev) => {
-                              const next = { ...prev, [b.name]: n }
-                              return next
-                            })
-                          }}
-                          onBlur={() => void saveOverride(crewOverride, true)}
-                          className="w-20 h-8 rounded-md border border-border bg-surface px-2 text-sm font-mono text-fg focus-visible:outline-none focus-visible:border-border-focus focus-visible:ring-2 focus-visible:ring-accent"
-                        />
-                      </div>
                     </div>
-                  )
-                })}
-              </div>
-              <div className="flex items-center justify-between pt-2 border-t border-border">
-                <p className="text-sm text-fg">
-                  Total crews:{' '}
-                  <span className="font-mono font-semibold tabular-nums">
-                    {overrideTotal}
-                  </span>
+                  </div>
+                )
+              })}
+            </div>
+            <div className="flex items-center justify-between pt-2 border-t border-border flex-wrap gap-2">
+              <p className="text-sm text-fg">
+                Total crews:{' '}
+                <span className="font-mono font-semibold tabular-nums">
+                  {overrideEnabled && overrideTotal > 0
+                    ? overrideTotal
+                    : data.options[activeOption].crew_count}
+                </span>
+                {overrideEnabled && overrideTotal > 0 && (
                   <span className="text-xs text-fg-muted ml-2">
-                    (vs Option {activeOption}:{' '}
+                    override (vs Option {activeOption}:{' '}
                     <span className="font-tabular">
                       {data.options[activeOption].crew_count}
                     </span>
                     )
                   </span>
-                </p>
-                <p className="text-xs text-fg-subtle">
-                  {savingOverride ? 'Saving…' : 'Auto-saves on blur. Re-run Bid Pricing to apply.'}
-                </p>
-              </div>
+                )}
+              </p>
+              <p className="text-xs text-fg-subtle">
+                {savingOverride
+                  ? 'Saving…'
+                  : overrideEnabled && overrideTotal > 0
+                    ? 'Override active. Re-run Bid Pricing / Workforce / Seasonality to apply.'
+                    : 'No override active. Type any crew count to start.'}
+              </p>
             </div>
-          )}
+          </div>
         </Card>
       )}
 


### PR DESCRIPTION
## Summary
User flagged two real problems with the prior manual-override shipment:

1. **Inputs were hidden behind a "Override active" checkbox**, so the UI looked like one box that just said "Use Option B" with no obvious way to type numbers. Restructured the card: per-branch inputs are visible immediately, pre-populated from whichever option is currently active. The override is *implicitly* active the moment any input deviates from that option's recommendation — no toggle ceremony. A "Use Option X instead" button clears it.

2. **The override only flowed into Bid Pricing.** User correctly pointed out that crews drive Workforce Sizing, Seasonality, and any other module that reads crew_count. New shared helper at \`api/_lib/analysis/crew-resolution.ts\` — \`resolveCrews(crewStrategyOutputs, constraints)\` returns \`{ effective_option, crew_count, per_branch, surge_crew_count, source }\` with priority **manual_override → user_selected_option → recommended_option**. Wired into:
   - bid-pricing-structure
   - workforce-sizing
   - seasonality-capacity

Also added the two new fields (\`crew_strategy_selected_option\`, \`crew_count_per_branch_override\`) to the \`OperationalConstraints\` interface and \`loadConstraints()\` merge so downstream modules can read them without ad-hoc casts.

## Test plan
- [ ] Open Crew Strategy. The Manual crew override card shows per-branch inputs immediately, pre-populated with Option B's per-branch counts.
- [ ] Change "Frisco TX" from 3 → 2. Card border turns indigo. Input shows "overridden". Total crews updates live.
- [ ] Re-run Bid Pricing → labor and crew_count reflect the override.
- [ ] Re-run Workforce Sizing → "Workforce A FTE" reflects the override (note copy says "manual per-branch override" instead of "Option B").
- [ ] Re-run Seasonality → baseline_crew_count_used = override total.
- [ ] Reload page → override values persist, override card border still indigo.
- [ ] Click "Use Option B instead" → inputs reset, border returns to neutral, override clears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)