### PR TITLE
Fix utilization math (hardcoded 1880/8 → actual config) + overnight classification audit

### DIFF
--- a/api/_lib/scheduler/build-routing-template.ts
+++ b/api/_lib/scheduler/build-routing-template.ts
@@ -139,6 +139,22 @@ export interface TemplateBuildResult {
   soft_constraint_violations: number
   optimization_score: number
   optimizer_notes: string
+  classification_audit: {
+    total_properties: number
+    local_count: number
+    remote_count: number
+    remote_pct: number
+    threshold_hours: number
+    drive_speed_mph: number
+    branch_validation_issues: string[]
+    sample: Array<{
+      address: string
+      nearest_branch: string
+      miles_to_nearest: number
+      drive_hours_to_nearest: number
+      classified: 'local' | 'remote'
+    }>
+  }
 }
 
 const DAYS_PER_YEAR = 365
@@ -223,22 +239,75 @@ export function buildRoutingTemplate(input: BuildTemplateInput): TemplateBuildRe
   const overnightTriggerHours = input.config.overnight_trigger_one_way_hours
   const speed = input.config.drive_speed_mph
 
+  // Defensive: branches with NaN/0 lat or lng cause haversine to return
+  // garbage (often huge), which marks every property as remote. This
+  // is a frequent root cause of "every property looks like overnight."
+  const branchValidationIssues: string[] = []
+  for (let i = 0; i < input.branches.length; i++) {
+    const b = input.branches[i]
+    if (
+      !Number.isFinite(b.lat) ||
+      !Number.isFinite(b.lng) ||
+      Math.abs(b.lat) < 1e-6 ||
+      Math.abs(b.lng) < 1e-6 ||
+      Math.abs(b.lat) > 90 ||
+      Math.abs(b.lng) > 180
+    ) {
+      branchValidationIssues.push(
+        `Branch "${b.name ?? `#${i + 1}`}" has invalid coordinates (${b.lat}, ${b.lng}); every property will look far from this branch.`
+      )
+    }
+  }
+  if (
+    !Number.isFinite(overnightTriggerHours) ||
+    overnightTriggerHours <= 0
+  ) {
+    branchValidationIssues.push(
+      `overnight_trigger_one_way_hours is ${overnightTriggerHours}; with a non-positive threshold every property classifies as overnight. Set to 3 hr unless you really mean it.`
+    )
+  }
+
   const local: VisitSpec[] = []
   const remote: VisitSpec[] = []
+  // Audit: per-property classification trace, sampled for the response
+  // notes when an unusually large fraction lands in "remote." Helps
+  // the user diagnose Cycle 7-style "everything is overnight" reports.
+  type ClassEntry = {
+    address: string
+    nearest_branch: string
+    miles_to_nearest: number
+    drive_hours_to_nearest: number
+    classified: 'local' | 'remote'
+  }
+  const classificationAudit: ClassEntry[] = []
   for (const v of visitSpecs) {
     if (input.branches.length === 0) {
       local.push(v)
       continue
     }
     let bestDist = Infinity
+    let bestBranchName = ''
     for (const b of input.branches) {
       const d = haversineMiles({ lat: v.lat, lng: v.lng }, b)
-      if (d < bestDist) bestDist = d
+      if (d < bestDist) {
+        bestDist = d
+        bestBranchName = b.name ?? ''
+      }
     }
     const hours = driveTimeMinutes(bestDist, speed) / 60
-    if (hours > overnightTriggerHours) remote.push(v)
+    const classified = hours > overnightTriggerHours ? 'remote' : 'local'
+    classificationAudit.push({
+      address: v.address,
+      nearest_branch: bestBranchName,
+      miles_to_nearest: Math.round(bestDist * 10) / 10,
+      drive_hours_to_nearest: Math.round(hours * 100) / 100,
+      classified,
+    })
+    if (classified === 'remote') remote.push(v)
     else local.push(v)
   }
+  const remotePct =
+    visitSpecs.length > 0 ? (remote.length / visitSpecs.length) * 100 : 0
 
   const clusters: ClusterSpec[] = []
   // Local clusters: one per branch.
@@ -587,6 +656,18 @@ export function buildRoutingTemplate(input: BuildTemplateInput): TemplateBuildRe
   if (totalNights > 0) {
     notes.push(`${totalNights} overnight nights/cycle across remote clusters.`)
   }
+  // Surface branch / config validation issues found during classification
+  // — the most common cause of "every property looks like overnight."
+  for (const issue of branchValidationIssues) {
+    notes.push(`⚠ ${issue}`)
+  }
+  if (remotePct >= 50 && visitSpecs.length >= 4) {
+    notes.push(
+      `⚠ ${Math.round(remotePct)}% of properties (${remote.length}/${visitSpecs.length}) classified as overnight. ` +
+        `Likely causes: branch coords wrong, overnight_trigger_one_way_hours too low (${overnightTriggerHours} hr), or drive_speed_mph too low (${speed} mph). ` +
+        `Sample: ${classificationAudit.slice(0, 3).map((c) => `"${c.address}" → ${c.miles_to_nearest}mi to ${c.nearest_branch} = ${c.drive_hours_to_nearest}hr (${c.classified})`).join('; ')}.`
+    )
+  }
 
   return {
     cycle_length_days: cycleDays,
@@ -624,6 +705,17 @@ export function buildRoutingTemplate(input: BuildTemplateInput): TemplateBuildRe
     soft_constraint_violations: softViolations,
     optimization_score: score,
     optimizer_notes: notes.join(' '),
+    classification_audit: {
+      total_properties: visitSpecs.length,
+      local_count: local.length,
+      remote_count: remote.length,
+      remote_pct: Math.round(remotePct * 10) / 10,
+      threshold_hours: overnightTriggerHours,
+      drive_speed_mph: speed,
+      branch_validation_issues: branchValidationIssues,
+      // First 10 sample classifications for user audit on the cycle UI.
+      sample: classificationAudit.slice(0, 10),
+    },
   }
 }
 

--- a/api/_lib/scheduler/crew-utilization.ts
+++ b/api/_lib/scheduler/crew-utilization.ts
@@ -55,6 +55,11 @@ interface ComputeOptions {
   between_trips_gap_max_days?: number
 }
 
+// Fallback only — actual capacity should come from the routing
+// template's config.hours_per_day. The old hardcoded 8 produced a
+// utilization that was 25%+ too high when the real config was 10
+// (hours_per_day default), because (work_hours / 8) is bigger than
+// (work_hours / 10) for the same numerator.
 const DEFAULT_CAPACITY_HOURS = 8
 const DEFAULT_GAP_MAX_DAYS = 3
 
@@ -64,7 +69,6 @@ export async function computeCrewUtilization(
   options: ComputeOptions = {}
 ): Promise<CrewUtilizationDay[]> {
   const includeWeekends = options.include_weekends ?? false
-  const capacity = options.workdays_capacity_hours ?? DEFAULT_CAPACITY_HOURS
   const gapMax = options.between_trips_gap_max_days ?? DEFAULT_GAP_MAX_DAYS
 
   const { data: cycle, error: cycleErr } = await db
@@ -76,10 +80,19 @@ export async function computeCrewUtilization(
 
   const { data: tpl } = await db
     .from('routing_templates')
-    .select('crew_count, crew_assignments')
+    .select('crew_count, crew_assignments, config')
     .eq('id', (cycle as any).template_id)
     .single()
   const crewCount = (tpl as any)?.crew_count ?? 1
+  // Pull capacity from the routing template's saved config so the
+  // utilization denominator matches the day length the template was
+  // built against (e.g. 10 hr/day) rather than the legacy hardcoded 8.
+  const tplHoursPerDay = Number((tpl as any)?.config?.hours_per_day)
+  const capacity =
+    options.workdays_capacity_hours ??
+    (Number.isFinite(tplHoursPerDay) && tplHoursPerDay > 0
+      ? tplHoursPerDay
+      : DEFAULT_CAPACITY_HOURS)
 
   const { data: routes } = await db
     .from('crew_day_routes')

--- a/api/analyses/account/[accountId]/clients/[clientId]/crew-strategy.ts
+++ b/api/analyses/account/[accountId]/clients/[clientId]/crew-strategy.ts
@@ -85,10 +85,29 @@ export interface CrewStrategyInputs {
     ideal_max_pct: number
     scope: 'per_branch' | 'per_region' | 'portfolio'
   }
+  // Phase 4 follow-up — used to derive FTE capacity from the user's
+  // actual config (working_days_per_year × hours_per_day) instead of
+  // a hardcoded 47 × 40 = 1880 that assumed 8-hour days.
+  working_days_per_year?: number | null
 }
 
-const FTE_HOURS_PER_YEAR = 1880 // 47 weeks × 40 hours
+// FTE capacity is now derived per-call from
+// constraints.working_days_per_year × constraints.hours_per_day so
+// utilization scales with the user's actual day length (default
+// 250 × 10 = 2500, not the legacy 47 × 40 = 1880 which assumed
+// 8-hour days and overstated utilization by ~33%).
+const DEFAULT_WORKING_DAYS_PER_YEAR = 250
 const ROVING_ESTIMATED_ANNUAL_MILES_PER_CREW = 30000
+
+function computeFteHoursPerYear(inputs: { hours_per_day: number }, workingDaysPerYear?: number | null): number {
+  const days = Number.isFinite(workingDaysPerYear) && (workingDaysPerYear ?? 0) > 0
+    ? Number(workingDaysPerYear)
+    : DEFAULT_WORKING_DAYS_PER_YEAR
+  const hpd = Number.isFinite(inputs.hours_per_day) && inputs.hours_per_day > 0
+    ? inputs.hours_per_day
+    : 8
+  return days * hpd
+}
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method === 'OPTIONS') return res.status(200).end()
@@ -137,6 +156,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     drive_speed_mph: body.drive_speed_mph ?? constraints.drive_speed_mph,
     utilization_constraint:
       (body as any).utilization_constraint ?? constraints.utilization_constraint,
+    working_days_per_year: constraints.working_days_per_year ?? null,
   }
 
   let analysisId: string
@@ -231,6 +251,10 @@ export function computeCrewStrategy(
   inputs: CrewStrategyInputs,
   overnight?: OvernightResult
 ) {
+  const fteHoursPerYear = computeFteHoursPerYear(
+    inputs,
+    inputs.working_days_per_year ?? null
+  )
   // ── Per-property work hours per year ──────────────────────────────────────
   // For each property we want total annual project-crew hours. A property may
   // have multiple service_locations (e.g. project clean + upholstery for the
@@ -430,7 +454,7 @@ export function computeCrewStrategy(
     optionA_crews > 0
       ? Math.min(
           100,
-          Math.round((totalAnnualHours / (optionA_crews * FTE_HOURS_PER_YEAR)) * 100)
+          Math.round((totalAnnualHours / (optionA_crews * fteHoursPerYear)) * 100)
         )
       : 0
   const optionA_vehicle =
@@ -473,7 +497,7 @@ export function computeCrewStrategy(
   )
 
   const optionB_labor =
-    optionB_crews * FTE_HOURS_PER_YEAR * inputs.hourly_loaded_labor_cost * inputs.crew_size
+    optionB_crews * fteHoursPerYear * inputs.hourly_loaded_labor_cost * inputs.crew_size
 
   // Per-branch utilization rows for output.
   let optionB_util_sum = 0
@@ -497,7 +521,7 @@ export function computeCrewStrategy(
   }> = []
   for (let i = 0; i < branches.length; i++) {
     const crews = crewsPerBranch[i]
-    const available = crews * FTE_HOURS_PER_YEAR
+    const available = crews * fteHoursPerYear
     const utilPct = available > 0 ? Math.round((branchHours[i] / available) * 100) : 0
     const status = classifyUtilization(utilPct, band)
     optionB_util_sum += utilPct
@@ -566,7 +590,7 @@ export function computeCrewStrategy(
   const optionC_labor = optionC_FT_labor + optionC_surge_labor
   // FT crews are highly utilized year-round; surge crews are utilized only
   // when active. A blended utilization estimate.
-  const optionC_FT_capacity = optionC_FT_crews * FTE_HOURS_PER_YEAR
+  const optionC_FT_capacity = optionC_FT_crews * fteHoursPerYear
   const optionC_FT_util = Math.min(
     1,
     totalAnnualHours / (optionC_FT_capacity + inputs.surge_crew_count * inputs.surge_weeks_per_year * hoursPerWeek)
@@ -622,7 +646,7 @@ export function computeCrewStrategy(
       regionMap.get(region) ?? { branches_in_region: [], work_hours: 0, available_hours: 0 }
     cur.branches_in_region.push(branchMeta[i].city_state)
     cur.work_hours += branchHours[i]
-    cur.available_hours += crewsPerBranch[i] * FTE_HOURS_PER_YEAR
+    cur.available_hours += crewsPerBranch[i] * fteHoursPerYear
     regionMap.set(region, cur)
   }
   const optionB_per_region = Array.from(regionMap.entries()).map(([region, v]) => {
@@ -640,12 +664,12 @@ export function computeCrewStrategy(
 
   const optionB_portfolio_pct =
     optionB_crews > 0
-      ? Math.round((totalProjectHours / (optionB_crews * FTE_HOURS_PER_YEAR)) * 100)
+      ? Math.round((totalProjectHours / (optionB_crews * fteHoursPerYear)) * 100)
       : 0
   const optionB_portfolio = {
     crew_count: optionB_crews,
     work_hours: Math.round(totalProjectHours),
-    available_hours: optionB_crews * FTE_HOURS_PER_YEAR,
+    available_hours: optionB_crews * fteHoursPerYear,
     utilization_pct: optionB_portfolio_pct,
     status: classifyUtilization(optionB_portfolio_pct, band),
   }
@@ -655,7 +679,7 @@ export function computeCrewStrategy(
   const optionA_portfolio = {
     crew_count: optionA_crews,
     work_hours: Math.round(totalProjectHours),
-    available_hours: optionA_crews * FTE_HOURS_PER_YEAR,
+    available_hours: optionA_crews * fteHoursPerYear,
     utilization_pct: optionA_util_pct,
     status: classifyUtilization(optionA_util_pct, band),
   }
@@ -665,7 +689,7 @@ export function computeCrewStrategy(
     crew_count: optionC_FT_crews,
     surge_crew_count: inputs.surge_crew_count,
     work_hours: Math.round(totalProjectHours),
-    available_hours: optionC_FT_crews * FTE_HOURS_PER_YEAR,
+    available_hours: optionC_FT_crews * fteHoursPerYear,
     utilization_pct: optionC_util_pct,
     status: classifyUtilization(optionC_util_pct, band),
   }


### PR DESCRIPTION
## Summary
User reported Cycle 7 has "nearly every property classified as overnight (even ones <1 mile from the office)" and "49% utilization that feels off." Two confirmed bugs + diagnostics for the third.

### P0 #1 — Crew Strategy utilization understates capacity by 33%
\`crew-strategy.ts\` hardcoded \`FTE_HOURS_PER_YEAR = 1880\` (47 weeks × 40 hours, i.e. 8-hour days). System's default \`hours_per_day\` is 10, so real annual capacity per crew is 250 days × 10 hr = **2500 hours**. The hardcoded denominator overstated utilization by 2500/1880 ≈ 1.33×. Real 37% util displayed as 49%. Used in 6 spots: Option A util, Option B labor + per-branch util, Option C FT capacity, region rollup, portfolio util.

Now derived per-call from \`computeFteHoursPerYear(inputs, working_days_per_year)\` — scales with the actual config.

### P0 #2 — Cycle Gantt utilization had the same bug
\`crew-utilization.ts\` had \`DEFAULT_CAPACITY_HOURS = 8\` even though \`hours_per_day\` default is 10. Same 33% overstatement on the cycle's daily utilization %. Now reads \`config.hours_per_day\` off the saved routing template.

### P1 — Overnight classification audit
The classification logic itself is mechanically correct — find the property's nearest branch, compute drive hours, compare to threshold. For a property <1 mi from the office to be classified "overnight," one of these must be wrong:
- Branch lat/lng (e.g., 0,0)
- \`overnight_trigger_one_way_hours\` < ~0.05
- \`drive_speed_mph\` < a few mph

Added defensive validation + an audit record on the template output:
- Branches with NaN, 0, or out-of-range coords → emit a warning in \`optimizer_notes\`.
- \`overnight_trigger_one_way_hours <= 0\` → warning.
- When >50% of properties land in "remote" (with ≥4 total), the optimizer notes call it out and sample the first 3 properties' actual distance/drive-hours so the user can see WHY they were classified.
- \`classification_audit\` object on the template result: total/local/remote counts, threshold + speed used, validation issues, 10-property sample. UI can surface this on the template/cycle page.

## Test plan
- [ ] Re-run Crew Strategy → utilization percentages drop to their real values (no more 33% inflation).
- [ ] Open Cycle 7's Gantt → daily util percentages also drop.
- [ ] Build a new routing template → if classification looks wrong, optimizer_notes now contains a clear "X% classified overnight, here's why" diagnostic with sample data.
- [ ] Bad-data scenarios (branch with 0,0 coords, threshold = 0) emit explicit warnings instead of silently mis-classifying.

## Recommended follow-up for Cycle 7 specifically
After this deploys, the user should:
1. Verify selected branches' coordinates are correct.
2. Check that \`hotel_cost_config.overnight_trigger_one_way_hours\` is 3 (default), not 0 or some unintentionally low value.
3. Rebuild the routing template — Cycle 7 was generated from a template that baked in the bad classification; regenerating after fixing the data will produce a corrected cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)