### PR TITLE
Allow switching K after a selection is locked + carry current branches into the modal

### DIFF
--- a/src/components/analysis/BranchOptimizationChart.tsx
+++ b/src/components/analysis/BranchOptimizationChart.tsx
@@ -295,17 +295,24 @@ export default function BranchOptimizationChart({
         </section>
       )}
 
-      {/* Per-K selection table */}
-      {showTable && onBuild && (
+      {/* Per-K selection / scenario table. Always shown when there's a
+          callback so the user can switch K after locking in a selection
+          (otherwise the only way to change K is to clear and re-pick,
+          which loses every per-branch override). The currently-selected
+          K row is highlighted; other rows show "Switch to K=N" so the
+          user can model alternatives in a click. */}
+      {onBuild && (
         <section className="space-y-2">
           <div>
             <h4 className="text-[10px] font-semibold uppercase tracking-wider text-fg-subtle">
-              Pick a branch count to build your selection
+              {selectedK != null
+                ? 'Branch count scenarios'
+                : 'Pick a branch count to build your selection'}
             </h4>
             <p className="mt-1 text-xs text-fg-muted">
-              Each row shows the modeled cost at K branches. Click a row's button to
-              start building your selection — you'll specify the actual locations
-              manually.
+              {selectedK != null
+                ? `Currently selected: K=${selectedK}. Click any other row to switch — your existing branches will be re-used as locked rows so you only fill the new ones.`
+                : 'Each row shows the modeled cost at K branches. Click a row\'s button to start building your selection — you\'ll specify the actual locations manually.'}
             </p>
           </div>
           <div className="rounded-md border border-border bg-surface overflow-hidden">
@@ -324,15 +331,23 @@ export default function BranchOptimizationChart({
               <TableBody>
                 {data.k_results.map((r) => {
                   const isRec = r.k === data.recommended_k
+                  const isCurrent = selectedK != null && r.k === selectedK
                   return (
                     <TableRow
                       key={r.k}
-                      className={isRec ? 'bg-success-subtle/40' : undefined}
+                      className={
+                        isCurrent
+                          ? 'bg-accent-subtle'
+                          : isRec
+                            ? 'bg-success-subtle/40'
+                            : undefined
+                      }
                     >
                       <TableCell className="font-mono font-semibold text-fg">
                         <span className="inline-flex items-center gap-1.5">
                           {r.k}
-                          {isRec && <Badge variant="success">Recommended</Badge>}
+                          {isCurrent && <Badge variant="accent">Current</Badge>}
+                          {isRec && !isCurrent && <Badge variant="success">Recommended</Badge>}
                         </span>
                       </TableCell>
                       <TableCell numeric className="text-fg">
@@ -351,9 +366,15 @@ export default function BranchOptimizationChart({
                         {r.branches.map((b) => b.city_state).join(' · ')}
                       </TableCell>
                       <TableCell className="text-right">
-                        <Button size="sm" onClick={() => onBuild(r.k)}>
-                          Build K={r.k} →
-                        </Button>
+                        {isCurrent ? (
+                          <span className="text-xs text-fg-subtle italic">
+                            already selected
+                          </span>
+                        ) : (
+                          <Button size="sm" onClick={() => onBuild(r.k)}>
+                            {selectedK != null ? `Switch to K=${r.k}` : `Build K=${r.k}`} →
+                          </Button>
+                        )}
                       </TableCell>
                     </TableRow>
                   )

--- a/src/components/analysis/BuildSelectionModal.tsx
+++ b/src/components/analysis/BuildSelectionModal.tsx
@@ -58,6 +58,11 @@ interface Props {
   existingBranches: ExistingBranch[]
   referenceCentroids: ReferenceCentroid[]
   sourceAnalysisId: string | null
+  // When the user is SWITCHING K (already has a selection), carry
+  // their current branches into the modal as the starting rows so they
+  // don't have to re-pick from scratch. Locked infrastructure rows
+  // still come first; current selection fills the editable rows.
+  prefillSelection?: SelectedBranch[]
   onConfirm: (payload: {
     k: number
     branches: SelectedBranch[]
@@ -87,6 +92,7 @@ export default function BuildSelectionModal({
   existingBranches,
   referenceCentroids,
   sourceAnalysisId,
+  prefillSelection,
   onConfirm,
 }: Props) {
   const initialRows = useMemo<RowDraft[]>(() => {
@@ -109,6 +115,23 @@ export default function BuildSelectionModal({
         },
       })
     }
+    // After locked infrastructure rows, carry over the user's current
+    // selection (skipping any already in existingBranches by name) so
+    // a K-switch doesn't lose their work. They can edit any of these
+    // rows afterward.
+    if (prefillSelection && prefillSelection.length > 0) {
+      const lockedNames = new Set(
+        existingBranches.map((b) => (b.name ?? '').toLowerCase())
+      )
+      for (const sel of prefillSelection) {
+        if (rows.length >= k) break
+        if (lockedNames.has((sel.name ?? '').toLowerCase())) continue
+        rows.push({
+          kind: 'filled',
+          branch: { ...sel },
+        })
+      }
+    }
     while (rows.length < k) rows.push({ kind: 'empty' })
     if (k === 1 && rows[0]?.kind === 'filled') {
       rows[0] = {
@@ -117,7 +140,7 @@ export default function BuildSelectionModal({
       }
     }
     return rows
-  }, [existingBranches, k])
+  }, [existingBranches, prefillSelection, k])
 
   const [rows, setRows] = useState<RowDraft[]>(initialRows)
   const [activePicker, setActivePicker] = useState<number | null>(null)

--- a/src/pages/accounts/AccountAnalysis.tsx
+++ b/src/pages/accounts/AccountAnalysis.tsx
@@ -1109,6 +1109,7 @@ export default function AccountAnalysisPage() {
               existingBranches={existingBranches}
               referenceCentroids={modalCentroids}
               sourceAnalysisId={modalSourceAnalysisId}
+              prefillSelection={selectedBranches ?? undefined}
               onConfirm={handleConfirmSelection}
             />
           )}


### PR DESCRIPTION
## Summary
User: "I don't have the ability to edit branch selection after making a selection. What if I want to change from 3 to 4 and see the scenario?"

Previously impossible without clearing the entire selection via "Change selection" — losing every per-branch override (main/satellite types, manual addresses, manual lat/lng) and per-branch crew overrides in the process.

### Two changes
1. **BranchOptimizationChart's per-K scenario table is now always visible.** Removed the \`!hasSelection\` gate. When a selection exists, the current K row is highlighted with an accent "Current" badge, recommended K still highlighted with a success badge if different, and every other row's button switches its label to "Switch to K=N" so the action is unambiguous.
2. **BuildSelectionModal accepts \`prefillSelection\`** — the user's current branches. When switching K, the modal pre-fills the editable rows with whatever they already had (skipping any locked infrastructure rows). For K=3 → K=4, they see their 3 branches filled + 1 empty row. They edit only what they want.

\`AccountAnalysis\` passes \`selectedBranches\` as \`prefillSelection\`. The existing \`/select-branches\` POST already handles updating the locked selection — no backend changes needed.

## Test plan
- [ ] Open Smart Analysis with a locked branch selection (K=3).
- [ ] Branch Optimization module shows the scenario table with the K=3 row marked "Current."
- [ ] Click "Switch to K=4" → modal opens with 3 of your existing branches filled in + 1 empty row at the bottom.
- [ ] Save → SelectionStatusBanner now shows 4 branches; the originals are preserved with their main/satellite types intact.
- [ ] Re-run Bid Pricing / Crew Strategy — they pick up the new K.
- [ ] Switch back to K=3 → modal shows 3 of the 4 (truncates) so you can adjust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)