### PR TITLE
Use optimistic (paired) crew count as the recommendation; conservative becomes ceiling

### DIFF
--- a/api/analyses/account/[accountId]/clients/[clientId]/crew-strategy.ts
+++ b/api/analyses/account/[accountId]/clients/[clientId]/crew-strategy.ts
@@ -472,10 +472,13 @@ export function computeCrewStrategy(
       : DEFAULT_WORKING_DAYS_PER_YEAR
 
   // ── Option A: Roving ──────────────────────────────────────────────────────
-  // Variable cost — paid only for hours worked. Crew count comes from the
-  // building-count math (conservative); cost is hours-based regardless.
-  const optionA_crews = crewCountAnalysis.conservative.crews_needed
-  const optionA_crews_optimistic = crewCountAnalysis.optimistic.crews_needed
+  // Phase 4 follow-up — primary crew count is now the OPTIMISTIC count
+  // (small buildings paired). Real-world dispatch always pairs adjacent
+  // smalls; the conservative count was a worst-case ceiling that
+  // recommended over-staffing. Conservative is kept as
+  // crew_count_conservative for display ("up to N without pairing").
+  const optionA_crews = crewCountAnalysis.optimistic.crews_needed
+  const optionA_crews_ceiling = crewCountAnalysis.conservative.crews_needed
   const optionA_labor =
     totalAnnualHours * inputs.hourly_loaded_labor_cost * inputs.crew_size
   // Building-day utilization: how many crew-days of work do we have
@@ -524,10 +527,14 @@ export function computeCrewStrategy(
   // below as informational annotation on the per-branch breakdown.
   const band = inputs.utilization_constraint
   const bandActive = band.enabled
-  const crewsPerBranch = crewCountPerBranch.map((c) => Math.max(1, c.conservative))
-  const crewsPerBranchOptimistic = crewCountPerBranch.map((c) => Math.max(1, c.optimistic))
+  // Phase 4 follow-up — primary count = optimistic (paired). The
+  // conservative "1 building/day no pairing" is kept as a ceiling
+  // annotation so the user can see the worst case if dispatchers
+  // don't realize the pairing.
+  const crewsPerBranch = crewCountPerBranch.map((c) => Math.max(1, c.optimistic))
+  const crewsPerBranchCeiling = crewCountPerBranch.map((c) => Math.max(1, c.conservative))
   const optionB_crews = crewsPerBranch.reduce((a: number, b: number) => a + b, 0)
-  const optionB_crews_optimistic = crewsPerBranchOptimistic.reduce(
+  const optionB_crews_ceiling = crewsPerBranchCeiling.reduce(
     (a: number, b: number) => a + b,
     0
   )
@@ -543,14 +550,12 @@ export function computeCrewStrategy(
     city_state: string
     population: number | null
     crew_count: number
+    crew_count_ceiling: number
     crew_count_optimistic: number
     work_hours: number
     available_hours: number
     utilization_pct: number
     property_count: number
-    // Phase 4 follow-up — surface building-day math directly so the
-    // per-branch util table can drop hours-based columns ("Work hrs" /
-    // "Available") in favor of "Buildings" / "Available work days."
     building_days: number
     available_work_days: number
     avg_drive_miles_one_way: number
@@ -598,7 +603,9 @@ export function computeCrewStrategy(
       city_state: branchMeta[i].city_state,
       population: branchMeta[i].population,
       crew_count: crews,
-      crew_count_optimistic: crewsPerBranchOptimistic[i],
+      crew_count_ceiling: crewsPerBranchCeiling[i],
+      // Deprecated alias — back-compat for older chart consumers.
+      crew_count_optimistic: crews,
       work_hours: Math.round(branchHours[i]),
       available_hours: Math.round(available),
       utilization_pct: utilPct,
@@ -877,7 +884,10 @@ export function computeCrewStrategy(
     A: {
       label: 'Roving Crews',
       crew_count: optionA_crews,
-      crew_count_optimistic: optionA_crews_optimistic,
+      crew_count_ceiling: optionA_crews_ceiling,
+      // Deprecated alias for back-compat with older chart consumers.
+      // Kept until the UI fully migrates to crew_count_ceiling.
+      crew_count_optimistic: optionA_crews,
       utilization_pct: optionA_util_pct,
       annual_labor_cost: Math.round(optionA_labor),
       annual_vehicle_cost: Math.round(optionA_vehicle),
@@ -900,7 +910,8 @@ export function computeCrewStrategy(
     B: {
       label: 'Dedicated Crews',
       crew_count: optionB_crews,
-      crew_count_optimistic: optionB_crews_optimistic,
+      crew_count_ceiling: optionB_crews_ceiling,
+      crew_count_optimistic: optionB_crews,
       utilization_pct: optionB_util_pct,
       annual_labor_cost: Math.round(optionB_labor),
       annual_vehicle_cost: Math.round(optionB_vehicle),

--- a/src/components/analysis/CrewStrategyChart.tsx
+++ b/src/components/analysis/CrewStrategyChart.tsx
@@ -52,6 +52,7 @@ interface BranchUtilRow {
 interface CrewOption {
   label: string
   crew_count: number
+  crew_count_ceiling?: number
   crew_count_optimistic?: number
   surge_crew_count?: number
   surge_weeks?: number
@@ -360,17 +361,19 @@ export default function CrewStrategyChart({
           </p>
           <p className="mt-1 text-sm text-fg">
             <span className="font-tabular font-semibold">
-              {data.crew_count_analysis.conservative.crews_needed} crews
+              {data.crew_count_analysis.optimistic.crews_needed} crews
             </span>{' '}
-            assuming 1 building/day
-            {data.crew_count_analysis.optimistic.crews_needed !==
-              data.crew_count_analysis.conservative.crews_needed && (
+            recommended (small buildings paired)
+            {data.crew_count_analysis.conservative.crews_needed !==
+              data.crew_count_analysis.optimistic.crews_needed && (
               <>
-                {' — drops to '}
-                <span className="font-tabular font-semibold">
-                  {data.crew_count_analysis.optimistic.crews_needed}
+                {' — '}
+                <span className="font-tabular">
+                  {data.crew_count_analysis.conservative.crews_needed}
                 </span>{' '}
-                if dispatchers pair up small (≤4 hr) buildings 2-per-day
+                <span className="text-fg-muted">
+                  if dispatch can&apos;t pair adjacent small (≤4 hr) buildings
+                </span>
               </>
             )}
           </p>
@@ -684,14 +687,16 @@ export default function CrewStrategyChart({
             <dl className="my-3 grid grid-cols-2 gap-3 border-y border-border py-3 text-sm">
               <Stat label="Crews">
                 <span className="font-tabular">{o.crew_count}</span>
-                {o.crew_count_optimistic != null &&
-                  o.crew_count_optimistic !== o.crew_count && (
+                {o.crew_count_ceiling != null &&
+                  o.crew_count_ceiling !== o.crew_count && (
                     <span
                       className="text-fg-muted text-xs"
-                      title={`Optimistic count assumes small buildings (≤4 work-hours each) get paired so a crew handles two of them in one day. ${o.crew_count_optimistic} is the floor if your dispatchers consistently pair them; ${o.crew_count} is the ceiling without pairing.`}
+                      title={`Recommended count assumes small buildings (≤4 work-hours each) get paired so a crew handles two of them in one day. Ceiling is what you'd need if pairing isn't realized.`}
                     >
                       {' '}
-                      (down to <span className="font-tabular">{o.crew_count_optimistic}</span> if small buildings are paired)
+                      <span className="text-fg-subtle">
+                        (up to {o.crew_count_ceiling} without pairing)
+                      </span>
                     </span>
                   )}
                 {o.surge_crew_count ? (


### PR DESCRIPTION
## Summary
User: "The recommendation should just be 3 not '6 or 3 with pairing'. You always combine if you can. And the system can't recommend a plan with 48% / 69% / 52% utilization — I'd fire an analyst that proposed that."

Both symptoms came from the same choice: the headline \`crew_count\` was the conservative count (1 building/day, no pairing). That over-staffed the recommendation, which in turn produced the ugly 48-69% utilization figures because there were too many crews chasing too few building-days.

## Flipped
- \`crew_count\` (primary) is now \`optimistic.crews_needed\` — paired-small assumption.
- New \`crew_count_ceiling\` = conservative.crews_needed (the worst case if dispatch can't realize the pairing).
- \`crew_count_optimistic\` field retained as alias for backward compat with older chart consumers.
- Same flip for Option B per-branch sums.
- Util math (already building-day-based after PR #158) now uses the optimistic numerator + the lower (correct) denominator. With the recommendation right-sized, util naturally lands in the 90s%+.

## UI labels
- Building-count panel: "3 crews recommended (small buildings paired) — 6 if dispatch can't pair adjacent small (≤4 hr) buildings"
- Per-option Crews stat: "3 (up to 6 without pairing)" with hover tooltip explaining the ceiling

## Test plan
- [ ] Re-run Crew Strategy.
- [ ] Recommended crew count drops from previous high → optimistic value.
- [ ] Option A/B/C utilization % rises from 48-69% to typically 85-100%.
- [ ] Per-branch util table shows healthy utilization on each branch (within band).
- [ ] If pairing isn't possible (no small buildings), conservative = optimistic and the ceiling annotation disappears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)