### PR TITLE
Gantt: clickable legend filters + actually-visible cell colors

### DIFF
--- a/src/components/scheduler/CalendarView.tsx
+++ b/src/components/scheduler/CalendarView.tsx
@@ -200,7 +200,7 @@ export default function CalendarView({ days, onDayClick, onCellDrop }: Props) {
                     className={cn(
                       'flex items-center gap-1 text-[10px] leading-tight rounded px-1 py-0.5',
                       isIdle
-                        ? 'bg-danger/10 text-danger'
+                        ? 'bg-red-50 text-red-700'
                         : 'bg-surface-subtle hover:bg-surface',
                       d.state.kind === 'partial' && 'opacity-80',
                       draggable && 'cursor-grab'
@@ -210,7 +210,7 @@ export default function CalendarView({ days, onDayClick, onCellDrop }: Props) {
                     <span
                       className={cn(
                         'h-2 w-2 rounded-full shrink-0',
-                        isIdle ? 'bg-danger/60' : CREW_COLORS[d.crew_index % CREW_COLORS.length]
+                        isIdle ? 'bg-red-500' : CREW_COLORS[d.crew_index % CREW_COLORS.length]
                       )}
                     />
                     <span className="truncate flex-1 font-medium text-fg">{label}</span>

--- a/src/components/scheduler/CrewUtilizationChip.tsx
+++ b/src/components/scheduler/CrewUtilizationChip.tsx
@@ -29,22 +29,26 @@ const STATE_LABEL: Record<CrewDayStateKind, string> = {
   overnight_continuation: 'Overnight',
 }
 
+// Use Tailwind's static palette for these state colors — the
+// CSS-var-based theme tokens (bg-accent etc.) don't support the
+// `/<opacity>` modifier without channel-formatted vars, and silent
+// no-op opacity is what made the Gantt look colorless.
 export function stateClass(kind: CrewDayStateKind): string {
   switch (kind) {
     case 'fully_utilized':
-      return 'bg-accent/90 text-white border-accent'
+      return 'bg-indigo-600 text-white border-indigo-700'
     case 'partial':
-      return 'bg-accent/40 text-fg border-accent/50'
+      return 'bg-indigo-200 text-indigo-900 border-indigo-300'
     case 'idle':
-      return 'bg-danger/15 text-danger border-danger/30'
+      return 'bg-red-100 text-red-700 border-red-300'
     case 'between_trips':
-      return 'bg-fg-subtle/15 text-fg-muted border-fg-subtle/20'
+      return 'bg-zinc-200 text-zinc-700 border-zinc-300'
     case 'travel_day':
-      return 'bg-warning/30 text-fg border-warning/40'
+      return 'bg-amber-200 text-amber-900 border-amber-400'
     case 'rest_day':
-      return 'bg-surface-subtle text-fg-muted border-border'
+      return 'bg-zinc-100 text-zinc-600 border-zinc-200'
     case 'overnight_continuation':
-      return 'bg-accent/70 text-white border-accent'
+      return 'bg-indigo-500 text-white border-indigo-600'
   }
 }
 

--- a/src/components/scheduler/GanttView.tsx
+++ b/src/components/scheduler/GanttView.tsx
@@ -65,6 +65,17 @@ export default function GanttView({
   scrollToToday,
 }: Props) {
   const [selected, setSelected] = useState<Set<CellKey>>(new Set())
+  // Phase 4f-4 — filter chips for the legend. Empty Set = no filter
+  // (all kinds visible). Add a kind to mute cells of that kind.
+  const [hiddenKinds, setHiddenKinds] = useState<Set<CrewDayStateKind>>(new Set())
+  const toggleKind = (kind: CrewDayStateKind) => {
+    setHiddenKinds((prev) => {
+      const next = new Set(prev)
+      if (next.has(kind)) next.delete(kind)
+      else next.add(kind)
+      return next
+    })
+  }
   const [dragOver, setDragOver] = useState<CellKey | null>(null)
   const dragSource = useRef<CellKey | null>(null)
   const containerRef = useRef<HTMLDivElement>(null)
@@ -369,7 +380,8 @@ export default function GanttView({
                           stateClass(cell.state.kind),
                           isSelected && 'ring-2 ring-accent ring-inset',
                           isDragOver && 'ring-2 ring-warning ring-inset opacity-70',
-                          draggable && 'cursor-grab'
+                          draggable && 'cursor-grab',
+                          hiddenKinds.has(cell.state.kind) && 'opacity-15 grayscale'
                         )}
                         style={{ minWidth: 28, height: 36 }}
                         title={`${cell.crew_label} · ${cell.scheduled_date}\n${cell.work_hours_scheduled.toFixed(1)}h · ${cell.utilization_pct}%${cell.trip_label ? `\n${cell.trip_label}` : ''}\nCmd+click to select; drag to move`}
@@ -387,25 +399,52 @@ export default function GanttView({
           </tbody>
         </table>
       </div>
-      <div className="border-t border-border bg-surface-subtle px-3 py-2 text-xs text-fg-muted flex items-center gap-4 flex-wrap">
-        <span className="flex items-center gap-1">
-          <span className="inline-block h-3 w-3 rounded bg-accent/90" /> Full
-        </span>
-        <span className="flex items-center gap-1">
-          <span className="inline-block h-3 w-3 rounded bg-accent/40" /> Partial
-        </span>
-        <span className="flex items-center gap-1">
-          <span className="inline-block h-3 w-3 rounded bg-danger/15 border border-danger/30" /> Idle
-        </span>
-        <span className="flex items-center gap-1">
-          <span className="inline-block h-3 w-3 rounded bg-fg-subtle/15 border border-fg-subtle/20" /> Between
-        </span>
-        <span className="flex items-center gap-1">
-          <span className="inline-block h-3 w-3 rounded bg-warning/30 border border-warning/40" /> Travel
-        </span>
-        <span className="flex items-center gap-1">
-          <span className="inline-block h-3 w-3 rounded bg-accent/70" /> Overnight
-        </span>
+      <div className="border-t border-border bg-surface-subtle px-3 py-2 text-xs text-fg-muted flex items-center gap-2 flex-wrap">
+        <span className="text-fg-subtle mr-1">Filter:</span>
+        {(
+          [
+            { kinds: ['fully_utilized'] as const, label: 'Full', dot: 'bg-indigo-600' },
+            { kinds: ['partial'] as const, label: 'Partial', dot: 'bg-indigo-200 border border-indigo-300' },
+            { kinds: ['idle'] as const, label: 'Idle', dot: 'bg-red-100 border border-red-300' },
+            { kinds: ['between_trips'] as const, label: 'Between', dot: 'bg-zinc-200 border border-zinc-300' },
+            { kinds: ['travel_day'] as const, label: 'Travel', dot: 'bg-amber-200 border border-amber-400' },
+            { kinds: ['overnight_continuation'] as const, label: 'Overnight', dot: 'bg-indigo-500' },
+          ] as Array<{ kinds: readonly CrewDayStateKind[]; label: string; dot: string }>
+        ).map((chip) => {
+          const allHidden = chip.kinds.every((k) => hiddenKinds.has(k))
+          return (
+            <button
+              key={chip.label}
+              type="button"
+              onClick={() => {
+                setHiddenKinds((prev) => {
+                  const next = new Set(prev)
+                  if (allHidden) for (const k of chip.kinds) next.delete(k)
+                  else for (const k of chip.kinds) next.add(k)
+                  return next
+                })
+              }}
+              className={cn(
+                'inline-flex items-center gap-1 rounded-full border px-2 py-0.5 transition-colors',
+                allHidden
+                  ? 'border-border text-fg-subtle line-through opacity-60'
+                  : 'border-border-strong text-fg hover:bg-surface'
+              )}
+            >
+              <span className={cn('inline-block h-2.5 w-2.5 rounded', chip.dot)} />
+              {chip.label}
+            </button>
+          )
+        })}
+        {hiddenKinds.size > 0 && (
+          <button
+            type="button"
+            onClick={() => setHiddenKinds(new Set())}
+            className="text-accent hover:underline"
+          >
+            Clear filters
+          </button>
+        )}
         <span className="ml-auto text-fg-subtle">
           Cmd+click to select · drag to move · T jumps to today
         </span>


### PR DESCRIPTION
## Summary
User reported the Gantt's legend at the bottom looked like filter chips that didn't filter anything, AND there were no colors at all on the cells.

Two real bugs:

1. **Legend was static** — just a color key, no \`onClick\`. Made each chip a button that toggles whether cells of that kind are muted (\`opacity-15 grayscale\`). Multi-select accumulates. "Clear filters" link appears when anything is hidden. The chip itself shows line-through + faded when its kind is filtered out.

2. **Cell colors were silently invisible.** \`stateClass\` used \`bg-accent/90\`, \`bg-danger/15\`, etc. — Tailwind's \`/<opacity>\` modifier needs colors defined as channel values (\`rgb(<r> <g> <b> / <alpha-value>)\`). Our theme tokens are \`var(--color-accent)\` — a plain CSS variable, which generates a no-op rgba() with 0 alpha. So every Gantt cell was technically colored but with zero alpha → blank. Switched stateClass and the legend dots to Tailwind's static palette (\`indigo-600\`, \`indigo-200\`, \`red-100\`, \`zinc-200\`, \`amber-200\`) which renders regardless of token shape.

## Test plan
- [ ] Open a populated cycle's Gantt → cells show actual colors per state.
- [ ] Click "Idle" chip in the legend → all idle cells fade out, chip goes line-through. Click again → restored.
- [ ] Multi-select Full + Partial → only those kinds show; everything else fades.
- [ ] "Clear filters" link removes all filters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)