### PR TITLE
Building size classifier uses crew-clock hours, not raw labor hours

### DIFF
--- a/api/_lib/analysis/building-size.ts
+++ b/api/_lib/analysis/building-size.ts
@@ -1,33 +1,65 @@
 // Phase 3.8 — building size classification.
-//
-// Crews can typically only do one building per day regardless of how
-// many hours that building takes (setup, breakdown, drive between, and
-// crew workflow constraints). Two small buildings can sometimes pair
-// in a single day, and very large buildings consume multiple days.
+// Phase 4 follow-up — classifier now uses crew-clock hours (hoursPerVisit
+// ÷ crew_size) instead of raw labor hours. A 24-hour task done by a
+// 3-person crew is 8 clock hours = ONE day, not three. The previous
+// version classified anything >16 hr as multi_day and billed 2-4
+// crew-days per visit, which inflated total crew-days dramatically
+// and produced over-recommended crew counts.
 
 export type BuildingSizeClass = 'small' | 'standard' | 'large' | 'multi_day'
 
-export function classifyBuildingSize(hoursPerVisit: number): BuildingSizeClass {
-  if (hoursPerVisit <= 4) return 'small'
-  if (hoursPerVisit <= 8) return 'standard'
-  if (hoursPerVisit <= 16) return 'large'
+export interface ClassifyContext {
+  crew_size: number
+  hours_per_day: number
+}
+
+const DEFAULT_CTX: ClassifyContext = { crew_size: 3, hours_per_day: 10 }
+
+function clockHours(hoursPerVisit: number, ctx: ClassifyContext): number {
+  const cs = Number.isFinite(ctx.crew_size) && ctx.crew_size > 0 ? ctx.crew_size : 1
+  return hoursPerVisit / cs
+}
+
+export function classifyBuildingSize(
+  hoursPerVisit: number,
+  ctx: ClassifyContext = DEFAULT_CTX
+): BuildingSizeClass {
+  const ch = clockHours(hoursPerVisit, ctx)
+  const hpd =
+    Number.isFinite(ctx.hours_per_day) && ctx.hours_per_day > 0
+      ? ctx.hours_per_day
+      : 10
+  // small = ≤ 40% of a workday — eligible for pairing with another
+  //         small in the same day.
+  // standard = ≤ 70% of a workday.
+  // large = ≤ 1 full workday.
+  // multi_day = needs more than 1 calendar day's clock-hours from this
+  //         crew. Realistically rare with a 3-person crew on a 10-hr
+  //         day (>30 labor-hours of work).
+  if (ch <= hpd * 0.4) return 'small'
+  if (ch <= hpd * 0.7) return 'standard'
+  if (ch <= hpd) return 'large'
   return 'multi_day'
 }
 
-export function effectiveSizeClass(serviceLocation: {
-  hours_per_visit: number
-  building_size_class_override?: BuildingSizeClass | null
-}): BuildingSizeClass {
+export function effectiveSizeClass(
+  serviceLocation: {
+    hours_per_visit: number
+    building_size_class_override?: BuildingSizeClass | null
+  },
+  ctx: ClassifyContext = DEFAULT_CTX
+): BuildingSizeClass {
   return (
     serviceLocation.building_size_class_override ??
-    classifyBuildingSize(serviceLocation.hours_per_visit)
+    classifyBuildingSize(serviceLocation.hours_per_visit, ctx)
   )
 }
 
 export function crewDaysPerVisit(
   sizeClass: BuildingSizeClass,
   hoursPerVisit: number,
-  mode: 'conservative' | 'optimistic'
+  mode: 'conservative' | 'optimistic',
+  ctx: ClassifyContext = DEFAULT_CTX
 ): number {
   switch (sizeClass) {
     case 'small':
@@ -36,7 +68,13 @@ export function crewDaysPerVisit(
       return 1.0
     case 'large':
       return 1.0
-    case 'multi_day':
-      return Math.max(1, Math.ceil(hoursPerVisit / 8))
+    case 'multi_day': {
+      const ch = clockHours(hoursPerVisit, ctx)
+      const hpd =
+        Number.isFinite(ctx.hours_per_day) && ctx.hours_per_day > 0
+          ? ctx.hours_per_day
+          : 10
+      return Math.max(1, Math.ceil(ch / hpd))
+    }
   }
 }

--- a/api/_lib/analysis/crew-count.ts
+++ b/api/_lib/analysis/crew-count.ts
@@ -8,6 +8,7 @@ import {
   crewDaysPerVisit,
   effectiveSizeClass,
   type BuildingSizeClass,
+  type ClassifyContext,
 } from './building-size.js'
 import { countWorkingDays, getDefaultHolidays } from './working-days.js'
 
@@ -20,6 +21,13 @@ export interface CrewCountInput {
   cycle_length_days: number
   cycle_start_date?: Date
   cycles_per_year: number
+  // Phase 4 follow-up — passed to the classifier so we use crew-clock
+  // hours instead of raw labor hours. Default: 3-person crew, 10-hr
+  // day. Without this, a 24-hour cleaning task gets classified as
+  // multi-day (3 crew-days) when in reality a 3-person crew finishes
+  // in 8 clock hours (1 crew-day).
+  crew_size?: number
+  hours_per_day?: number
 }
 
 export interface CrewCountModeResult {
@@ -73,19 +81,25 @@ export function computeCrewCount(input: CrewCountInput): CrewCountResult {
   }
   const contributors: Contributor[] = []
 
+  const ctx: ClassifyContext = {
+    crew_size: input.crew_size ?? 3,
+    hours_per_day: input.hours_per_day ?? 10,
+  }
   for (const visit of input.routed_visits) {
-    const sizeClass = effectiveSizeClass(visit)
+    const sizeClass = effectiveSizeClass(visit, ctx)
     sizeBreakdown[sizeClass]++
     const dConservative = crewDaysPerVisit(
       sizeClass,
       visit.hours_per_visit,
-      'conservative'
+      'conservative',
+      ctx
     )
     conservativeCrewDays += dConservative
     optimisticCrewDays += crewDaysPerVisit(
       sizeClass,
       visit.hours_per_visit,
-      'optimistic'
+      'optimistic',
+      ctx
     )
     if (sizeClass === 'multi_day') {
       multiDayVisits += 1

--- a/api/analyses/account/[accountId]/clients/[clientId]/crew-strategy.ts
+++ b/api/analyses/account/[accountId]/clients/[clientId]/crew-strategy.ts
@@ -424,6 +424,8 @@ export function computeCrewStrategy(
     routed_visits: routedVisits,
     cycle_length_days: 365,
     cycles_per_year: 1,
+    crew_size: inputs.crew_size,
+    hours_per_day: inputs.hours_per_day,
   })
   // Per-branch slice for Option B (each branch's crews scale with its own
   // building-day workload).
@@ -441,6 +443,8 @@ export function computeCrewStrategy(
       routed_visits: branchVisits,
       cycle_length_days: 365,
       cycles_per_year: 1,
+      crew_size: inputs.crew_size,
+      hours_per_day: inputs.hours_per_day,
     })
     return {
       conservative: a.conservative.crews_needed,


### PR DESCRIPTION
## Summary
User: "There should not be any multi-day buildings. 4 crews → 180 idle days." Both symptoms stem from one bug: the classifier compared **raw labor hours** to fixed thresholds, ignoring crew_size.

A 24-hour cleaning task done by a 3-person crew = **8 clock hours = 1 day**. The old code:
\`\`\`ts
if (hoursPerVisit > 16) return 'multi_day'  // wrong — that's labor-hours, not clock-hours
case 'multi_day': return Math.ceil(hoursPerVisit / 8)  // bills 3 crew-days for an 8-hour day
\`\`\`
Result: many properties got mis-classified as multi-day, each consuming 2-4 crew-days. Total \`crew_days\` ballooned. Crew count was over-recommended. User (or template input) picked 4 crews based on the inflated number. Real building-day workload only needs ~2 crews → the extras sit idle, 180 days/year.

## Fix
\`classifyBuildingSize\` now takes \`crew_size\` + \`hours_per_day\` and compares **clock_hours = hoursPerVisit / crew_size** against fractions of the configured workday:
- small: ≤ 40% of workday (eligible for pairing)
- standard: ≤ 70%
- large: ≤ 1 full workday
- multi_day: > 1 full workday (truly needs more than a day)

\`crewDaysPerVisit\` for multi_day now uses \`ceil(clock_hours / hours_per_day)\`, not \`ceil(hoursPerVisit / 8)\`.

\`computeCrewCount\` and \`crew-strategy.ts\` thread \`crew_size\` + \`hours_per_day\` through.

## Effect on Cycle 7
After re-running Crew Strategy:
- Most "multi-day" properties reclassify as standard (1 crew-day each, not 2-4)
- Total crew-days drops materially
- Recommended crew_count drops with it
- After lowering the routing template's manual crew_count to match, idle days should collapse

## Test plan
- [ ] Open Crew Strategy → "Audit the math" details panel.
- [ ] Multi-day count dropped (likely to 0 or a handful of true >30-labor-hr cases).
- [ ] Top consumers list no longer dominated by 2-4 day-per-visit entries.
- [ ] Recommended crew count is lower than before.
- [ ] Rebuild routing template with the new (lower) crew_count.
- [ ] Cycle Gantt: idle day count drops dramatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)