### PR TITLE
Fix cycle generation: visits dropped due to FK violation in unplaced fallback

### DIFF
--- a/api/_lib/scheduler/build-routing-template.ts
+++ b/api/_lib/scheduler/build-routing-template.ts
@@ -502,6 +502,11 @@ export function buildRoutingTemplate(input: BuildTemplateInput): TemplateBuildRe
         for (const v of remaining) {
           unplaced.push({
             service_location_id: v.service_location_id,
+            // Without property_id the cycle generator can't insert the
+            // row (scheduled_visits.property_id is NOT NULL with FK to
+            // properties.id) and the whole batch rolls back, eating the
+            // placed visits too.
+            property_id: v.property_id,
             address: v.address,
             reason: 'time_overflow',
             detail: hitCycleEnd

--- a/api/_lib/scheduler/generate-cycle-instance.ts
+++ b/api/_lib/scheduler/generate-cycle-instance.ts
@@ -205,13 +205,39 @@ export async function generateCycleInstance(
   }
 
   // Surface unplaced visits as scheduled_visits with status='unplaced'.
-  for (const u of (template.unplaced_visits ?? []) as any[]) {
+  // Older templates (pre-fix) may be missing property_id on unplaced
+  // entries; look them up from service_locations rather than fall back
+  // to the SL id (which violates the property_id FK and rolls back the
+  // entire batch insert via Postgres single-statement semantics).
+  const unplacedRaw = (template.unplaced_visits ?? []) as any[]
+  const slIdsNeedingPropId = unplacedRaw
+    .filter((u) => u.service_location_id && !u.property_id)
+    .map((u) => u.service_location_id as string)
+  let propIdBySlId = new Map<string, string>()
+  if (slIdsNeedingPropId.length > 0) {
+    const { data: slRows } = await db
+      .from('service_locations')
+      .select('id, property_id')
+      .in('id', slIdsNeedingPropId)
+    propIdBySlId = new Map(
+      (slRows ?? []).map((r) => [(r as any).id as string, (r as any).property_id as string])
+    )
+  }
+  for (const u of unplacedRaw) {
     if (!u.service_location_id) continue
+    const propertyId = u.property_id ?? propIdBySlId.get(u.service_location_id)
+    if (!propertyId) {
+      // Skip rather than break the whole batch with a bad FK.
+      console.warn(
+        `[generate-cycle] skipping unplaced visit for SL ${u.service_location_id}: no property_id resolvable`
+      )
+      continue
+    }
     scheduledVisits.push({
       cycle_instance_id: cycleInstanceId,
       template_id: templateId,
       service_location_id: u.service_location_id,
-      property_id: u.property_id ?? u.service_location_id,
+      property_id: propertyId,
       visit_number_in_cycle: 1,
       status: 'unplaced',
       unplaced_reason: u.detail ?? u.reason,
@@ -220,16 +246,20 @@ export async function generateCycleInstance(
     })
   }
 
-  // Bulk-insert in chunks.
+  // Bulk-insert in chunks. THROW on failure rather than swallow — a
+  // silent "generated cycle with 0 visits" is worse than a real error
+  // because the user sees the cycle as successful and only later
+  // notices the empty Gantt / map / list.
   let crewDaysCreated = 0
   for (let i = 0; i < crewDayRoutes.length; i += INSERT_BATCH_SIZE) {
     const chunk = crewDayRoutes.slice(i, i + INSERT_BATCH_SIZE)
     const { error } = await db.from('crew_day_routes').insert(chunk)
     if (error) {
-      console.error('[generate-cycle] crew_day_routes batch failed:', error.message)
-    } else {
-      crewDaysCreated += chunk.length
+      throw new Error(
+        `crew_day_routes insert failed at batch ${i}-${i + chunk.length}: ${error.message}`
+      )
     }
+    crewDaysCreated += chunk.length
   }
 
   let visitsCreated = 0
@@ -237,10 +267,11 @@ export async function generateCycleInstance(
     const chunk = scheduledVisits.slice(i, i + INSERT_BATCH_SIZE)
     const { error } = await db.from('scheduled_visits').insert(chunk)
     if (error) {
-      console.error('[generate-cycle] scheduled_visits batch failed:', error.message)
-    } else {
-      visitsCreated += chunk.length
+      throw new Error(
+        `scheduled_visits insert failed at batch ${i}-${i + chunk.length}: ${error.message}`
+      )
     }
+    visitsCreated += chunk.length
   }
 
   return {


### PR DESCRIPTION
## Summary
Generated cycles were ending up with crew days but zero scheduled visits — empty Gantt, list view showing crew days with no stops, map with no pins. Two compounding bugs:

1. **Builder didn't include \`property_id\` on \`unplaced_visits\`.** The cycle generator fell back to \`property_id: u.property_id ?? u.service_location_id\` which substituted an SL id where a property id was required. That violated \`scheduled_visits.property_id\` (NOT NULL, FK to \`properties\`). Because supabase-js \`.insert(array)\` is a single statement, **one bad row rolls back every row in that batch** — including all the placed visits.
2. **The error was swallowed.** The chunked insert wrapped Postgres errors in \`console.error\` and kept going, returning \`visits_created: 0\` alongside \`crew_days_created > 0\` and a 200 OK. Cycle "succeeded" with no visits.

## Fixes
- Builder now includes \`property_id\` on every \`unplaced_visits\` entry (VisitSpec already has it; just carry it through).
- Generator falls back to a real \`service_locations\` lookup for older templates whose unplaced entries are missing \`property_id\`. Skips with a warning if a property_id can't be resolved — no more SL-as-property-id substitution.
- Both insert loops now **throw on error** so the API returns a proper 500 with the Postgres error message instead of silently producing an empty cycle.

## Test plan
- [ ] Generate a cycle from a routing template with the fix deployed.
- [ ] Cycle Detail page: visits populate the list view, Gantt shows stops, map shows pins.
- [ ] Existing (pre-fix) templates: regenerate works because the generator looks up missing property_ids.
- [ ] Force a real failure (e.g., bad data) → user gets a 500 with the actual Postgres message, not a silent 200 with 0 visits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)