### PR TITLE
Switch utilization from hours to building-days + add crew-count audit

### DIFF
--- a/api/_lib/analysis/crew-count.ts
+++ b/api/_lib/analysis/crew-count.ts
@@ -35,6 +35,20 @@ export interface CrewCountResult {
   size_class_breakdown: Record<BuildingSizeClass, number>
   total_visits_per_cycle: number
   cycles_per_year: number
+  // Phase 4 follow-up — surface the visits eating the most crew-days
+  // so the user can audit "why does it say 6 crews" — multi-day
+  // buildings + high visits_per_year are the usual suspects.
+  audit: {
+    top_consumers: Array<{
+      service_location_id: string
+      hours_per_visit: number
+      size_class: BuildingSizeClass
+      crew_days_per_visit_conservative: number
+    }>
+    multi_day_visits: number
+    multi_day_crew_days: number
+    visits_per_year_distribution: Record<number, number>
+  }
 }
 
 export function computeCrewCount(input: CrewCountInput): CrewCountResult {
@@ -46,21 +60,81 @@ export function computeCrewCount(input: CrewCountInput): CrewCountResult {
     large: 0,
     multi_day: 0,
   }
+  let multiDayVisits = 0
+  let multiDayCrewDays = 0
+  // Group visits by service_location_id to count visits/year.
+  const visitsBySl = new Map<string, number>()
+  // Per-visit contribution so we can surface the worst offenders.
+  type Contributor = {
+    service_location_id: string
+    hours_per_visit: number
+    size_class: BuildingSizeClass
+    crew_days_per_visit_conservative: number
+  }
+  const contributors: Contributor[] = []
 
   for (const visit of input.routed_visits) {
     const sizeClass = effectiveSizeClass(visit)
     sizeBreakdown[sizeClass]++
-    conservativeCrewDays += crewDaysPerVisit(
+    const dConservative = crewDaysPerVisit(
       sizeClass,
       visit.hours_per_visit,
       'conservative'
     )
+    conservativeCrewDays += dConservative
     optimisticCrewDays += crewDaysPerVisit(
       sizeClass,
       visit.hours_per_visit,
       'optimistic'
     )
+    if (sizeClass === 'multi_day') {
+      multiDayVisits += 1
+      multiDayCrewDays += dConservative
+    }
+    visitsBySl.set(
+      visit.service_location_id,
+      (visitsBySl.get(visit.service_location_id) ?? 0) + 1
+    )
+    contributors.push({
+      service_location_id: visit.service_location_id,
+      hours_per_visit: visit.hours_per_visit,
+      size_class: sizeClass,
+      crew_days_per_visit_conservative: dConservative,
+    })
   }
+
+  // Distribution of visits/year across service_locations — high
+  // visits_per_year (e.g. 6 instead of the default 2) is the other
+  // usual suspect for an inflated crew_count.
+  const visitsDistribution: Record<number, number> = {}
+  for (const count of visitsBySl.values()) {
+    visitsDistribution[count] = (visitsDistribution[count] ?? 0) + 1
+  }
+
+  // Top 8 unique service_locations sorted by crew-days they
+  // consumed (sum across all their visits in the cycle).
+  const totalsBySl = new Map<string, Contributor & { totalDays: number }>()
+  for (const c of contributors) {
+    const existing = totalsBySl.get(c.service_location_id)
+    if (existing) {
+      existing.totalDays += c.crew_days_per_visit_conservative
+    } else {
+      totalsBySl.set(c.service_location_id, {
+        ...c,
+        totalDays: c.crew_days_per_visit_conservative,
+      })
+    }
+  }
+  const topConsumers = Array.from(totalsBySl.values())
+    .sort((a, b) => b.totalDays - a.totalDays)
+    .slice(0, 8)
+    .map((c) => ({
+      service_location_id: c.service_location_id,
+      hours_per_visit: Math.round(c.hours_per_visit * 10) / 10,
+      size_class: c.size_class,
+      crew_days_per_visit_conservative:
+        Math.round(c.crew_days_per_visit_conservative * 10) / 10,
+    }))
 
   const start = input.cycle_start_date ?? new Date()
   const end = new Date(
@@ -105,6 +179,12 @@ export function computeCrewCount(input: CrewCountInput): CrewCountResult {
     size_class_breakdown: sizeBreakdown,
     total_visits_per_cycle: input.routed_visits.length,
     cycles_per_year: input.cycles_per_year,
+    audit: {
+      top_consumers: topConsumers,
+      multi_day_visits: multiDayVisits,
+      multi_day_crew_days: Math.round(multiDayCrewDays * 10) / 10,
+      visits_per_year_distribution: visitsDistribution,
+    },
   }
 }
 

--- a/api/_lib/scheduler/crew-utilization.ts
+++ b/api/_lib/scheduler/crew-utilization.ts
@@ -130,8 +130,16 @@ export async function computeCrewUtilization(
       const route = routeByKey.get(`${crewIdx}|${date}`)
       if (route) {
         const workHours = (route.total_work_minutes ?? 0) / 60
-        const utilPct =
-          capacity > 0 ? Math.round((workHours / capacity) * 100) : 0
+        const stops = Array.isArray(route.route) ? (route.route as any[]) : []
+        // Building-day utilization: a crew can only do one building
+        // per day (with small-property pairing as the optimistic
+        // ceiling). If the crew has any visits at all that day, the
+        // day is "used" — hours-fraction is informational only. The
+        // old hours/capacity ratio implied a 6-hour day was 60%
+        // utilized when in reality the crew can't go to a second
+        // building, so the day is fully consumed.
+        const dayIsUsed = stops.length > 0
+        const utilPct = dayIsUsed ? 100 : 0
         let kind: CrewDayStateKind
         if (route.day_type === 'travel') {
           kind = 'travel_day'
@@ -146,14 +154,11 @@ export async function computeCrewUtilization(
         ) {
           // Mid-stretch of a multi-day overnight trip.
           kind = 'overnight_continuation'
-        } else if (utilPct >= 90) {
+        } else if (dayIsUsed) {
           kind = 'fully_utilized'
-        } else if (utilPct >= 30) {
-          kind = 'partial'
         } else {
           kind = 'idle'
         }
-        const stops = Array.isArray(route.route) ? (route.route as any[]) : []
         const addresses = stops
           .map((s) => (typeof s?.address === 'string' ? s.address.trim() : null))
           .filter((s): s is string => !!s)

--- a/api/analyses/account/[accountId]/clients/[clientId]/crew-strategy.ts
+++ b/api/analyses/account/[accountId]/clients/[clientId]/crew-strategy.ts
@@ -427,10 +427,15 @@ export function computeCrewStrategy(
   })
   // Per-branch slice for Option B (each branch's crews scale with its own
   // building-day workload).
-  const crewCountPerBranch = branches.map((_, i) => {
+  const crewCountPerBranchFull = branches.map((_, i) => {
     const branchVisits = routedVisits.filter((v) => v.branch_idx === i)
     if (branchVisits.length === 0) {
-      return { conservative: 1, optimistic: 1 }
+      return {
+        conservative: 1,
+        optimistic: 1,
+        building_days: 0,
+        working_days: crewCountAnalysis.conservative.working_days_per_cycle,
+      }
     }
     const a = computeCrewCount({
       routed_visits: branchVisits,
@@ -440,8 +445,27 @@ export function computeCrewStrategy(
     return {
       conservative: a.conservative.crews_needed,
       optimistic: a.optimistic.crews_needed,
+      building_days: a.conservative.total_crew_days_per_cycle,
+      working_days: a.conservative.working_days_per_cycle,
     }
   })
+  const crewCountPerBranch = crewCountPerBranchFull
+  // Phase 4 follow-up — utilization is now BUILDING-DAY based, not
+  // hours-based. A crew can only do one building per day (with small-
+  // property pairing as the optimistic ceiling), so dividing total
+  // hours by total available hours gave a meaningless number — the
+  // crew might work 6 hours and still have used the entire day's
+  // capacity because they can't drive to a second building.
+  const annualBuildingDays =
+    crewCountAnalysis.conservative.total_crew_days_per_cycle *
+    (crewCountAnalysis.cycles_per_year ?? 1)
+  const annualBuildingDaysOptimistic =
+    crewCountAnalysis.optimistic.total_crew_days_per_cycle *
+    (crewCountAnalysis.cycles_per_year ?? 1)
+  const workingDaysPerYearForUtil =
+    Number.isFinite(inputs.working_days_per_year) && (inputs.working_days_per_year ?? 0) > 0
+      ? Number(inputs.working_days_per_year)
+      : DEFAULT_WORKING_DAYS_PER_YEAR
 
   // ── Option A: Roving ──────────────────────────────────────────────────────
   // Variable cost — paid only for hours worked. Crew count comes from the
@@ -450,11 +474,19 @@ export function computeCrewStrategy(
   const optionA_crews_optimistic = crewCountAnalysis.optimistic.crews_needed
   const optionA_labor =
     totalAnnualHours * inputs.hourly_loaded_labor_cost * inputs.crew_size
+  // Building-day utilization: how many crew-days of work do we have
+  // vs how many workdays we're paying the crews to be available?
+  // Pairing-aware (uses optimistic count if it pulled small buildings
+  // together) since paired days only count as 1 used day.
   const optionA_util_pct =
     optionA_crews > 0
       ? Math.min(
           100,
-          Math.round((totalAnnualHours / (optionA_crews * fteHoursPerYear)) * 100)
+          Math.round(
+            (annualBuildingDaysOptimistic /
+              (optionA_crews * workingDaysPerYearForUtil)) *
+              100
+          )
         )
       : 0
   const optionA_vehicle =
@@ -522,7 +554,14 @@ export function computeCrewStrategy(
   for (let i = 0; i < branches.length; i++) {
     const crews = crewsPerBranch[i]
     const available = crews * fteHoursPerYear
-    const utilPct = available > 0 ? Math.round((branchHours[i] / available) * 100) : 0
+    // Building-day util per branch — same shift as Option A.
+    const branchBuildingDays =
+      crewCountPerBranchFull[i]?.building_days ?? 0
+    const branchAvailableDays = crews * workingDaysPerYearForUtil
+    const utilPct =
+      branchAvailableDays > 0
+        ? Math.min(100, Math.round((branchBuildingDays / branchAvailableDays) * 100))
+        : 0
     const status = classifyUtilization(utilPct, band)
     optionB_util_sum += utilPct
     optionB_util_count += 1
@@ -588,14 +627,16 @@ export function computeCrewStrategy(
     inputs.surge_premium_multiplier *
     inputs.crew_size
   const optionC_labor = optionC_FT_labor + optionC_surge_labor
-  // FT crews are highly utilized year-round; surge crews are utilized only
-  // when active. A blended utilization estimate.
-  const optionC_FT_capacity = optionC_FT_crews * fteHoursPerYear
-  const optionC_FT_util = Math.min(
-    1,
-    totalAnnualHours / (optionC_FT_capacity + inputs.surge_crew_count * inputs.surge_weeks_per_year * hoursPerWeek)
-  )
-  const optionC_util_pct = Math.round(Math.min(0.99, optionC_FT_util * 1.07) * 100) // FT highly utilized
+  // FT crews handle the steady-state building-day load; surge crews
+  // pick up peak periods. Convert surge weeks into building-days
+  // (5 working days per week) for the same denominator.
+  const optionC_capacity_days =
+    optionC_FT_crews * workingDaysPerYearForUtil +
+    inputs.surge_crew_count * inputs.surge_weeks_per_year * 5
+  const optionC_util_pct =
+    optionC_capacity_days > 0
+      ? Math.min(99, Math.round((annualBuildingDaysOptimistic / optionC_capacity_days) * 100))
+      : 0
   const optionC_vehicle =
     (optionC_FT_crews + inputs.surge_crew_count) *
     inputs.vehicles_per_crew *
@@ -636,22 +677,41 @@ export function computeCrewStrategy(
   }
 
   // ── Per-region rollup for Option B ────────────────────────────────────────
+  // Building-day based: aggregate building-days needed across branches
+  // in the region, divided by total available crew-days for those
+  // branches. work_hours/available_hours kept for display only.
   const regionMap = new Map<
     string,
-    { branches_in_region: string[]; work_hours: number; available_hours: number }
+    {
+      branches_in_region: string[]
+      work_hours: number
+      available_hours: number
+      building_days: number
+      available_days: number
+    }
   >()
   for (let i = 0; i < branches.length; i++) {
     const region = branchMeta[i].region
     const cur =
-      regionMap.get(region) ?? { branches_in_region: [], work_hours: 0, available_hours: 0 }
+      regionMap.get(region) ?? {
+        branches_in_region: [],
+        work_hours: 0,
+        available_hours: 0,
+        building_days: 0,
+        available_days: 0,
+      }
     cur.branches_in_region.push(branchMeta[i].city_state)
     cur.work_hours += branchHours[i]
     cur.available_hours += crewsPerBranch[i] * fteHoursPerYear
+    cur.building_days += crewCountPerBranchFull[i]?.building_days ?? 0
+    cur.available_days += crewsPerBranch[i] * workingDaysPerYearForUtil
     regionMap.set(region, cur)
   }
   const optionB_per_region = Array.from(regionMap.entries()).map(([region, v]) => {
     const utilPct =
-      v.available_hours > 0 ? Math.round((v.work_hours / v.available_hours) * 100) : 0
+      v.available_days > 0
+        ? Math.min(100, Math.round((v.building_days / v.available_days) * 100))
+        : 0
     return {
       region,
       branches_in_region: v.branches_in_region,
@@ -664,7 +724,14 @@ export function computeCrewStrategy(
 
   const optionB_portfolio_pct =
     optionB_crews > 0
-      ? Math.round((totalProjectHours / (optionB_crews * fteHoursPerYear)) * 100)
+      ? Math.min(
+          100,
+          Math.round(
+            (annualBuildingDays /
+              (optionB_crews * workingDaysPerYearForUtil)) *
+              100
+          )
+        )
       : 0
   const optionB_portfolio = {
     crew_count: optionB_crews,

--- a/src/components/analysis/CrewStrategyChart.tsx
+++ b/src/components/analysis/CrewStrategyChart.tsx
@@ -103,6 +103,17 @@ interface CrewCountAnalysis {
   }
   total_visits_per_cycle: number
   cycles_per_year: number
+  audit?: {
+    top_consumers: Array<{
+      service_location_id: string
+      hours_per_visit: number
+      size_class: 'small' | 'standard' | 'large' | 'multi_day'
+      crew_days_per_visit_conservative: number
+    }>
+    multi_day_visits: number
+    multi_day_crew_days: number
+    visits_per_year_distribution: Record<string, number>
+  }
 }
 
 interface CrewStrategyBranch {
@@ -392,6 +403,91 @@ export default function CrewStrategyChart({
               </span>
             </Stat>
           </dl>
+          {data.crew_count_analysis.audit && (
+            <details className="mt-4 group">
+              <summary className="cursor-pointer text-xs font-semibold text-accent hover:underline list-none">
+                Why this many crews? Audit the math ▾
+              </summary>
+              <div className="mt-3 space-y-3 text-xs">
+                {data.crew_count_analysis.audit.multi_day_visits > 0 && (
+                  <div className="rounded-md border border-warning/30 bg-warning/5 p-3">
+                    <p className="font-semibold text-fg">
+                      Multi-day buildings consume {data.crew_count_analysis.audit.multi_day_crew_days} crew-days
+                    </p>
+                    <p className="mt-1 text-fg-muted leading-relaxed">
+                      <span className="font-tabular">{data.crew_count_analysis.audit.multi_day_visits}</span> visit
+                      {data.crew_count_analysis.audit.multi_day_visits === 1 ? '' : 's'} are at buildings
+                      &gt;16 hours each, which take{' '}
+                      <span className="font-mono">ceil(hours ÷ 8)</span> crew-days per visit instead of 1.
+                      {' '}A 32-hour building = 4 crew-days, not 1.
+                    </p>
+                  </div>
+                )}
+                {Object.keys(data.crew_count_analysis.audit.visits_per_year_distribution).length > 1 && (
+                  <div className="rounded-md border border-border bg-surface p-3">
+                    <p className="font-semibold text-fg">Visits per year distribution</p>
+                    <ul className="mt-1 text-fg-muted">
+                      {Object.entries(
+                        data.crew_count_analysis.audit.visits_per_year_distribution
+                      )
+                        .sort(([a], [b]) => Number(a) - Number(b))
+                        .map(([visits, count]) => (
+                          <li key={visits}>
+                            <span className="font-tabular">{count}</span> propert
+                            {count === 1 ? 'y' : 'ies'} visited{' '}
+                            <span className="font-tabular">{visits}</span>×/year ={' '}
+                            <span className="font-tabular">{Number(visits) * count}</span> crew-days
+                          </li>
+                        ))}
+                    </ul>
+                    <p className="mt-2 text-fg-subtle italic">
+                      A property visited 4×/year contributes 4 crew-days, not 1.
+                      Default is 2; check Cost Assumptions or per-SL overrides if any are higher.
+                    </p>
+                  </div>
+                )}
+                {data.crew_count_analysis.audit.top_consumers.length > 0 && (
+                  <div className="rounded-md border border-border bg-surface p-3">
+                    <p className="font-semibold text-fg">Top crew-day consumers</p>
+                    <table className="mt-2 w-full text-[11px]">
+                      <thead className="text-fg-subtle text-[10px] uppercase tracking-wider">
+                        <tr>
+                          <th className="text-left pb-1">Property (id)</th>
+                          <th className="text-right pb-1">Hours/visit</th>
+                          <th className="text-right pb-1">Size class</th>
+                          <th className="text-right pb-1">Crew-days/visit</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {data.crew_count_analysis.audit.top_consumers.map((c) => (
+                          <tr key={c.service_location_id}>
+                            <td className="py-1 font-mono text-fg-muted">
+                              {c.service_location_id.slice(0, 8)}…
+                            </td>
+                            <td className="py-1 text-right font-tabular">
+                              {c.hours_per_visit}
+                            </td>
+                            <td className="py-1 text-right font-tabular">
+                              {c.size_class}
+                            </td>
+                            <td className="py-1 text-right font-mono font-semibold">
+                              {c.crew_days_per_visit_conservative}
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                )}
+                <p className="text-fg-subtle italic leading-relaxed">
+                  Formula: total crew-days ÷ working days/cycle = crews needed.
+                  Each visit contributes 1 crew-day (1 building/day rule), except
+                  multi-day buildings which consume <span className="font-mono">ceil(hours ÷ 8)</span> days.
+                  Optimistic mode pairs two small (≤4hr) buildings per day, halving their contribution.
+                </p>
+              </div>
+            </details>
+          )}
         </Card>
       )}
 


### PR DESCRIPTION
## Summary
User pushed back on the hours-based utilization framing: "A crew can do one building a day. It rarely takes them 10 hours, usually 6, but they can't go to a second building unless there are two small ones close together." Hours-divided-by-capacity is meaningless — a 6-hour day where the crew did one building should be 100% used, not 60%.

Plus user asked to verify whether the crew-count formula truly uses \`buildings ÷ working-days\`. Spoiler: it does, but two multipliers can inflate the count without being obvious — multi-day buildings (>16 hr) consuming \`ceil(hours/8)\` days each, and per-SL \`visits_per_year_override\` raising the visit count. Surfaced both with an audit panel.

## Changes

### Utilization framing flipped from hours → building-days
- \`crew-strategy.ts\` Options A / B / C util %, per-branch util %, per-region util %, and portfolio util % now use \`annual_building_days / (crews × working_days_per_year)\` instead of \`hours / hours\`. Building-day counts already come from \`computeCrewCount\` — the display denominators just weren't reading them.
- \`crew-utilization.ts\` (the cycle Gantt's data source) treats each crew-day as binary fully_utilized vs idle (the 'partial' state is gone). \`utilization_pct\` is 100 if any visits scheduled else 0. Work hours are still surfaced as informational secondary metric.

### Crew-count audit
- \`computeCrewCount\` now returns an \`audit\` block:
  - \`top_consumers\` — top 8 service_locations sorted by crew-days they consumed
  - \`multi_day_visits\` + \`multi_day_crew_days\` — how much came from >16 hr buildings (which use \`ceil(hours/8)\` days, not 1)
  - \`visits_per_year_distribution\` — count of properties at each visit frequency
- "Building-count crew math" panel in \`CrewStrategyChart\` gets a collapsible "Audit the math" details block with all three. The user can now see exactly which properties are driving the count.

## Test plan
- [ ] Re-run Crew Strategy.
- [ ] Open the Building-count panel → click "Audit the math" → see top consumers list, multi-day inflation, visit-frequency distribution.
- [ ] Confirm formula: \`total_crew_days / working_days = crews\` exactly.
- [ ] Open a populated cycle's Gantt → days with visits show full color, days without show idle. No more "partial" middle state.
- [ ] Crew Strategy Option A/B/C util % use the building-day formula. Cycle Gantt aggregate util = used_days / total_workdays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)