### PR TITLE
Bid pricing reconciliation: surface unpriced offerings + every-line config editor

### DIFF
--- a/api/analyses/account/[accountId]/clients/[clientId]/bid-pricing-structure.ts
+++ b/api/analyses/account/[accountId]/clients/[clientId]/bid-pricing-structure.ts
@@ -344,6 +344,17 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       ;(result.outputs as any).service_line_bid = serviceLineBid
     }
 
+    // Always emit the unpriced-offerings audit (even when service_line_bid
+    // is null because no offerings were configured at all) so the UI
+    // can surface a reconciliation banner whenever the headline bid
+    // omits offerings the client is actually serving.
+    try {
+      const audit = await computeUnpricedOfferings(db, accountId, clientId, properties, offerings)
+      ;(result.outputs as any).unpriced_offerings = audit
+    } catch (err: any) {
+      console.error('[bid-pricing] unpriced-offerings audit failed:', err?.message ?? err)
+    }
+
     await completeAnalysisRecord(db, analysisId, {
       outputs: result.outputs,
       summary_text: result.summary_text,
@@ -830,7 +841,7 @@ async function computeServiceLineBid(args: {
     .eq('account_id', accountId)
     .eq('client_id', clientId)
     .eq('is_active', true)
-  const configs = (configRows ?? []) as Array<{
+  const allConfigs = (configRows ?? []) as Array<{
     service_offering_id: string
     pricing_model: 'per_visit_blended_sqft' | 'per_sqft_monthly'
     rate_per_sqft_per_visit: number | null
@@ -838,6 +849,16 @@ async function computeServiceLineBid(args: {
     billable_sqft_pct: number
     target_gross_margin_pct_override: number | null
   }>
+
+  // An offering with a row but null/zero rate isn't really priced.
+  // Filter those out for the actual bid calc, but track them so the
+  // caller can surface "N offerings configured but missing rates".
+  const configs = allConfigs.filter((c) => {
+    if (c.pricing_model === 'per_visit_blended_sqft') {
+      return Number(c.rate_per_sqft_per_visit ?? 0) > 0
+    }
+    return Number(c.rate_per_sqft_per_month ?? 0) > 0
+  })
   if (configs.length === 0) return null
 
   const accountMargin =
@@ -949,4 +970,78 @@ async function computeServiceLineBid(args: {
           flat_amount: Number(result.outputs.cost_buildup.insurance?.total ?? 0),
         },
   })
+}
+
+// Audit which offerings the client is actually serving (≥1 SL) but
+// have no pricing config — or have a config row with a null/zero rate.
+// The UI uses this to render a reconciliation banner so the user
+// doesn't stare at a Service Line Breakdown total that's silently much
+// smaller than the headline bid because half their offerings aren't
+// in service_line_pricing_config.
+async function computeUnpricedOfferings(
+  db: any,
+  accountId: string,
+  clientId: string,
+  properties: Awaited<ReturnType<typeof loadAccountProperties>>,
+  offerings: Map<string, { id: string; name: string }>
+): Promise<Array<{
+  offering_id: string
+  offering_name: string
+  sl_count: number
+  total_sqft: number
+  reason: 'no_config' | 'zero_rate'
+}>> {
+  const { data: configRows } = await db
+    .from('service_line_pricing_config')
+    .select(
+      'service_offering_id, pricing_model, rate_per_sqft_per_visit, rate_per_sqft_per_month, is_active'
+    )
+    .eq('account_id', accountId)
+    .eq('client_id', clientId)
+    .eq('is_active', true)
+  const configByOffering = new Map<string, any>()
+  for (const c of configRows ?? []) {
+    configByOffering.set((c as any).service_offering_id, c)
+  }
+
+  type Acc = { offering_name: string; sl_count: number; total_sqft: number; reason: 'no_config' | 'zero_rate' }
+  const unpriced = new Map<string, Acc>()
+  for (const p of properties) {
+    for (const sl of p.service_locations) {
+      if (!sl.service_offering_id) continue
+      const cfg = configByOffering.get(sl.service_offering_id)
+      let reason: 'no_config' | 'zero_rate' | null = null
+      if (!cfg) {
+        reason = 'no_config'
+      } else {
+        const rate =
+          cfg.pricing_model === 'per_visit_blended_sqft'
+            ? Number(cfg.rate_per_sqft_per_visit ?? 0)
+            : Number(cfg.rate_per_sqft_per_month ?? 0)
+        if (rate <= 0) reason = 'zero_rate'
+      }
+      if (!reason) continue
+      const off = offerings.get(sl.service_offering_id)
+      const name = off?.name ?? '(unknown offering)'
+      const entry = unpriced.get(sl.service_offering_id) ?? {
+        offering_name: name,
+        sl_count: 0,
+        total_sqft: 0,
+        reason,
+      }
+      entry.sl_count += 1
+      entry.total_sqft += Number(sl.serviceable_sqft ?? 0)
+      unpriced.set(sl.service_offering_id, entry)
+    }
+  }
+
+  return Array.from(unpriced.entries())
+    .map(([offering_id, u]) => ({
+      offering_id,
+      offering_name: u.offering_name,
+      sl_count: u.sl_count,
+      total_sqft: Math.round(u.total_sqft),
+      reason: u.reason,
+    }))
+    .sort((a, b) => b.total_sqft - a.total_sqft)
 }

--- a/api/v1/clients/[id]/service-line-pricing.ts
+++ b/api/v1/clients/[id]/service-line-pricing.ts
@@ -33,17 +33,66 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (!accountId) return res.status(404).json({ error: 'Client not found' })
 
   if (req.method === 'GET') {
-    const { data, error } = await db
+    // Return ALL offerings the client has access to (account-scoped or
+    // shared), left-joined with any existing config row. Offerings
+    // without a config show up with nulls — the UI renders a "Set rate"
+    // CTA for those, eliminating the silent-exclusion bug where a new
+    // offering wasn't in the migration backfill and was therefore
+    // invisible to both the editor AND the bid breakdown.
+    const { data: offeringRows, error: offeringErr } = await db
+      .from('service_offerings')
+      .select('id, name, offering_role, account_id')
+      .or(`account_id.is.null,account_id.eq.${accountId}`)
+      .order('name', { ascending: true })
+    if (offeringErr) return res.status(500).json({ error: offeringErr.message })
+
+    const { data: configRows, error: configErr } = await db
       .from('service_line_pricing_config')
       .select(
-        'id, service_offering_id, pricing_model, rate_per_sqft_per_visit, rate_per_sqft_per_month, billable_sqft_pct, billable_sqft_pct_notes, target_gross_margin_pct_override, is_active, updated_at, service_offering:service_offerings(id, name, offering_role)'
+        'id, service_offering_id, pricing_model, rate_per_sqft_per_visit, rate_per_sqft_per_month, billable_sqft_pct, billable_sqft_pct_notes, target_gross_margin_pct_override, is_active, updated_at'
       )
       .eq('account_id', accountId)
       .eq('client_id', clientId)
       .eq('is_active', true)
-      .order('updated_at', { ascending: true })
-    if (error) return res.status(500).json({ error: error.message })
-    return res.status(200).json({ configs: data ?? [] })
+    if (configErr) return res.status(500).json({ error: configErr.message })
+
+    const configByOfferingId = new Map<string, any>()
+    for (const c of configRows ?? []) {
+      configByOfferingId.set((c as any).service_offering_id, c)
+    }
+
+    // Merge: every offering yields a row. Offerings with a config keep
+    // its values; offerings without get the placeholder shape with
+    // nulls + a sensible default pricing_model based on offering_role
+    // ('addon' / 'recurring' / 'project') so the UI's editor opens
+    // pre-filled with a reasonable starting point.
+    const configs = (offeringRows ?? []).map((o: any) => {
+      const cfg = configByOfferingId.get(o.id)
+      if (cfg) {
+        return {
+          ...cfg,
+          service_offering: { id: o.id, name: o.name, offering_role: o.offering_role },
+          has_config: true,
+        }
+      }
+      const defaultModel: 'per_visit_blended_sqft' | 'per_sqft_monthly' =
+        o.offering_role === 'recurring' ? 'per_sqft_monthly' : 'per_visit_blended_sqft'
+      return {
+        id: null,
+        service_offering_id: o.id,
+        pricing_model: defaultModel,
+        rate_per_sqft_per_visit: null,
+        rate_per_sqft_per_month: null,
+        billable_sqft_pct: 100,
+        billable_sqft_pct_notes: null,
+        target_gross_margin_pct_override: null,
+        is_active: true,
+        updated_at: null,
+        service_offering: { id: o.id, name: o.name, offering_role: o.offering_role },
+        has_config: false,
+      }
+    })
+    return res.status(200).json({ configs })
   }
 
   if (req.method === 'PUT') {

--- a/src/components/analysis/BidPricingChart.tsx
+++ b/src/components/analysis/BidPricingChart.tsx
@@ -139,6 +139,17 @@ interface BidOutputs {
     margin: number
     other: number
   }
+  // Phase 4 follow-up — offerings the client serves but that have no
+  // pricing config (or config with zero rate). When non-empty, the
+  // service-line breakdown total is structurally lower than the
+  // headline bid; UI surfaces a banner.
+  unpriced_offerings?: Array<{
+    offering_id: string
+    offering_name: string
+    sl_count: number
+    total_sqft: number
+    reason: 'no_config' | 'zero_rate'
+  }>
   // Phase 4 — service line bid pricing structure. Per-line revenue/cost/
   // margin computed from configured rates × billable sqft, with shared
   // overhead allocated by revenue share.
@@ -277,6 +288,22 @@ export default function BidPricingChart({
     }
   })()
 
+  // Reconciliation between headline bid (cost-buildup math) and
+  // service-line breakdown (rate × billable sqft × frequency). When
+  // they diverge by >10%, surface a banner. Most common cause: some
+  // offerings have SLs but no entry in service_line_pricing_config,
+  // so they're invisible to the breakdown.
+  const headlineBid = data.bid_total
+  const serviceLineRevenue = data.service_line_bid?.summary.total_annual_revenue ?? 0
+  const reconciliationGapPct =
+    headlineBid > 0 ? Math.abs(headlineBid - serviceLineRevenue) / headlineBid : 0
+  const showReconciliation =
+    !!data.service_line_bid &&
+    serviceLineRevenue > 0 &&
+    (reconciliationGapPct > 0.1 || (data.unpriced_offerings ?? []).length > 0)
+  const showAllUnpriced =
+    !data.service_line_bid && (data.unpriced_offerings ?? []).length > 0
+
   return (
     <div className="space-y-6">
       {/* Source-of-truth indicator */}
@@ -296,6 +323,65 @@ export default function BidPricingChart({
         </p>
         <p className="mt-0.5 text-fg-muted">{sourceLine.sub}</p>
       </div>
+
+      {/* Reconciliation banner — fires when the service-line breakdown
+          excludes offerings the client is actually serving, so the
+          breakdown total looks much smaller than the headline bid. */}
+      {(showReconciliation || showAllUnpriced) && (
+        <div className="rounded-md border border-warning/40 bg-warning/5 px-4 py-3 text-sm">
+          <p className="font-semibold text-warning">
+            ⚠ Service line breakdown is incomplete
+          </p>
+          {showReconciliation && (
+            <p className="mt-1 text-fg-muted">
+              Headline bid is{' '}
+              <span className="font-mono font-semibold text-fg">
+                ${headlineBid.toLocaleString()}
+              </span>{' '}
+              but the service-line breakdown sums to{' '}
+              <span className="font-mono font-semibold text-fg">
+                ${serviceLineRevenue.toLocaleString()}
+              </span>{' '}
+              — a <span className="font-tabular">{Math.round(reconciliationGapPct * 100)}%</span> gap.
+            </p>
+          )}
+          {showAllUnpriced && (
+            <p className="mt-1 text-fg-muted">
+              No service-line pricing is configured. The headline bid is computed
+              from the cost-buildup math (labor + overhead + margin) only.
+            </p>
+          )}
+          {(data.unpriced_offerings ?? []).length > 0 && (
+            <div className="mt-2">
+              <p className="text-xs text-fg">
+                {data.unpriced_offerings!.length} offering
+                {data.unpriced_offerings!.length === 1 ? '' : 's'} {' '}
+                are not priced and contribute $0 to the breakdown:
+              </p>
+              <ul className="mt-1 ml-4 list-disc text-xs text-fg-muted space-y-0.5">
+                {data.unpriced_offerings!.slice(0, 8).map((u) => (
+                  <li key={u.offering_id}>
+                    <span className="text-fg">{u.offering_name}</span>{' '}
+                    — {u.sl_count} SL{u.sl_count === 1 ? '' : 's'},{' '}
+                    {u.total_sqft.toLocaleString()} sqft (
+                    {u.reason === 'no_config' ? 'no pricing config' : 'rate is $0'}
+                    )
+                  </li>
+                ))}
+                {data.unpriced_offerings!.length > 8 && (
+                  <li className="italic">
+                    +{data.unpriced_offerings!.length - 8} more
+                  </li>
+                )}
+              </ul>
+              <p className="mt-2 text-xs text-fg-muted">
+                Set rates in <span className="font-medium">Cost Assumptions → Service line pricing</span>{' '}
+                to bring these into the breakdown.
+              </p>
+            </div>
+          )}
+        </div>
+      )}
 
       {/* Headline bid number — quiet 1px-bordered card per design rules
           (the legacy version used a green→teal gradient + 2px border which
@@ -322,46 +408,96 @@ export default function BidPricingChart({
         </div>
 
         {/* Per-service-line $/sqft. Project lines = $/sqft/visit;
-            recurring janitorial = $/sqft/year (when scoped). */}
+            recurring janitorial = $/sqft/year (when scoped or
+            configured via Phase 4). */}
         {data.per_service_line && data.per_service_line.length > 0 && (
           <div className="mt-5 pt-4 border-t border-border space-y-2">
             <p className="text-[10px] font-semibold uppercase tracking-wider text-fg-subtle">
               $/sqft by service line
             </p>
             <ul className="grid grid-cols-1 sm:grid-cols-2 gap-2">
-              {data.per_service_line.map((line) => (
-                <li
-                  key={line.service_line}
-                  className="rounded-md border border-border bg-surface-subtle/40 px-3 py-2"
-                >
-                  <div className="flex items-baseline justify-between gap-2 flex-wrap">
-                    <span className="text-xs font-medium text-fg">{line.label}</span>
-                    {line.rate_per_sqft != null ? (
-                      <span className="font-mono text-base font-semibold tabular-nums text-fg">
-                        ${line.rate_per_sqft.toFixed(2)}
-                        <span className="text-xs text-fg-muted ml-1">
-                          /sqft/{line.unit}
+              {data.per_service_line.map((line) => {
+                // When a Phase 4 config exists for this category,
+                // prefer its rate over the bid-allocation math. Maps
+                // category → average rate from service_line_bid lines
+                // whose offering name fits.
+                const sib = data.service_line_bid?.service_lines ?? []
+                const categoryMatch = sib.find((s) => {
+                  const n = s.offering_name.toLowerCase()
+                  if (line.service_line === 'project_clean')
+                    return /project clean/.test(n) && !/upholstery/.test(n)
+                  if (line.service_line === 'upholstery') return /upholstery/.test(n)
+                  if (line.service_line === 'recurring_janitorial')
+                    return /recurring janitorial|housekeeping|home cleaning/.test(n)
+                  return false
+                })
+                const phase4Rate = categoryMatch?.rate ?? null
+                const phase4Unit = categoryMatch
+                  ? categoryMatch.pricing_model === 'per_sqft_monthly'
+                    ? 'month'
+                    : 'visit'
+                  : null
+
+                const displayRate = phase4Rate != null && phase4Rate > 0
+                  ? phase4Rate
+                  : line.rate_per_sqft
+                const displayUnit = phase4Unit ?? line.unit
+                const isTrulyZero =
+                  displayRate == null || displayRate < 0.005
+
+                return (
+                  <li
+                    key={line.service_line}
+                    className="rounded-md border border-border bg-surface-subtle/40 px-3 py-2"
+                  >
+                    <div className="flex items-baseline justify-between gap-2 flex-wrap">
+                      <span className="text-xs font-medium text-fg">{line.label}</span>
+                      {!isTrulyZero ? (
+                        <span className="font-mono text-base font-semibold tabular-nums text-fg">
+                          ${displayRate!.toFixed(2)}
+                          <span className="text-xs text-fg-muted ml-1">
+                            /sqft/{displayUnit}
+                          </span>
                         </span>
-                      </span>
-                    ) : (
-                      <span className="text-xs text-fg-subtle italic">not priced</span>
+                      ) : (
+                        <span
+                          className="text-xs text-fg-subtle italic"
+                          title={
+                            line.rate_per_sqft == null
+                              ? 'No rate is configured for this service line'
+                              : 'Rate rounds below $0.01/sqft — likely no contributing hours or sqft'
+                          }
+                        >
+                          —
+                        </span>
+                      )}
+                    </div>
+                    <p className="mt-0.5 text-[11px] text-fg-muted">
+                      <span className="font-tabular">{line.sl_count}</span> SLs ·{' '}
+                      <span className="font-tabular">{line.sqft.toLocaleString()}</span> sqft
+                      {line.avg_visits_per_year != null && displayUnit === 'visit' && (
+                        <>
+                          {' · '}
+                          <span className="font-tabular">{line.avg_visits_per_year}</span>×/yr avg
+                        </>
+                      )}
+                    </p>
+                    {phase4Rate != null && phase4Rate > 0 && (
+                      <p className="mt-0.5 text-[10px] text-accent">
+                        ✓ Rate from Service Line Pricing config
+                      </p>
                     )}
-                  </div>
-                  <p className="mt-0.5 text-[11px] text-fg-muted">
-                    <span className="font-tabular">{line.sl_count}</span> SLs ·{' '}
-                    <span className="font-tabular">{line.sqft.toLocaleString()}</span> sqft
-                    {line.avg_visits_per_year != null && line.unit === 'visit' && (
-                      <>
-                        {' · '}
-                        <span className="font-tabular">{line.avg_visits_per_year}</span>×/yr avg
-                      </>
+                    {phase4Rate == null && line.note && (
+                      <p className="mt-1 text-[11px] text-fg-subtle italic">{line.note}</p>
                     )}
-                  </p>
-                  {line.note && (
-                    <p className="mt-1 text-[11px] text-fg-subtle italic">{line.note}</p>
-                  )}
-                </li>
-              ))}
+                    {isTrulyZero && phase4Rate == null && line.rate_per_sqft != null && (
+                      <p className="mt-1 text-[11px] text-warning">
+                        Set a rate in Cost Assumptions → Service line pricing
+                      </p>
+                    )}
+                  </li>
+                )
+              })}
             </ul>
           </div>
         )}

--- a/src/components/analysis/ServiceLinePricingSection.tsx
+++ b/src/components/analysis/ServiceLinePricingSection.tsx
@@ -34,7 +34,7 @@ import {
 type PricingModel = 'per_visit_blended_sqft' | 'per_sqft_monthly'
 
 interface PricingConfig {
-  id: string
+  id: string | null
   service_offering_id: string
   pricing_model: PricingModel
   rate_per_sqft_per_visit: number | null
@@ -43,6 +43,10 @@ interface PricingConfig {
   billable_sqft_pct_notes?: string | null
   target_gross_margin_pct_override: number | null
   service_offering: { id: string; name: string; offering_role?: string | null } | null
+  // Phase 4 follow-up — endpoint returns every offering, including
+  // those without a saved config. has_config = true when a row
+  // exists in service_line_pricing_config, false for placeholder rows.
+  has_config?: boolean
 }
 
 interface Props {
@@ -159,7 +163,8 @@ export default function ServiceLinePricingSection({
 
       {sorted.length === 0 ? (
         <p className="text-xs text-fg-muted italic">
-          No service offerings have pricing configured yet for this client.
+          No service offerings exist for this client yet. Create offerings first
+          and they'll show here for pricing.
         </p>
       ) : (
         <div className="rounded-md border border-border bg-surface overflow-hidden">
@@ -184,10 +189,19 @@ export default function ServiceLinePricingSection({
                   c.target_gross_margin_pct_override != null
                     ? `${c.target_gross_margin_pct_override}%`
                     : `${accountTargetMarginPct.toFixed(0)}% (default)`
+                const hasConfig = c.has_config !== false && rate != null
                 return (
-                  <TableRow key={c.id}>
+                  <TableRow
+                    key={c.service_offering_id}
+                    className={!hasConfig ? 'bg-warning-subtle/30' : undefined}
+                  >
                     <TableCell className="font-medium text-fg">
                       {c.service_offering?.name ?? '(unknown)'}
+                      {!hasConfig && (
+                        <span className="ml-2 text-[10px] text-warning font-medium">
+                          unpriced
+                        </span>
+                      )}
                     </TableCell>
                     <TableCell>
                       <Badge variant="outline" className="text-[10px]">
@@ -195,7 +209,9 @@ export default function ServiceLinePricingSection({
                       </Badge>
                     </TableCell>
                     <TableCell className="text-right font-tabular text-xs">
-                      {rate != null ? `$${Number(rate).toFixed(2)}/sqft` : '—'}
+                      {rate != null
+                        ? `$${Number(rate).toFixed(2)}/sqft`
+                        : <span className="text-warning">no rate</span>}
                     </TableCell>
                     <TableCell className="text-right font-tabular text-xs">
                       {Number(c.billable_sqft_pct).toFixed(0)}%
@@ -207,10 +223,14 @@ export default function ServiceLinePricingSection({
                       <button
                         type="button"
                         onClick={() => setEditing(c)}
-                        className="text-fg-subtle hover:text-accent inline-flex items-center gap-1 text-xs"
+                        className={
+                          hasConfig
+                            ? 'text-fg-subtle hover:text-accent inline-flex items-center gap-1 text-xs'
+                            : 'text-accent hover:underline inline-flex items-center gap-1 text-xs font-medium'
+                        }
                       >
                         <Pencil className="h-3 w-3" />
-                        Edit
+                        {hasConfig ? 'Edit' : 'Set rate'}
                       </button>
                     </TableCell>
                   </TableRow>


### PR DESCRIPTION
## Summary
User caught the audit miss: their bid card showed \$1.97M headline but the Service Line Breakdown only summed to \$732K, with Project Clean missing entirely from the breakdown, Upholstery at \$0.00, and Recurring Janitorial flagged "not priced." Static code review missed it because all four bugs were data-state / display issues that only appear with a real client's configs.

Four fixes:

### 1. Service Line Pricing editor shows every offering, not just configured ones
\`GET /api/v1/clients/[id]/service-line-pricing\` now left-joins ALL offerings the client has access to (account-scoped + shared) against existing configs. Offerings without a config come back with \`has_config: false\` and null rates. UI renders them with a yellow "unpriced" warning + "Set rate" CTA instead of silently excluding them.

### 2. Bid pricing emits an \`unpriced_offerings\` audit
On every run, identifies offerings the client is actually serving (≥1 SL) but with no config or rate ≤ 0. Includes \`offering_id\`, \`offering_name\`, \`sl_count\`, \`total_sqft\`, and \`reason\` ('no_config' | 'zero_rate'). Always emitted, even when no service_line_bid was producible.

### 3. Reconciliation banner on the Bid Pricing card
Fires when \`|headline - service_line_breakdown| / headline > 10%\` OR when \`unpriced_offerings\` is non-empty. Names the unpriced offerings, shows the gap, points at Cost Assumptions → Service line pricing.

### 4. Per-service-line \$/sqft display
- Prefers Phase 4 configured rates when present (so Recurring Janitorial finally gets a real rate when configured, instead of the hardcoded "not priced" note).
- When rate is null OR rounds below \$0.01, displays "—" with a tooltip explaining the cause (no contributing hours/sqft, or rate not set) and pointing at where to set it.
- "✓ Rate from Service Line Pricing config" badge appears when the displayed rate came from Phase 4.

## Test plan
- [ ] Open Cost Assumptions → Service line pricing on a client with offerings that previously had no config rows. Every offering shows up; missing ones are highlighted "unpriced" with "Set rate" link.
- [ ] Click "Set rate" on an unpriced offering → modal opens with sensible defaults; saving creates the config row.
- [ ] Re-run Bid Pricing on a client where breakdown is incomplete → reconciliation banner appears at top with the gap math + list of unpriced offerings.
- [ ] Configure rates for the unpriced lines → re-run → banner clears, breakdown total grows, headline-vs-breakdown gap closes.
- [ ] Recurring Janitorial card in \$/sqft section now shows its configured monthly rate when set, with the "Rate from Service Line Pricing config" badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)