### PR TITLE
Let user reclassify selected branches as main/satellite without clearing

### DIFF
--- a/src/components/analysis/SelectionStatusBanner.tsx
+++ b/src/components/analysis/SelectionStatusBanner.tsx
@@ -9,6 +9,13 @@ interface Props {
   selectedAt: string | null
   selectedFromAnalysisId: string | null
   onChangeSelection: () => Promise<void>
+  // Phase 3.9 — toggle a branch between main and satellite without
+  // re-doing the whole selection. Optional; if not provided, the
+  // toggles render as read-only badges.
+  onToggleBranchType?: (
+    branchName: string,
+    nextType: 'main' | 'satellite'
+  ) => Promise<void>
 }
 
 export default function SelectionStatusBanner({
@@ -16,9 +23,11 @@ export default function SelectionStatusBanner({
   selectedAt,
   selectedFromAnalysisId,
   onChangeSelection,
+  onToggleBranchType,
 }: Props) {
   const [confirming, setConfirming] = useState(false)
   const [working, setWorking] = useState(false)
+  const [savingBranch, setSavingBranch] = useState<string | null>(null)
 
   const handleChange = async () => {
     if (!confirming) {
@@ -47,9 +56,71 @@ export default function SelectionStatusBanner({
               K = <span className="font-tabular">{branches.length}</span>
             </Badge>
           </div>
-          <p className="text-sm text-fg break-words">
-            {branches.map((b) => preferCityState(b)).join(' · ')}
-          </p>
+          <ul className="flex flex-wrap gap-2">
+            {branches.map((b) => {
+              const type = b.branch_type ?? 'main'
+              const label = preferCityState(b)
+              const isSaving = savingBranch === b.name
+              return (
+                <li
+                  key={b.name}
+                  className="inline-flex items-center gap-1.5 rounded-md border border-border bg-surface px-2 py-1 text-xs"
+                >
+                  <span className="text-fg font-medium">{label}</span>
+                  {onToggleBranchType ? (
+                    <div className="inline-flex rounded-md border border-border overflow-hidden text-[10px]">
+                      <button
+                        type="button"
+                        disabled={isSaving}
+                        onClick={async () => {
+                          if (type === 'main') return
+                          setSavingBranch(b.name)
+                          try {
+                            await onToggleBranchType(b.name, 'main')
+                          } finally {
+                            setSavingBranch(null)
+                          }
+                        }}
+                        className={
+                          'px-1.5 py-0.5 transition ' +
+                          (type === 'main'
+                            ? 'bg-accent text-white'
+                            : 'text-fg-muted hover:bg-surface-subtle')
+                        }
+                      >
+                        Main
+                      </button>
+                      <button
+                        type="button"
+                        disabled={isSaving}
+                        onClick={async () => {
+                          if (type === 'satellite') return
+                          setSavingBranch(b.name)
+                          try {
+                            await onToggleBranchType(b.name, 'satellite')
+                          } finally {
+                            setSavingBranch(null)
+                          }
+                        }}
+                        className={
+                          'px-1.5 py-0.5 transition ' +
+                          (type === 'satellite'
+                            ? 'bg-accent text-white'
+                            : 'text-fg-muted hover:bg-surface-subtle')
+                        }
+                      >
+                        Satellite
+                      </button>
+                    </div>
+                  ) : (
+                    <Badge variant="outline" className="text-[10px] capitalize">
+                      {type}
+                    </Badge>
+                  )}
+                </li>
+              )
+            })}
+          </ul>
           {selectedAt && (
             <p className="text-xs text-fg-muted">
               Selected {relativeTime(selectedAt)}

--- a/src/pages/accounts/AccountAnalysis.tsx
+++ b/src/pages/accounts/AccountAnalysis.tsx
@@ -450,6 +450,39 @@ export default function AccountAnalysisPage() {
     setConstraintsUpdatedAt(json.updated_at ?? null)
   }, [accountId, getToken])
 
+  // Flip a single branch between main and satellite without clearing
+  // the rest of the selection. Re-POSTs to /select-branches with the
+  // updated branches array.
+  const handleToggleBranchType = useCallback(
+    async (branchName: string, nextType: 'main' | 'satellite') => {
+      if (!accountId || !clientId || !selectedBranches) return
+      const next = selectedBranches.map((b) =>
+        b.name === branchName ? { ...b, branch_type: nextType } : b
+      )
+      const token = await getToken()
+      const res = await fetch(
+        `/api/accounts/${accountId}/clients/${clientId}/select-branches`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({
+            k: next.length,
+            branches: next,
+            source_analysis_id: selectedFromAnalysisId,
+          }),
+        }
+      )
+      const json = await res.json().catch(() => ({}))
+      if (!res.ok) throw new Error(json.error ?? `HTTP ${res.status}`)
+      setSelectedBranches(json.selected_branches ?? next)
+      setConstraintsUpdatedAt(json.updated_at ?? null)
+    },
+    [accountId, clientId, getToken, selectedBranches, selectedFromAnalysisId]
+  )
+
   const hasSelection = !!selectedBranches && selectedBranches.length > 0
 
   // ─── Tick every 1s so elapsed-time displays + stuck-state derivation refresh
@@ -844,6 +877,7 @@ export default function AccountAnalysisPage() {
               selectedAt={selectedAt}
               selectedFromAnalysisId={selectedFromAnalysisId}
               onChangeSelection={handleClearSelection}
+              onToggleBranchType={handleToggleBranchType}
             />
           )}
 


### PR DESCRIPTION
## Summary
The Main/Satellite toggle only existed inside \`BuildSelectionModal\` — and that modal is only reachable when no selection is locked. Once a user confirms a branch selection, the SelectionStatusBanner only has "Change selection" (which clears everything). So there was no path to flip a branch from main to satellite after the fact, and all branches default to main.

Fix: each branch chip in the SelectionStatusBanner now has an inline segmented Main|Satellite control. Clicking re-POSTs to \`/select-branches\` with the same array but the one branch's \`branch_type\` flipped. Bid pricing's branch overhead breakdown picks up the new classification on the next run.

## Test plan
- [ ] Open Smart Analysis → Branch selection banner shows each branch as a chip with Main / Satellite toggle.
- [ ] Click "Satellite" on a branch → it becomes indigo, "Main" goes neutral.
- [ ] Reload the page → the change persists.
- [ ] Re-run Bid Pricing → expand the Branch overhead row → the per-branch breakdown shows the updated mix (e.g. "1 main · 2 satellite").

🤖 Generated with [Claude Code](https://claude.com/claude-code)