### PR TITLE
Hybrid crew recommendation (dedicated + roving), uncap util, per-branch override drives util

### DIFF
--- a/api/analyses/account/[accountId]/clients/[clientId]/crew-strategy.ts
+++ b/api/analyses/account/[accountId]/clients/[clientId]/crew-strategy.ts
@@ -89,6 +89,11 @@ export interface CrewStrategyInputs {
   // actual config (working_days_per_year × hours_per_day) instead of
   // a hardcoded 47 × 40 = 1880 that assumed 8-hour days.
   working_days_per_year?: number | null
+  // Phase 4 follow-up — manual per-branch crew override carried into
+  // crew strategy so the per-branch utilization table reflects what
+  // the user actually selected. Special '__roving' key counts toward
+  // total but isn't tied to a specific branch.
+  crew_count_per_branch_override?: Record<string, number> | null
 }
 
 // FTE capacity is now derived per-call from
@@ -157,6 +162,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     utilization_constraint:
       (body as any).utilization_constraint ?? constraints.utilization_constraint,
     working_days_per_year: constraints.working_days_per_year ?? null,
+    crew_count_per_branch_override:
+      constraints.crew_count_per_branch_override ?? null,
   }
 
   let analysisId: string
@@ -485,15 +492,14 @@ export function computeCrewStrategy(
   // vs how many workdays we're paying the crews to be available?
   // Pairing-aware (uses optimistic count if it pulled small buildings
   // together) since paired days only count as 1 used day.
+  // Don't cap at 100 — over-utilization is a real signal the user
+  // needs to see (means current crew count is short).
   const optionA_util_pct =
     optionA_crews > 0
-      ? Math.min(
-          100,
-          Math.round(
-            (annualBuildingDaysOptimistic /
-              (optionA_crews * workingDaysPerYearForUtil)) *
-              100
-          )
+      ? Math.round(
+          (annualBuildingDaysOptimistic /
+            (optionA_crews * workingDaysPerYearForUtil)) *
+            100
         )
       : 0
   const optionA_vehicle =
@@ -527,13 +533,72 @@ export function computeCrewStrategy(
   // below as informational annotation on the per-branch breakdown.
   const band = inputs.utilization_constraint
   const bandActive = band.enabled
-  // Phase 4 follow-up — primary count = optimistic (paired). The
-  // conservative "1 building/day no pairing" is kept as a ceiling
-  // annotation so the user can see the worst case if dispatchers
-  // don't realize the pairing.
-  const crewsPerBranch = crewCountPerBranch.map((c) => Math.max(1, c.optimistic))
-  const crewsPerBranchCeiling = crewCountPerBranch.map((c) => Math.max(1, c.conservative))
-  const optionB_crews = crewsPerBranch.reduce((a: number, b: number) => a + b, 0)
+  // Phase 4 follow-up — Option B is now a HYBRID: each branch gets
+  // dedicated crews for the workload that fully utilizes them, and a
+  // roving pool absorbs the leftover. Without this, every branch was
+  // ceil()'d to its own dedicated count — which over-staffed any
+  // branch whose workload didn't divide evenly into a working year
+  // (the source of the user's "fire an analyst that recommended 48%
+  // util" complaint). 3 branches × 1 dedicated each + 1 roving for
+  // overflow is what an operations analyst actually does.
+  //
+  // User's manual per-branch override (if present) wins over the
+  // recommendation. Special key '__roving' = floating crews not tied
+  // to a single branch.
+  const perBranchOverride = inputs.crew_count_per_branch_override ?? null
+  const branchBuildingDaysList = crewCountPerBranch.map((c) => c.building_days)
+
+  // Compute the recommendation when no manual override is in play.
+  // Each branch: floor(building_days / working_days) dedicated crews
+  // (each fully utilized). Anything left over in fractional days
+  // gets aggregated and absorbed by a roving pool.
+  const recommendedDedicatedPerBranch = branchBuildingDaysList.map((bd) => {
+    if (bd <= 0) return 0
+    return Math.floor(bd / workingDaysPerYearForUtil)
+  })
+  const recommendedRemainderDays = branchBuildingDaysList.reduce(
+    (sum, bd, i) =>
+      sum +
+      Math.max(0, bd - recommendedDedicatedPerBranch[i] * workingDaysPerYearForUtil),
+    0
+  )
+  // Total crews must still cover the work — if no branch hits a full
+  // dedicated crew (e.g. all branches small), we still need at least
+  // ceil(remainder / working_days) roving to cover.
+  const recommendedRoving =
+    recommendedRemainderDays > 0
+      ? Math.ceil(recommendedRemainderDays / workingDaysPerYearForUtil)
+      : 0
+  // If everything dedicated and no roving but a branch has 0 — that's
+  // a branch with no work, fine (return 0 dedicated).
+  // Floor: every branch with any workload gets at least 1 dedicated
+  // unless the user explicitly set it to 0 via override. Without this
+  // a branch with <250 building-days would have zero dedicated and
+  // entirely depend on the roving pool.
+  // Actually: not enforced. Let the math speak. A branch with 100
+  // building-days legitimately doesn't need a dedicated crew if a
+  // roving crew can serve it.
+
+  // Apply override if present, else use the recommendation.
+  const rovingOverride =
+    perBranchOverride && Number.isFinite(perBranchOverride['__roving'])
+      ? Math.max(0, Math.floor(Number(perBranchOverride['__roving'])))
+      : null
+  const crewsPerBranch = branches.map((b, i) => {
+    if (perBranchOverride) {
+      const ovr = perBranchOverride[b.name]
+      if (Number.isFinite(ovr) && (ovr ?? 0) >= 0) {
+        return Math.floor(Number(ovr))
+      }
+    }
+    return recommendedDedicatedPerBranch[i]
+  })
+  const rovingCrews = rovingOverride != null ? rovingOverride : recommendedRoving
+  const crewsPerBranchCeiling = crewCountPerBranch.map((c) =>
+    Math.max(1, c.conservative)
+  )
+  const optionB_crews =
+    crewsPerBranch.reduce((a: number, b: number) => a + b, 0) + rovingCrews
   const optionB_crews_ceiling = crewsPerBranchCeiling.reduce(
     (a: number, b: number) => a + b,
     0
@@ -574,7 +639,7 @@ export function computeCrewStrategy(
     const branchAvailableDays = crews * workingDaysPerYearForUtil
     const utilPct =
       branchAvailableDays > 0
-        ? Math.min(100, Math.round((branchBuildingDays / branchAvailableDays) * 100))
+        ? Math.round((branchBuildingDays / branchAvailableDays) * 100)
         : 0
     const status = classifyUtilization(utilPct, band)
     optionB_util_sum += utilPct
@@ -653,7 +718,7 @@ export function computeCrewStrategy(
     inputs.surge_crew_count * inputs.surge_weeks_per_year * 5
   const optionC_util_pct =
     optionC_capacity_days > 0
-      ? Math.min(99, Math.round((annualBuildingDaysOptimistic / optionC_capacity_days) * 100))
+      ? Math.round((annualBuildingDaysOptimistic / optionC_capacity_days) * 100)
       : 0
   const optionC_vehicle =
     (optionC_FT_crews + inputs.surge_crew_count) *
@@ -728,7 +793,7 @@ export function computeCrewStrategy(
   const optionB_per_region = Array.from(regionMap.entries()).map(([region, v]) => {
     const utilPct =
       v.available_days > 0
-        ? Math.min(100, Math.round((v.building_days / v.available_days) * 100))
+        ? Math.round((v.building_days / v.available_days) * 100)
         : 0
     return {
       region,
@@ -742,13 +807,10 @@ export function computeCrewStrategy(
 
   const optionB_portfolio_pct =
     optionB_crews > 0
-      ? Math.min(
-          100,
-          Math.round(
-            (annualBuildingDays /
-              (optionB_crews * workingDaysPerYearForUtil)) *
-              100
-          )
+      ? Math.round(
+          (annualBuildingDays /
+            (optionB_crews * workingDaysPerYearForUtil)) *
+            100
         )
       : 0
   const optionB_portfolio = {
@@ -908,10 +970,19 @@ export function computeCrewStrategy(
         'Mature operations with strong dispatch + consistent year-round volume.',
     },
     B: {
-      label: 'Dedicated Crews',
+      label: 'Dedicated + Roving',
       crew_count: optionB_crews,
       crew_count_ceiling: optionB_crews_ceiling,
       crew_count_optimistic: optionB_crews,
+      // Phase 4 follow-up — split out the dedicated vs roving counts.
+      // Total crew_count = dedicated_total + roving.
+      dedicated_per_branch: branches.map((b, i) => ({
+        branch_name: b.name,
+        city_state: branchMeta[i].city_state,
+        crew_count: crewsPerBranch[i],
+      })),
+      roving_crews: rovingCrews,
+      dedicated_total: crewsPerBranch.reduce((a, b) => a + b, 0),
       utilization_pct: optionB_util_pct,
       annual_labor_cost: Math.round(optionB_labor),
       annual_vehicle_cost: Math.round(optionB_vehicle),
@@ -924,17 +995,17 @@ export function computeCrewStrategy(
       },
       overnight_summary: overnightSummary,
       pros: [
-        'Simple — each crew owns one cluster',
-        'Defensible to clients — predictable, named teams',
-        'Lower coordination overhead',
+        'Each branch has dedicated crews fully utilized year-round',
+        'Roving pool absorbs leftover work — no per-branch idle time',
+        'Defensible to clients — named teams per branch',
       ],
       cons: [
-        'Lower average utilization (paid for some idle time)',
-        'Branches outside the band need surge crews or consolidation',
-        'Harder to flex across branches when seasonal demand shifts',
+        'Roving crew needs a dispatcher who can cross-branch route',
+        'Higher coordination overhead than pure dedicated',
+        'Roving crew\'s fuel + drive time higher than dedicated',
       ],
       recommended_use_case:
-        'Year 1 of a new portfolio. Best when geographic spread > 5 states.',
+        'Year 1+ of a portfolio with uneven branch workloads. Most common operating pattern.',
     },
     C: {
       label: 'Surge Model',

--- a/src/components/analysis/CrewStrategyChart.tsx
+++ b/src/components/analysis/CrewStrategyChart.tsx
@@ -55,6 +55,15 @@ interface CrewOption {
   crew_count_ceiling?: number
   crew_count_optimistic?: number
   surge_crew_count?: number
+  // Phase 4 follow-up — Option B is now hybrid: dedicated per branch
+  // + roving pool. crew_count = dedicated_total + roving_crews.
+  dedicated_per_branch?: Array<{
+    branch_name: string
+    city_state: string | null
+    crew_count: number
+  }>
+  roving_crews?: number
+  dedicated_total?: number
   surge_weeks?: number
   utilization_pct: number
   annual_labor_cost: number
@@ -305,19 +314,38 @@ export default function CrewStrategyChart({
   // The total is then a sum of EVERY branch's visible value, not just
   // the ones the user explicitly typed into. This matches the inputs
   // they see on screen.
+  // Pull recommended dedicated counts out of Option B's hybrid output
+  // when present; that's the new building-day-aware recommendation.
+  const recommendedDedicatedByBranch: Record<string, number> = {}
+  for (const dp of data.options.B.dedicated_per_branch ?? []) {
+    recommendedDedicatedByBranch[dp.branch_name] = dp.crew_count
+  }
+  const recommendedRoving = data.options.B.roving_crews ?? 0
+
   const visibleOverride: Record<string, number> = {}
   for (const b of data.branches ?? []) {
     if (crewOverride[b.name] != null) {
       visibleOverride[b.name] = crewOverride[b.name]
     } else {
-      const rec = branchBreakdown.find((bb) => bb.branch_name === b.name)?.crew_count ?? 0
+      // Fall back to the recommended dedicated count for this branch
+      // (could be 0 — branch has no work justifying a dedicated crew).
+      // If recommendation isn't available (older outputs), use the
+      // legacy crew_count from branchBreakdown.
+      const rec =
+        recommendedDedicatedByBranch[b.name] ??
+        branchBreakdown.find((bb) => bb.branch_name === b.name)?.crew_count ??
+        0
       visibleOverride[b.name] = rec
     }
   }
-  const overrideTotal = Object.values(visibleOverride).reduce(
-    (s, v) => s + (Number.isFinite(v) ? Math.max(0, Math.floor(v)) : 0),
-    0
-  )
+  // Roving — special key '__roving' on the override jsonb.
+  const visibleRoving =
+    crewOverride['__roving'] != null ? crewOverride['__roving'] : recommendedRoving
+  const overrideTotal =
+    Object.values(visibleOverride).reduce(
+      (s, v) => s + (Number.isFinite(v) ? Math.max(0, Math.floor(v)) : 0),
+      0
+    ) + Math.max(0, Math.floor(Number.isFinite(visibleRoving) ? visibleRoving : 0))
   const allowAllocations =
     accountId != null && clientId != null && (data.branches?.length ?? 0) > 0
   const opts = [
@@ -687,6 +715,14 @@ export default function CrewStrategyChart({
             <dl className="my-3 grid grid-cols-2 gap-3 border-y border-border py-3 text-sm">
               <Stat label="Crews">
                 <span className="font-tabular">{o.crew_count}</span>
+                {o.dedicated_total != null && o.roving_crews != null && o.roving_crews > 0 && (
+                  <span className="text-fg-muted text-xs">
+                    {' '}
+                    <span className="text-fg-subtle">
+                      ({o.dedicated_total} dedicated + {o.roving_crews} roving)
+                    </span>
+                  </span>
+                )}
                 {o.crew_count_ceiling != null &&
                   o.crew_count_ceiling !== o.crew_count && (
                     <span
@@ -788,6 +824,36 @@ export default function CrewStrategyChart({
                 const userValue = crewOverride[b.name]
                 const value = userValue ?? recommended
                 const isDirty = userValue != null && userValue !== recommended
+                // Compute and persist the FULL override map (every
+                // branch + roving). Used by both per-branch and
+                // roving onBlur paths so they save consistent state.
+                const persistFull = () => {
+                  const fullMap: Record<string, number> = {}
+                  for (const branch of data.branches ?? []) {
+                    const u = crewOverride[branch.name]
+                    if (u != null) {
+                      fullMap[branch.name] = u
+                    } else {
+                      fullMap[branch.name] =
+                        recommendedDedicatedByBranch[branch.name] ??
+                        branchBreakdown.find((bb) => bb.branch_name === branch.name)
+                          ?.crew_count ??
+                        0
+                    }
+                  }
+                  const rovingVal =
+                    crewOverride['__roving'] != null
+                      ? crewOverride['__roving']
+                      : recommendedRoving
+                  if (rovingVal > 0) fullMap['__roving'] = rovingVal
+                  const total =
+                    Object.values(fullMap).reduce(
+                      (s, v) =>
+                        s + (Number.isFinite(v) ? Math.max(0, Math.floor(v)) : 0),
+                      0
+                    )
+                  void saveOverride(fullMap, total > 0)
+                }
                 return (
                   <div
                     key={b.name}
@@ -801,11 +867,11 @@ export default function CrewStrategyChart({
                     </p>
                     {breakdown && (
                       <p className="text-[10px] text-fg-subtle mt-0.5">
-                        {breakdown.property_count} properties ·{' '}
-                        {breakdown.work_hours.toLocaleString()} hr/yr · Option{' '}
-                        {activeOption} rec:{' '}
-                        <span className="font-tabular">{recommended}</span>{' '}
-                        crews
+                        {breakdown.property_count} properties · rec:{' '}
+                        <span className="font-tabular">
+                          {recommendedDedicatedByBranch[b.name] ?? recommended}
+                        </span>{' '}
+                        dedicated
                       </p>
                     )}
                     <div className="mt-2 flex items-center gap-2">
@@ -819,36 +885,9 @@ export default function CrewStrategyChart({
                           const raw = e.target.value
                           const n = raw === '' ? 0 : Math.max(0, Math.floor(Number(raw)))
                           setCrewOverride((prev) => ({ ...prev, [b.name]: n }))
-                          // Override is implicitly enabled the moment
-                          // the user types anything. Keep state in sync.
                           if (!overrideEnabled) setOverrideEnabled(true)
                         }}
-                        onBlur={() => {
-                          // Save the FULL per-branch map the user sees
-                          // on screen (override values + recommended
-                          // fallbacks for branches they left untouched),
-                          // so the bid pricing / workforce / seasonality
-                          // modules see crew counts for every branch,
-                          // not just the ones the user typed into.
-                          const fullMap: Record<string, number> = {}
-                          for (const branch of data.branches ?? []) {
-                            const u = crewOverride[branch.name]
-                            if (u != null) {
-                              fullMap[branch.name] = u
-                            } else {
-                              const rec = branchBreakdown.find(
-                                (bb) => bb.branch_name === branch.name
-                              )?.crew_count ?? 0
-                              fullMap[branch.name] = rec
-                            }
-                          }
-                          const total = Object.values(fullMap).reduce(
-                            (s, v) =>
-                              s + (Number.isFinite(v) ? Math.max(0, Math.floor(v)) : 0),
-                            0
-                          )
-                          void saveOverride(fullMap, total > 0)
-                        }}
+                        onBlur={persistFull}
                         className="w-20 h-8 rounded-md border border-border bg-surface px-2 text-sm font-mono text-fg focus-visible:outline-none focus-visible:border-border-focus focus-visible:ring-2 focus-visible:ring-accent"
                       />
                       {isDirty && (
@@ -858,6 +897,77 @@ export default function CrewStrategyChart({
                   </div>
                 )
               })}
+              {/* Roving crew input — not tied to a specific branch.
+                  Counts toward total but isn't a per-branch denominator. */}
+              {(() => {
+                const userRoving = crewOverride['__roving']
+                const rovingValue = userRoving ?? recommendedRoving
+                const isRovingDirty =
+                  userRoving != null && userRoving !== recommendedRoving
+                return (
+                  <div
+                    className={cn(
+                      'rounded-md border bg-surface-subtle/40 p-3',
+                      isRovingDirty ? 'border-accent' : 'border-border'
+                    )}
+                  >
+                    <p className="text-sm font-semibold text-fg truncate">
+                      Roving (any branch)
+                    </p>
+                    <p className="text-[10px] text-fg-subtle mt-0.5">
+                      Floats between branches to absorb overflow · rec:{' '}
+                      <span className="font-tabular">{recommendedRoving}</span>{' '}
+                      crews
+                    </p>
+                    <div className="mt-2 flex items-center gap-2">
+                      <label className="text-xs text-fg-muted">Crews:</label>
+                      <input
+                        type="number"
+                        min={0}
+                        step={1}
+                        value={rovingValue}
+                        onChange={(e) => {
+                          const raw = e.target.value
+                          const n = raw === '' ? 0 : Math.max(0, Math.floor(Number(raw)))
+                          setCrewOverride((prev) => ({ ...prev, ['__roving']: n }))
+                          if (!overrideEnabled) setOverrideEnabled(true)
+                        }}
+                        onBlur={() => {
+                          const fullMap: Record<string, number> = {}
+                          for (const branch of data.branches ?? []) {
+                            const u = crewOverride[branch.name]
+                            if (u != null) {
+                              fullMap[branch.name] = u
+                            } else {
+                              fullMap[branch.name] =
+                                recommendedDedicatedByBranch[branch.name] ??
+                                branchBreakdown.find(
+                                  (bb) => bb.branch_name === branch.name
+                                )?.crew_count ??
+                                0
+                            }
+                          }
+                          const r =
+                            crewOverride['__roving'] != null
+                              ? crewOverride['__roving']
+                              : recommendedRoving
+                          if (r > 0) fullMap['__roving'] = r
+                          const total = Object.values(fullMap).reduce(
+                            (s, v) =>
+                              s + (Number.isFinite(v) ? Math.max(0, Math.floor(v)) : 0),
+                            0
+                          )
+                          void saveOverride(fullMap, total > 0)
+                        }}
+                        className="w-20 h-8 rounded-md border border-border bg-surface px-2 text-sm font-mono text-fg focus-visible:outline-none focus-visible:border-border-focus focus-visible:ring-2 focus-visible:ring-accent"
+                      />
+                      {isRovingDirty && (
+                        <span className="text-[10px] text-accent">overridden</span>
+                      )}
+                    </div>
+                  </div>
+                )
+              })()}
             </div>
             <div className="flex items-center justify-between pt-2 border-t border-border flex-wrap gap-2">
               <p className="text-sm text-fg">


### PR DESCRIPTION
## Summary
Three fixes from one round of feedback:

### 1. Uncap utilization display
\`Math.min(100, …)\` on Option A/B portfolio + per-branch + per-region util %, and \`Math.min(99, …)\` on Option C. All removed. If the user's crew count is short for the workload, util should show 115% — that's the signal to add a crew. Capping hid the problem.

### 2. Per-branch util respects the manual override
Previously the per-branch utilization table stayed on the Option B recommendation even after the user manually set 2/1/1. \`crew-strategy.ts\` now reads \`constraints.crew_count_per_branch_override\` (passed through inputs) and uses those values; falls through to the recommendation otherwise. Makes the table consistent with what bid pricing, workforce sizing, and seasonality already see.

### 3. Option B is now Dedicated + Roving (recommended)
User: "If recommendations were working appropriately I shouldn't need to override to 3 dedicated 1 roving — the recommendation should BE that."

- For each branch: dedicated = \`floor(branch_building_days / working_days_per_year)\`. Each dedicated crew is fully utilized by construction.
- Roving = \`ceil(remainder / working_days_per_year)\` — picks up leftover work that doesn't fully utilize a dedicated crew anywhere.
- Total Option B = \`dedicated_total + roving\`.
- Output adds \`dedicated_per_branch\` + \`roving_crews\` + \`dedicated_total\`. Chart shows "4 (3 dedicated + 1 roving)" on the Crews stat.
- Pros / cons text rewritten ("Each branch fully utilized year-round" / "Roving needs cross-branch dispatch" etc.).

Manual override panel adds a "Roving (any branch)" input alongside per-branch inputs. Persisted on the special \`__roving\` key in the \`crew_count_per_branch_override\` jsonb. \`resolveCrews\` already sums every key for total crew count, so bid pricing / workforce / seasonality automatically see the roving count.

## Test plan
- [ ] Re-run Crew Strategy.
- [ ] Option B shows e.g. "4 (3 dedicated + 1 roving)" instead of just "4".
- [ ] Per-branch util table reflects the recommended dedicated counts (not the inflated all-dedicated count).
- [ ] If util genuinely exceeds 100% (e.g. you picked too few crews), the number reads 115% or whatever, not capped.
- [ ] Open the Manual override card → there's a "Roving (any branch)" input pre-populated with the recommended roving count.
- [ ] Set Frisco=2, Albuquerque=1, Sugar Land=1, Roving=0 → total reads 4. Per-branch util table reflects those exact assignments.
- [ ] Bid Pricing rerun: total crews = 4, labor scales accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)