### PR TITLE
Make crew-count pairing label self-explanatory

### DIFF
--- a/src/components/analysis/CrewStrategyChart.tsx
+++ b/src/components/analysis/CrewStrategyChart.tsx
@@ -362,15 +362,15 @@ export default function CrewStrategyChart({
             <span className="font-tabular font-semibold">
               {data.crew_count_analysis.conservative.crews_needed} crews
             </span>{' '}
-            (conservative)
+            assuming 1 building/day
             {data.crew_count_analysis.optimistic.crews_needed !==
               data.crew_count_analysis.conservative.crews_needed && (
               <>
-                {' — '}
+                {' — drops to '}
                 <span className="font-tabular font-semibold">
                   {data.crew_count_analysis.optimistic.crews_needed}
                 </span>{' '}
-                with small-property pairing (optimistic)
+                if dispatchers pair up small (≤4 hr) buildings 2-per-day
               </>
             )}
           </p>
@@ -686,9 +686,12 @@ export default function CrewStrategyChart({
                 <span className="font-tabular">{o.crew_count}</span>
                 {o.crew_count_optimistic != null &&
                   o.crew_count_optimistic !== o.crew_count && (
-                    <span className="text-fg-muted text-xs">
+                    <span
+                      className="text-fg-muted text-xs"
+                      title={`Optimistic count assumes small buildings (≤4 work-hours each) get paired so a crew handles two of them in one day. ${o.crew_count_optimistic} is the floor if your dispatchers consistently pair them; ${o.crew_count} is the ceiling without pairing.`}
+                    >
                       {' '}
-                      (or <span className="font-tabular">{o.crew_count_optimistic}</span> w/ pairing)
+                      (down to <span className="font-tabular">{o.crew_count_optimistic}</span> if small buildings are paired)
                     </span>
                   )}
                 {o.surge_crew_count ? (


### PR DESCRIPTION
## Summary
User: "It says 6 (or 3 w/pairing) — what does 3 with pairing mean?"

The label assumed users know what "small-property pairing" is. They don't. Reworded both call sites:

- Building-count math summary: "6 crews assuming 1 building/day — drops to 3 if dispatchers pair up small (≤4 hr) buildings 2-per-day"
- Per-option card "Crews" stat: "6 (down to 3 if small buildings are paired)" with a hover tooltip explaining the optimistic floor vs conservative ceiling

🤖 Generated with [Claude Code](https://claude.com/claude-code)