### PR TITLE
Per-branch utilization: show buildings + working days, not hours

### DIFF
--- a/api/analyses/account/[accountId]/clients/[clientId]/crew-strategy.ts
+++ b/api/analyses/account/[accountId]/clients/[clientId]/crew-strategy.ts
@@ -548,6 +548,11 @@ export function computeCrewStrategy(
     available_hours: number
     utilization_pct: number
     property_count: number
+    // Phase 4 follow-up — surface building-day math directly so the
+    // per-branch util table can drop hours-based columns ("Work hrs" /
+    // "Available") in favor of "Buildings" / "Available work days."
+    building_days: number
+    available_work_days: number
     avg_drive_miles_one_way: number
     avg_drive_minutes_one_way: number
     override_property_count: number
@@ -598,6 +603,8 @@ export function computeCrewStrategy(
       available_hours: Math.round(available),
       utilization_pct: utilPct,
       property_count: branchPropCount[i],
+      building_days: Math.round(branchBuildingDays * 10) / 10,
+      available_work_days: branchAvailableDays,
       avg_drive_miles_one_way: Math.round(avgDriveMiles * 10) / 10,
       avg_drive_minutes_one_way: avgDriveMinutes,
       override_property_count: branchOverrideCount[i],

--- a/src/components/analysis/CrewStrategyChart.tsx
+++ b/src/components/analysis/CrewStrategyChart.tsx
@@ -39,6 +39,8 @@ interface BranchUtilRow {
   available_hours: number
   utilization_pct: number
   property_count: number
+  building_days?: number
+  available_work_days?: number
   avg_drive_miles_one_way?: number
   avg_drive_minutes_one_way?: number
   override_property_count?: number
@@ -1065,8 +1067,9 @@ function UtilizationSection({
               <TableHead>Branch</TableHead>
               <TableHead className="text-right">Pop</TableHead>
               <TableHead className="text-right">Crews</TableHead>
-              <TableHead className="text-right">Work hrs</TableHead>
-              <TableHead className="text-right">Available</TableHead>
+              <TableHead className="text-right">Buildings</TableHead>
+              <TableHead className="text-right">Building-days</TableHead>
+              <TableHead className="text-right">Available work days</TableHead>
               <TableHead className="text-right">Util</TableHead>
               <TableHead>Status</TableHead>
             </TableRow>
@@ -1088,9 +1091,16 @@ function UtilizationSection({
                   {formatPop(b.population)}
                 </TableCell>
                 <TableCell numeric>{b.crew_count}</TableCell>
-                <TableCell numeric>{b.work_hours.toLocaleString()}</TableCell>
+                <TableCell numeric>{b.property_count.toLocaleString()}</TableCell>
                 <TableCell numeric className="text-fg-muted">
-                  {b.available_hours.toLocaleString()}
+                  {b.building_days != null
+                    ? b.building_days.toLocaleString()
+                    : '—'}
+                </TableCell>
+                <TableCell numeric className="text-fg-muted">
+                  {b.available_work_days != null
+                    ? b.available_work_days.toLocaleString()
+                    : '—'}
                 </TableCell>
                 <TableCell numeric className="font-semibold">
                   {b.utilization_pct}%


### PR DESCRIPTION
## Summary
User: "I do not want work hours being a driver at all. I want quantity of buildings being the driver. So instead of available hours it should be available working days and instead of work hours it should be number of buildings for that branch."

The util % itself already switched to building-days in PR #158. This just realigns the displayed columns to match the actual math.

### Per-branch utilization table columns
- **Removed**: Work hrs, Available (hours)
- **Added**: Buildings (count of properties), Building-days (crew-days the branch's portfolio actually consumes), Available work days (crews × working_days_per_year)
- **Kept**: Branch, Pop, Crews, Util %, Status

Backend \`optionB_branch_breakdown\` rows now also carry \`building_days\` and \`available_work_days\` (work_hours / available_hours still on the row for other consumers, e.g., bid pricing's labor calc).

## Test plan
- [ ] Re-run Crew Strategy. Per-branch utilization table now shows Buildings / Building-days / Available work days instead of Work hrs / Available.
- [ ] Util % math: Building-days ÷ Available work days = Util %.
- [ ] Buildings column matches the property_count for that branch.
- [ ] Available work days = crews × 250 (or whatever working_days_per_year is configured).

🤖 Generated with [Claude Code](https://claude.com/claude-code)