### PR TITLE
Fix Gantt sticky crew column showing transparent on horizontal scroll

### DIFF
--- a/src/components/scheduler/GanttView.tsx
+++ b/src/components/scheduler/GanttView.tsx
@@ -209,7 +209,18 @@ export default function GanttView({
         <table className="border-collapse min-w-full">
           <thead>
             <tr className="bg-surface-subtle">
-              <th className="sticky left-0 z-10 bg-surface-subtle border-b border-r border-border px-3 py-2 text-left text-[10px] uppercase tracking-wider text-fg-subtle font-semibold">
+              <th
+                // Inline opaque background + bumped z-index so cells
+                // can't scroll through. border-collapse + sticky + rowSpan
+                // produces a known browser bug where Tailwind's bg-* on
+                // a sticky table cell paints transparently in some
+                // engines; the inline style guarantees a solid color.
+                style={{
+                  backgroundColor: 'var(--color-bg-subtle, #fafafa)',
+                  backgroundClip: 'padding-box',
+                }}
+                className="sticky left-0 z-20 border-b border-r border-border px-3 py-2 text-left text-[10px] uppercase tracking-wider text-fg-subtle font-semibold"
+              >
                 Crew
               </th>
               {allDates.map((d) => {
@@ -279,8 +290,16 @@ export default function GanttView({
                 <tr>
                   <th
                     rowSpan={2}
-                    className="sticky left-0 z-10 bg-surface border-b border-r border-border px-3 py-2 text-left whitespace-nowrap align-top"
-                    style={{ minWidth: 180 }}
+                    className="sticky left-0 z-20 border-b border-r border-border px-3 py-2 text-left whitespace-nowrap align-top"
+                    // Inline opaque background — see Crew header note.
+                    // Without this, the rowSpan'd sticky cell's bg-surface
+                    // class doesn't paint reliably and the day cells in
+                    // row 2 visibly scroll under the crew label.
+                    style={{
+                      minWidth: 180,
+                      backgroundColor: 'var(--color-bg, #ffffff)',
+                      backgroundClip: 'padding-box',
+                    }}
                   >
                     <div className="flex items-center gap-2">
                       <span


### PR DESCRIPTION
## Summary
Day cells were scrolling visibly through the supposedly-frozen left crew column. Two compounding issues:

1. **rowSpan + sticky + border-collapse** — the crew label cell uses \`rowSpan={2}\` to cover both the trip ribbon row and the day cells row. Inside a border-collapse table, sticky on a rowSpan cell has a cross-browser rendering quirk where the Tailwind \`bg-surface\` class paints inconsistently across the merged span, so the row-2 day cells underneath show through during horizontal scroll.
2. **z-index too low** — both sticky cells were at \`z-10\`. Fine in isolation but no margin against future ribbon/cell styling stacking weirdly.

## Fixes
- Inline \`backgroundColor: var(--color-bg, #ffffff)\` (and \`bg-subtle\` for the header) — inline style wins any class-merge ordering and guarantees the column paints solid even when the rowSpan rendering quirk hits.
- \`backgroundClip: padding-box\` so the rowSpan'd background fully fills both row heights without leaving the border edge transparent.
- Bumped sticky cells from \`z-10\` to \`z-20\`.

## Test plan
- [ ] Open a populated cycle Gantt.
- [ ] Scroll horizontally to a future month.
- [ ] Crew column on the left stays solid white (or solid dark in dark mode); no day-cell colors bleed through.
- [ ] Header "Crew" cell at top-left also stays solid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)