### PR TITLE
Fix Set location button discoverability on K-switch modal

### DIFF
--- a/src/components/analysis/BuildSelectionModal.tsx
+++ b/src/components/analysis/BuildSelectionModal.tsx
@@ -197,8 +197,11 @@ export default function BuildSelectionModal({
     for (let i = 0; i < rows.length; i++) {
       const r = rows[i]
       if (r.kind !== 'filled') {
+        // Auto-open the picker for the first empty row instead of forcing
+        // the user to find the "Set location" button on a crowded row.
+        setActivePicker(i)
         setError(
-          `Row ${i + 1} is missing a location. Click "Set location" to choose one.`
+          `Row ${i + 1} needs a location — pick one below.`
         )
         return
       }
@@ -244,8 +247,12 @@ export default function BuildSelectionModal({
             <TableBody>
               {rows.map((row, idx) => {
                 const isLocked = idx < lockedCount
+                const isEmpty = row.kind === 'empty'
                 return (
-                  <TableRow key={idx}>
+                  <TableRow
+                    key={idx}
+                    className={isEmpty ? 'bg-warning-subtle' : undefined}
+                  >
                     <TableCell className="text-fg-subtle font-tabular">
                       {idx + 1}
                     </TableCell>
@@ -330,7 +337,11 @@ export default function BuildSelectionModal({
                           <button
                             type="button"
                             onClick={() => setActivePicker(idx)}
-                            className="rounded-sm text-xs text-accent hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+                            className={
+                              row.kind === 'filled'
+                                ? 'rounded-sm text-xs text-accent hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent'
+                                : 'inline-flex items-center rounded-md bg-accent px-2.5 py-1 text-xs font-medium text-white shadow-sm hover:bg-accent-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent'
+                            }
                           >
                             {row.kind === 'filled' ? 'Change' : 'Set location'}
                           </button>


### PR DESCRIPTION
## Summary
- When users increase K on the branch-selection modal (e.g. 3→4), the newly added empty row needed a "Set location" click — but the button was rendered as small accent-colored text in a crowded action column and was easy to miss.
- Hitting Confirm produced an error telling the user to click "Set location," which they then couldn't find.

## Changes
- Empty rows now get a `bg-warning-subtle` highlight so they stand out as needing attention
- "Set location" promoted from `text-xs text-accent` link styling to a filled accent button (larger click target, much higher visual weight)
- On Confirm with one or more empty rows, the picker auto-opens for the first empty row instead of just showing an error — user types the city/address directly without hunting for the button

## Test plan
- [ ] Open Crew Strategy → switch K from 3→4 → modal shows row 4 highlighted with prominent "Set location" button
- [ ] Click Confirm without filling row 4 → location picker auto-opens, no need to find the button
- [ ] Existing behavior still works: filling row 4 manually then Confirm saves successfully
- [ ] `npx tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)