### PR TITLE
Show property names per crew-day on Gantt / Calendar / List + fix list crash

### DIFF
--- a/api/_lib/scheduler/crew-utilization.ts
+++ b/api/_lib/scheduler/crew-utilization.ts
@@ -41,6 +41,12 @@ export interface CrewUtilizationDay {
   trip_day_number: number | null
   trip_total_days: number | null
   day_type: string | null
+  // Per-day property labels — what the crew is actually visiting on
+  // this day. Phase 4f-4: the cluster (trip_label) alone wasn't useful
+  // because users wanted to see which property the crew is on.
+  property_count: number
+  property_summary: string | null
+  property_addresses: string[]
 }
 
 interface ComputeOptions {
@@ -78,7 +84,7 @@ export async function computeCrewUtilization(
   const { data: routes } = await db
     .from('crew_day_routes')
     .select(
-      'crew_index, crew_label, scheduled_date, day_type, total_work_minutes, trip_id, trip_label, trip_day_number, trip_total_days'
+      'crew_index, crew_label, scheduled_date, day_type, total_work_minutes, trip_id, trip_label, trip_day_number, trip_total_days, route'
     )
     .eq('cycle_instance_id', cycleInstanceId)
 
@@ -134,6 +140,11 @@ export async function computeCrewUtilization(
         } else {
           kind = 'idle'
         }
+        const stops = Array.isArray(route.route) ? (route.route as any[]) : []
+        const addresses = stops
+          .map((s) => (typeof s?.address === 'string' ? s.address.trim() : null))
+          .filter((s): s is string => !!s)
+        const propertySummary = summarizeAddresses(addresses)
         initial.push({
           crew_index: crewIdx,
           crew_label: route.crew_label ?? `Crew ${crewIdx + 1}`,
@@ -153,6 +164,9 @@ export async function computeCrewUtilization(
           trip_day_number: route.trip_day_number ?? null,
           trip_total_days: route.trip_total_days ?? null,
           day_type: route.day_type ?? null,
+          property_count: stops.length,
+          property_summary: propertySummary,
+          property_addresses: addresses,
         })
       } else {
         initial.push({
@@ -169,6 +183,9 @@ export async function computeCrewUtilization(
           trip_day_number: null,
           trip_total_days: null,
           day_type: null,
+          property_count: 0,
+          property_summary: null,
+          property_addresses: [],
         })
       }
     }
@@ -217,4 +234,18 @@ export async function computeCrewUtilization(
   }
 
   return initial
+}
+
+// Build a compact label that fits in a Gantt cell or Calendar tile.
+// Strips ", City, State ZIP" so we get the street portion. If multiple
+// stops, show the first + "+N more".
+function summarizeAddresses(addresses: string[]): string | null {
+  if (addresses.length === 0) return null
+  const street = (addr: string) => {
+    const comma = addr.indexOf(',')
+    return (comma > 0 ? addr.slice(0, comma) : addr).trim()
+  }
+  if (addresses.length === 1) return street(addresses[0])
+  const first = street(addresses[0])
+  return `${first} +${addresses.length - 1} more`
 }

--- a/src/components/scheduler/CalendarView.tsx
+++ b/src/components/scheduler/CalendarView.tsx
@@ -173,9 +173,15 @@ export default function CalendarView({ days, onDayClick, onCellDrop }: Props) {
               {sortedCellDays.map((d) => {
                 const isIdle = d.state.kind === 'idle' || d.state.kind === 'between_trips'
                 const draggable = !isIdle
+                // Phase 4f-4 — show the property the crew is at, not
+                // the cluster name. Falls back to trip_label for older
+                // cycles whose route jsonb didn't have addresses.
                 const label = isIdle
                   ? d.state.kind === 'idle' ? 'idle' : 'between'
-                  : d.trip_label ?? '—'
+                  : d.property_summary ?? d.trip_label ?? '—'
+                const fullTooltip = !isIdle && d.property_addresses && d.property_addresses.length > 0
+                  ? `${d.crew_label}: ${d.work_hours_scheduled.toFixed(1)}h · ${d.state.kind}\n${d.property_addresses.join('\n')}${d.trip_label ? `\nCluster: ${d.trip_label}` : ''}${draggable ? '\n(drag to move)' : ''}`
+                  : `${d.crew_label}: ${d.work_hours_scheduled.toFixed(1)}h · ${d.state.kind}${draggable ? ' (drag to move)' : ''}`
                 return (
                   <div
                     key={d.crew_index}
@@ -199,7 +205,7 @@ export default function CalendarView({ days, onDayClick, onCellDrop }: Props) {
                       d.state.kind === 'partial' && 'opacity-80',
                       draggable && 'cursor-grab'
                     )}
-                    title={`${d.crew_label}: ${d.work_hours_scheduled.toFixed(1)}h · ${d.state.kind}${draggable ? ' (drag to move)' : ''}`}
+                    title={fullTooltip}
                   >
                     <span
                       className={cn(

--- a/src/components/scheduler/GanttView.tsx
+++ b/src/components/scheduler/GanttView.tsx
@@ -20,6 +20,11 @@ export interface UtilDay {
   utilization_pct: number
   trip_id: string | null
   trip_label: string | null
+  // Phase 4f-4 — what the crew is actually visiting that day. Filled
+  // from crew_day_routes.route by the crew-utilization endpoint.
+  property_count?: number
+  property_summary?: string | null
+  property_addresses?: string[]
 }
 
 export interface DropTarget {
@@ -220,19 +225,42 @@ export default function GanttView({
               // Build a "trip ribbon" — consecutive same-trip days collapse
               // into one cell so the user can read the location without
               // hovering. Cells with no trip get their own narrow td.
-              const ribbon: Array<{ colSpan: number; label: string | null; trip_id: string | null }> = []
+              // Per-day property label. Merge consecutive days with the
+              // exact same property_summary so multi-day overnight stays
+              // collapse into one cell. trip_label is kept only as the
+              // hover tooltip — the user wanted to see WHICH PROPERTY
+              // the crew is on each day, not the cluster name.
+              const ribbon: Array<{
+                colSpan: number
+                label: string | null
+                tooltip: string | null
+                trip_id: string | null
+              }> = []
               let k = 0
               while (k < allDates.length) {
                 const c = crew.cells.get(allDates[k])
-                const tripId = c?.trip_id ?? null
-                if (!tripId) {
-                  ribbon.push({ colSpan: 1, label: null, trip_id: null })
+                const summary = c?.property_summary ?? null
+                if (!summary) {
+                  ribbon.push({ colSpan: 1, label: null, tooltip: null, trip_id: null })
                   k++
                   continue
                 }
                 let j = k
-                while (j < allDates.length && (crew.cells.get(allDates[j])?.trip_id ?? null) === tripId) j++
-                ribbon.push({ colSpan: j - k, label: c?.trip_label ?? tripId, trip_id: tripId })
+                while (
+                  j < allDates.length &&
+                  (crew.cells.get(allDates[j])?.property_summary ?? null) === summary
+                ) j++
+                const tooltipParts: string[] = []
+                if (c?.property_addresses && c.property_addresses.length > 0) {
+                  tooltipParts.push(c.property_addresses.join('\n'))
+                }
+                if (c?.trip_label) tooltipParts.push(`Cluster: ${c.trip_label}`)
+                ribbon.push({
+                  colSpan: j - k,
+                  label: summary,
+                  tooltip: tooltipParts.join('\n\n') || null,
+                  trip_id: c?.trip_id ?? null,
+                })
                 k = j
               }
               return (
@@ -266,7 +294,7 @@ export default function GanttView({
                         'border-b border-border text-[11px] text-fg-muted px-1 py-0.5 truncate',
                         seg.label && 'bg-surface-subtle font-medium text-fg'
                       )}
-                      title={seg.label ?? ''}
+                      title={seg.tooltip ?? seg.label ?? ''}
                       style={{ height: 18, minWidth: 28 }}
                     >
                       {seg.label ?? ''}

--- a/src/pages/accounts/scheduler/CycleDetail.tsx
+++ b/src/pages/accounts/scheduler/CycleDetail.tsx
@@ -445,15 +445,25 @@ export default function CycleDetailPage() {
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {crewDays.map((cd) => (
+                {crewDays.map((cd) => {
+                  const route = Array.isArray((cd as any).route) ? (cd as any).route as any[] : []
+                  const stopsLabel = route.length === 0
+                    ? null
+                    : route.length === 1
+                      ? (route[0]?.address ?? '').split(',')[0]
+                      : `${(route[0]?.address ?? '').split(',')[0]} +${route.length - 1} more`
+                  return (
                   <TableRow key={cd.id}>
                     <TableCell className="text-xs font-tabular">{cd.scheduled_date}</TableCell>
                     <TableCell numeric>{cd.crew_index + 1}</TableCell>
                     <TableCell className="text-sm">
-                      <div>
+                      <div className="font-medium text-fg">
+                        {stopsLabel ?? '—'}
+                      </div>
+                      <div className="text-[11px] text-fg-subtle">
                         {cd.trip_label ?? cd.trip_id}
                         {cd.trip_total_days && cd.trip_total_days > 1
-                          ? <span className="text-fg-subtle text-xs ml-1">(day {cd.trip_day_number}/{cd.trip_total_days})</span>
+                          ? <span className="ml-1">(day {cd.trip_day_number}/{cd.trip_total_days})</span>
                           : null}
                       </div>
                       {cd.day_type === 'overnight' && cd.start_location?.name && cd.start_location?.type === 'branch' && (
@@ -471,7 +481,8 @@ export default function CycleDetailPage() {
                     <TableCell numeric className="text-xs">{formatMin(cd.total_work_minutes ?? 0)}</TableCell>
                     <TableCell numeric className="text-xs">{formatMin(cd.total_day_minutes ?? 0)}</TableCell>
                   </TableRow>
-                ))}
+                  )
+                })}
               </TableBody>
             </Table>
           )}
@@ -574,7 +585,7 @@ export default function CycleDetailPage() {
                       </Badge>
                     </TableCell>
                     <TableCell className="text-xs">
-                      {v.attached_addons.length === 0 ? (
+                      {!v.attached_addons || v.attached_addons.length === 0 ? (
                         <span className="text-fg-subtle">—</span>
                       ) : (
                         <div className="flex flex-wrap gap-1">


### PR DESCRIPTION
## Summary
Three issues from a cycle-detail review:

1. **List view crashed** with \`Cannot read properties of null (reading 'length')\` on the addons cell. \`v.attached_addons\` was null on some rows. Defensive null check.

2. **Gantt + Calendar showed cluster name instead of properties.** User said "It is listing 'Frisco Local' on the Gantt — what it should be showing is what property the crew is on that day." Wired through:
   - \`crew_day_routes\` already has a \`route\` jsonb that's the array of stops with addresses.
   - \`crew-utilization\` endpoint now reads \`route\`, computes a compact \`property_summary\` (first stop street name + "+N more"), and surfaces \`property_summary\` / \`property_count\` / \`property_addresses\` on each UtilDay.
   - Gantt's trip ribbon now merges consecutive same-summary days (so multi-day overnights still collapse cleanly) but the visible label is property addresses instead of cluster name. Cluster name + full address list moves to the hover tooltip.
   - Calendar tiles use the same fallback chain (property_summary → trip_label → '—').

3. **List view 'Trip' column** now leads with the property summary on the primary line and the cluster as a smaller secondary line.

## Out of scope here
- The AI-chat-for-utilization request. That's a separate feature — happy to open a follow-up if you want me to build it.

## Test plan
- [ ] Open a cycle with placed visits.
- [ ] Gantt: each crew row shows day-by-day property addresses, not "Frisco Local". Hover any cell → tooltip shows full address list + cluster.
- [ ] Calendar: each tile shows property name instead of cluster.
- [ ] List view: the addons crash is gone; Trip column shows property name on top, cluster small underneath.

🤖 Generated with [Claude Code](https://claude.com/claude-code)