### PR TITLE
Add Travel & Trip Planner tab

### DIFF
--- a/api/v1/clients/[id]/manual-trips.ts
+++ b/api/v1/clients/[id]/manual-trips.ts
@@ -1,0 +1,345 @@
+// GET  /api/v1/clients/[id]/manual-trips
+//   → { trips: ManualTripWithMetrics[], properties: TravelProperty[] }
+//   The travel planner page calls this once and gets everything it
+//   needs: per-trip metrics (nights, miles, cost) and the per-property
+//   list with branch assignment + drive miles. Computing metrics
+//   server-side keeps the client dumb and avoids re-implementing the
+//   haversine / overnight math in two places.
+//
+// POST /api/v1/clients/[id]/manual-trips
+//   Body: { name, branch_name, property_ids[], visits_per_year?, notes? }
+//   Creates a trip. Returns the created row.
+//
+// PATCH /api/v1/clients/[id]/manual-trips
+//   Body: { trip_id, ...partial }  Updates an existing trip.
+//
+// DELETE /api/v1/clients/[id]/manual-trips
+//   Body: { trip_id }
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { createAdminClient } from '../../../_lib/supabase.js'
+import { authenticateRequest } from '../../../_lib/auth.js'
+import {
+  loadConstraints,
+  type SelectedBranch,
+} from '../../../_lib/analysis/operational-constraints.js'
+import { haversineMiles, driveTimeMinutes } from '../../../_lib/analysis/haversine.js'
+
+export const config = { maxDuration: 30 }
+
+interface PropertyRow {
+  id: string
+  address_line1: string | null
+  city: string | null
+  state: string | null
+  latitude: number | null
+  longitude: number | null
+}
+
+interface TripRow {
+  id: string
+  account_id: string
+  client_id: string
+  name: string
+  branch_name: string
+  property_ids: string[]
+  visits_per_year: number
+  notes: string | null
+  created_at: string
+  updated_at: string
+}
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method === 'OPTIONS') return res.status(200).end()
+  try {
+    await authenticateRequest(req)
+  } catch (err: any) {
+    return res.status(err.statusCode ?? 401).json({ error: err.message ?? 'Unauthorized' })
+  }
+  const clientId = req.query.id as string
+  if (!clientId) return res.status(400).json({ error: 'client id required' })
+  const db = createAdminClient()
+
+  const { data: clientRow } = await db
+    .from('clients')
+    .select('account_id')
+    .eq('id', clientId)
+    .maybeSingle()
+  const accountId = (clientRow as any)?.account_id as string | undefined
+  if (!accountId) return res.status(404).json({ error: 'Client not found' })
+
+  const constraints = await loadConstraints(db, accountId, clientId)
+  const branches: SelectedBranch[] = constraints.selected_branches ?? []
+  const driveSpeed = constraints.drive_speed_mph ?? 60
+  const hotelConfig = constraints.hotel_cost_config
+
+  if (req.method === 'GET') {
+    const { trips, properties } = await loadTripsAndProperties(
+      db,
+      accountId,
+      clientId
+    )
+    return res.status(200).json({
+      trips: trips.map((t) =>
+        annotateTrip(t, properties, branches, driveSpeed, hotelConfig)
+      ),
+      properties: annotateProperties(properties, branches, driveSpeed),
+      branches: branches.map((b) => ({
+        name: b.name,
+        city_state: b.city_state ?? null,
+        lat: b.lat,
+        lng: b.lng,
+      })),
+      hotel_config: hotelConfig,
+    })
+  }
+
+  if (req.method === 'POST') {
+    const body = (req.body ?? {}) as Record<string, unknown>
+    if (!body.name || typeof body.name !== 'string') {
+      return res.status(400).json({ error: 'name required' })
+    }
+    if (!body.branch_name || typeof body.branch_name !== 'string') {
+      return res.status(400).json({ error: 'branch_name required' })
+    }
+    const propertyIds = Array.isArray(body.property_ids)
+      ? (body.property_ids as string[])
+      : []
+    if (propertyIds.length === 0) {
+      return res.status(400).json({ error: 'property_ids must be non-empty' })
+    }
+    const visitsPerYear = Number.isFinite(body.visits_per_year as number)
+      ? Math.max(1, Math.floor(Number(body.visits_per_year)))
+      : 1
+    const { data, error } = await db
+      .from('manual_trips')
+      .insert({
+        account_id: accountId,
+        client_id: clientId,
+        name: body.name.trim(),
+        branch_name: body.branch_name.trim(),
+        property_ids: propertyIds,
+        visits_per_year: visitsPerYear,
+        notes: typeof body.notes === 'string' ? body.notes : null,
+      })
+      .select('*')
+      .single()
+    if (error) return res.status(500).json({ error: error.message })
+    return res.status(200).json({ trip: data })
+  }
+
+  if (req.method === 'PATCH') {
+    const body = (req.body ?? {}) as Record<string, unknown>
+    const tripId = body.trip_id as string | undefined
+    if (!tripId) return res.status(400).json({ error: 'trip_id required' })
+    const update: Record<string, unknown> = {
+      updated_at: new Date().toISOString(),
+    }
+    if (typeof body.name === 'string') update.name = body.name.trim()
+    if (typeof body.branch_name === 'string') update.branch_name = body.branch_name.trim()
+    if (Array.isArray(body.property_ids)) update.property_ids = body.property_ids
+    if (Number.isFinite(body.visits_per_year as number)) {
+      update.visits_per_year = Math.max(1, Math.floor(Number(body.visits_per_year)))
+    }
+    if (typeof body.notes === 'string' || body.notes === null) update.notes = body.notes
+    const { data, error } = await db
+      .from('manual_trips')
+      .update(update)
+      .eq('id', tripId)
+      .eq('account_id', accountId)
+      .eq('client_id', clientId)
+      .select('*')
+      .single()
+    if (error) return res.status(500).json({ error: error.message })
+    return res.status(200).json({ trip: data })
+  }
+
+  if (req.method === 'DELETE') {
+    const body = (req.body ?? {}) as Record<string, unknown>
+    const tripId = body.trip_id as string | undefined
+    if (!tripId) return res.status(400).json({ error: 'trip_id required' })
+    const { error } = await db
+      .from('manual_trips')
+      .delete()
+      .eq('id', tripId)
+      .eq('account_id', accountId)
+      .eq('client_id', clientId)
+    if (error) return res.status(500).json({ error: error.message })
+    return res.status(204).end()
+  }
+
+  return res.status(405).json({ error: 'Method not allowed' })
+}
+
+async function loadTripsAndProperties(
+  db: ReturnType<typeof createAdminClient>,
+  accountId: string,
+  clientId: string
+): Promise<{ trips: TripRow[]; properties: PropertyRow[] }> {
+  const [tripsRes, slRes] = await Promise.all([
+    db
+      .from('manual_trips')
+      .select('*')
+      .eq('account_id', accountId)
+      .eq('client_id', clientId)
+      .order('created_at', { ascending: true }),
+    db
+      .from('service_locations')
+      .select('property_id')
+      .eq('client_id', clientId),
+  ])
+  const trips = ((tripsRes.data ?? []) as TripRow[])
+  const propIds = Array.from(
+    new Set(((slRes.data ?? []) as { property_id: string }[]).map((r) => r.property_id))
+  )
+  let properties: PropertyRow[] = []
+  // Chunk to stay under PostgREST's URL length limit on huge clients.
+  for (let i = 0; i < propIds.length; i += 250) {
+    const chunk = propIds.slice(i, i + 250)
+    const { data } = await db
+      .from('properties')
+      .select('id, address_line1, city, state, latitude, longitude')
+      .in('id', chunk)
+    for (const p of data ?? []) properties.push(p as PropertyRow)
+  }
+  return { trips, properties }
+}
+
+function nearestBranch(
+  prop: PropertyRow,
+  branches: SelectedBranch[]
+): { branch: SelectedBranch | null; miles: number } {
+  if (
+    !branches.length ||
+    prop.latitude == null ||
+    prop.longitude == null
+  ) {
+    return { branch: null, miles: 0 }
+  }
+  let best: SelectedBranch | null = null
+  let bestMi = Infinity
+  for (const b of branches) {
+    const d = haversineMiles(
+      { lat: prop.latitude, lng: prop.longitude },
+      { lat: b.lat, lng: b.lng }
+    )
+    if (d < bestMi) {
+      bestMi = d
+      best = b
+    }
+  }
+  return { branch: best, miles: bestMi }
+}
+
+function annotateProperties(
+  properties: PropertyRow[],
+  branches: SelectedBranch[],
+  driveSpeed: number
+) {
+  return properties.map((p) => {
+    const { branch, miles } = nearestBranch(p, branches)
+    const driveMin = miles > 0 ? driveTimeMinutes(miles, driveSpeed) : 0
+    return {
+      property_id: p.id,
+      address_line1: p.address_line1,
+      city: p.city,
+      state: p.state,
+      lat: p.latitude,
+      lng: p.longitude,
+      assigned_branch: branch?.name ?? null,
+      assigned_branch_city_state: branch?.city_state ?? null,
+      miles_to_branch: Math.round(miles * 10) / 10,
+      drive_minutes_to_branch: Math.round(driveMin),
+    }
+  })
+}
+
+function annotateTrip(
+  trip: TripRow,
+  properties: PropertyRow[],
+  branches: SelectedBranch[],
+  driveSpeed: number,
+  hotelConfig: ReturnType<typeof loadConstraints> extends Promise<infer R>
+    ? R extends { hotel_cost_config: infer C }
+      ? C
+      : never
+    : never
+) {
+  const branch = branches.find(
+    (b) => b.name.toLowerCase() === trip.branch_name.toLowerCase()
+  )
+  const tripProps = trip.property_ids
+    .map((pid) => properties.find((p) => p.id === pid))
+    .filter((p): p is PropertyRow => !!p)
+  const validProps = tripProps.filter(
+    (p) => p.latitude != null && p.longitude != null
+  )
+
+  // Drive miles: branch → first property, between properties in order,
+  // last property → branch. We use the geographic ordering as given;
+  // a TSP-optimized variant could improve this but isn't necessary
+  // for the v1 hotel/fuel calc.
+  let totalDriveMiles = 0
+  if (branch && validProps.length > 0) {
+    let prev = { lat: branch.lat, lng: branch.lng }
+    for (const p of validProps) {
+      totalDriveMiles += haversineMiles(prev, {
+        lat: p.latitude!,
+        lng: p.longitude!,
+      })
+      prev = { lat: p.latitude!, lng: p.longitude! }
+    }
+    // Return leg
+    totalDriveMiles += haversineMiles(prev, { lat: branch.lat, lng: branch.lng })
+  }
+
+  // Drive time from branch to centroid (one-way) — used to determine
+  // whether this is an overnight trip vs a day trip.
+  let oneWayHours = 0
+  if (branch && validProps.length > 0) {
+    const lats = validProps.map((p) => p.latitude!)
+    const lngs = validProps.map((p) => p.longitude!)
+    const cLat = lats.reduce((s, v) => s + v, 0) / lats.length
+    const cLng = lngs.reduce((s, v) => s + v, 0) / lngs.length
+    const distMi = haversineMiles(
+      { lat: branch.lat, lng: branch.lng },
+      { lat: cLat, lng: cLng }
+    )
+    oneWayHours = driveTimeMinutes(distMi, driveSpeed) / 60
+  }
+
+  // Nights: 0 if day-trip distance (under hotelConfig.overnight_trigger);
+  // otherwise count of properties in trip (each takes a day, with the
+  // "1 building/day" rule). A more sophisticated version would account
+  // for crew_size + work_hours; v1 keeps it simple and explicit.
+  const isOvernight =
+    oneWayHours > (hotelConfig?.overnight_trigger_one_way_hours ?? 3)
+  const nightsPerTrip = isOvernight ? Math.max(1, validProps.length) : 0
+  const annualNights = nightsPerTrip * Math.max(1, trip.visits_per_year ?? 1)
+  const annualMiles = totalDriveMiles * Math.max(1, trip.visits_per_year ?? 1)
+
+  const costPerNight = hotelConfig?.cost_per_night ?? 0
+  const perDiemPerNight = hotelConfig?.per_diem_per_night ?? 0
+  // Crew size for per-diem comes from constraints; assume 3 if not set.
+  const crewSize = 3
+  const includePerDiem = hotelConfig?.include_per_diem !== false
+  const annualHotelCost = annualNights * costPerNight
+  const annualPerDiemCost = includePerDiem
+    ? annualNights * crewSize * perDiemPerNight
+    : 0
+  const annualLodgingCost = annualHotelCost + annualPerDiemCost
+
+  return {
+    ...trip,
+    property_count: tripProps.length,
+    properties_missing_coords: tripProps.length - validProps.length,
+    miles_per_trip: Math.round(totalDriveMiles * 10) / 10,
+    annual_miles: Math.round(annualMiles * 10) / 10,
+    one_way_drive_hours_to_centroid: Math.round(oneWayHours * 100) / 100,
+    is_overnight: isOvernight,
+    nights_per_trip: nightsPerTrip,
+    annual_nights: annualNights,
+    annual_hotel_cost: Math.round(annualHotelCost),
+    annual_per_diem_cost: Math.round(annualPerDiemCost),
+    annual_lodging_cost: Math.round(annualLodgingCost),
+  }
+}

--- a/api/v1/clients/[id]/manual-trips/suggest.ts
+++ b/api/v1/clients/[id]/manual-trips/suggest.ts
@@ -1,0 +1,237 @@
+// POST /api/v1/clients/[id]/manual-trips/suggest
+//
+// Smart trip suggestion. Walks the client's properties, clusters them
+// by their nearest branch + a density radius, and emits suggested
+// trips that the user can accept (POST to /manual-trips) or tweak.
+//
+// Body: { exclude_property_ids?: string[], cluster_radius_miles?: number }
+//   exclude_property_ids: properties already in saved trips that the
+//   user doesn't want to re-suggest. UI passes this so suggestions
+//   only cover unassigned properties.
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { createAdminClient } from '../../../../_lib/supabase.js'
+import { authenticateRequest } from '../../../../_lib/auth.js'
+import {
+  loadConstraints,
+  type SelectedBranch,
+} from '../../../../_lib/analysis/operational-constraints.js'
+import { haversineMiles, driveTimeMinutes } from '../../../../_lib/analysis/haversine.js'
+
+export const config = { maxDuration: 30 }
+
+const DEFAULT_CLUSTER_RADIUS_MILES = 30
+
+interface PropertyRow {
+  id: string
+  address_line1: string | null
+  city: string | null
+  state: string | null
+  latitude: number | null
+  longitude: number | null
+}
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'POST') return res.status(405).json({ error: 'Method not allowed' })
+  try {
+    await authenticateRequest(req)
+  } catch (err: any) {
+    return res.status(err.statusCode ?? 401).json({ error: err.message ?? 'Unauthorized' })
+  }
+  const clientId = req.query.id as string
+  if (!clientId) return res.status(400).json({ error: 'client id required' })
+  const db = createAdminClient()
+
+  const { data: clientRow } = await db
+    .from('clients')
+    .select('account_id')
+    .eq('id', clientId)
+    .maybeSingle()
+  const accountId = (clientRow as any)?.account_id as string | undefined
+  if (!accountId) return res.status(404).json({ error: 'Client not found' })
+
+  const constraints = await loadConstraints(db, accountId, clientId)
+  const branches: SelectedBranch[] = constraints.selected_branches ?? []
+  if (branches.length === 0) {
+    return res.status(400).json({
+      error: 'No branches selected. Confirm a branch selection first.',
+    })
+  }
+  const driveSpeed = constraints.drive_speed_mph ?? 60
+  const triggerHours =
+    constraints.hotel_cost_config?.overnight_trigger_one_way_hours ?? 3
+
+  const body = (req.body ?? {}) as Record<string, unknown>
+  const exclude = new Set(
+    Array.isArray(body.exclude_property_ids)
+      ? (body.exclude_property_ids as string[])
+      : []
+  )
+  const clusterRadius = Number.isFinite(body.cluster_radius_miles as number)
+    ? Math.max(5, Number(body.cluster_radius_miles))
+    : DEFAULT_CLUSTER_RADIUS_MILES
+
+  // Pull all properties that have at least one SL on this client.
+  const { data: slRows } = await db
+    .from('service_locations')
+    .select('property_id')
+    .eq('client_id', clientId)
+  const propIds = Array.from(
+    new Set((slRows ?? []).map((r) => (r as any).property_id as string))
+  ).filter((id) => !exclude.has(id))
+  if (propIds.length === 0) {
+    return res.status(200).json({ suggestions: [] })
+  }
+  const properties: PropertyRow[] = []
+  for (let i = 0; i < propIds.length; i += 250) {
+    const chunk = propIds.slice(i, i + 250)
+    const { data } = await db
+      .from('properties')
+      .select('id, address_line1, city, state, latitude, longitude')
+      .in('id', chunk)
+    for (const p of data ?? []) properties.push(p as PropertyRow)
+  }
+
+  // 1. Bucket each property into "remote enough to suggest as a trip"
+  //    (drive-hours from nearest branch > overnight threshold) vs
+  //    "day-trip" (close enough that a trip isn't useful — already
+  //    covered by routine routing).
+  type Bucket = { branchIdx: number; props: PropertyRow[] }
+  const remoteByBranch = new Map<number, PropertyRow[]>()
+  for (const p of properties) {
+    if (p.latitude == null || p.longitude == null) continue
+    let bestIdx = 0
+    let bestDist = Infinity
+    for (let i = 0; i < branches.length; i++) {
+      const d = haversineMiles(
+        { lat: p.latitude, lng: p.longitude },
+        { lat: branches[i].lat, lng: branches[i].lng }
+      )
+      if (d < bestDist) {
+        bestDist = d
+        bestIdx = i
+      }
+    }
+    const oneWayHr = driveTimeMinutes(bestDist, driveSpeed) / 60
+    if (oneWayHr > triggerHours) {
+      const arr = remoteByBranch.get(bestIdx) ?? []
+      arr.push(p)
+      remoteByBranch.set(bestIdx, arr)
+    }
+  }
+
+  // 2. Density-cluster the remote properties within clusterRadius
+  //    of each other, per-branch (a Frisco-anchored trip shouldn't
+  //    pull in an Albuquerque-anchored property even if they happen
+  //    to be near each other).
+  type Suggestion = {
+    suggested_name: string
+    branch_name: string
+    branch_city_state: string | null
+    property_ids: string[]
+    addresses: string[]
+    centroid_lat: number
+    centroid_lng: number
+    one_way_drive_hours_to_centroid: number
+    miles_per_trip_estimate: number
+    estimated_nights_per_trip: number
+    rationale: string
+  }
+  const suggestions: Suggestion[] = []
+  for (const [branchIdx, props] of remoteByBranch) {
+    const clusters = densityCluster(
+      props.map((p) => ({ id: p.id, lat: p.latitude!, lng: p.longitude! })),
+      clusterRadius
+    )
+    const branch = branches[branchIdx]
+    for (let ci = 0; ci < clusters.length; ci++) {
+      const ids = clusters[ci]
+      const inCluster = props.filter((p) => ids.has(p.id))
+      if (inCluster.length === 0) continue
+
+      const lats = inCluster.map((p) => p.latitude!)
+      const lngs = inCluster.map((p) => p.longitude!)
+      const cLat = lats.reduce((s, v) => s + v, 0) / lats.length
+      const cLng = lngs.reduce((s, v) => s + v, 0) / lngs.length
+      const distMi = haversineMiles(
+        { lat: branch.lat, lng: branch.lng },
+        { lat: cLat, lng: cLng }
+      )
+      const oneWayHours = driveTimeMinutes(distMi, driveSpeed) / 60
+      // Mileage estimate: 2× one-way (out+back) + half the
+      // intra-cluster spread as a rough proxy for between-stops drives.
+      let intraSum = 0
+      for (let i = 0; i < inCluster.length - 1; i++) {
+        intraSum += haversineMiles(
+          { lat: inCluster[i].latitude!, lng: inCluster[i].longitude! },
+          { lat: inCluster[i + 1].latitude!, lng: inCluster[i + 1].longitude! }
+        )
+      }
+      const milesEstimate = distMi * 2 + intraSum
+
+      // Build a short, human label from city/state of first prop +
+      // count, e.g. "Albuquerque NM area (8 properties)".
+      const firstCity = inCluster[0].city ?? ''
+      const firstState = inCluster[0].state ?? ''
+      const labelLoc = firstCity && firstState
+        ? `${firstCity} ${firstState}`
+        : firstCity || firstState || 'cluster'
+
+      suggestions.push({
+        suggested_name: `${labelLoc} (${inCluster.length} properties)`,
+        branch_name: branch.name,
+        branch_city_state: branch.city_state ?? null,
+        property_ids: inCluster.map((p) => p.id),
+        addresses: inCluster.map(
+          (p) => p.address_line1 ?? `${p.id.slice(0, 8)}…`
+        ),
+        centroid_lat: cLat,
+        centroid_lng: cLng,
+        one_way_drive_hours_to_centroid: Math.round(oneWayHours * 100) / 100,
+        miles_per_trip_estimate: Math.round(milesEstimate * 10) / 10,
+        estimated_nights_per_trip: Math.max(1, inCluster.length),
+        rationale: `${inCluster.length} properties within ${clusterRadius} mi of each other, ${Math.round(oneWayHours * 10) / 10} hr drive from ${branch.name}.`,
+      })
+    }
+  }
+
+  // Largest first — those are the highest-leverage trip suggestions.
+  suggestions.sort((a, b) => b.property_ids.length - a.property_ids.length)
+  return res.status(200).json({ suggestions })
+}
+
+// Single-link agglomerative density clustering: union-find any two
+// items within `radiusMiles` of each other. O(n²) pairwise check —
+// fine for the property volumes this endpoint handles.
+function densityCluster<T extends { id: string; lat: number; lng: number }>(
+  items: T[],
+  radiusMiles: number
+): Array<Set<string>> {
+  if (items.length === 0) return []
+  const parent = items.map((_, i) => i)
+  const find = (i: number): number => {
+    while (parent[i] !== i) {
+      parent[i] = parent[parent[i]]
+      i = parent[i]
+    }
+    return i
+  }
+  const union = (a: number, b: number) => {
+    const ra = find(a)
+    const rb = find(b)
+    if (ra !== rb) parent[ra] = rb
+  }
+  for (let i = 0; i < items.length; i++) {
+    for (let j = i + 1; j < items.length; j++) {
+      const d = haversineMiles(items[i], items[j])
+      if (d <= radiusMiles) union(i, j)
+    }
+  }
+  const groups = new Map<number, Set<string>>()
+  for (let i = 0; i < items.length; i++) {
+    const r = find(i)
+    const set = groups.get(r) ?? new Set<string>()
+    set.add(items[i].id)
+    groups.set(r, set)
+  }
+  return Array.from(groups.values())
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,6 +38,7 @@ import NewTemplatePage from './pages/accounts/scheduler/NewTemplate'
 import TemplateDetailPage from './pages/accounts/scheduler/TemplateDetail'
 import CycleComparePage from './pages/accounts/scheduler/CycleCompare'
 import CycleDetailPage from './pages/accounts/scheduler/CycleDetail'
+import TravelPlannerPage from './pages/accounts/TravelPlanner'
 import NewAccountClientPage from './pages/accounts/NewAccountClient'
 import ClientsListPage from './pages/clients/ClientsList'
 import NewClientPage from './pages/clients/NewClient'
@@ -169,6 +170,10 @@ export default function App() {
           <Route
             path="/accounts/:accountId/clients/:clientId/scheduler/compare"
             element={<AuthGuard><CycleComparePage /></AuthGuard>}
+          />
+          <Route
+            path="/accounts/:accountId/clients/:clientId/travel"
+            element={<AuthGuard><TravelPlannerPage /></AuthGuard>}
           />
           <Route path="/accounts/:id/clients/new" element={<AuthGuard><NewAccountClientPage /></AuthGuard>} />
 

--- a/src/pages/accounts/AccountAnalysis.tsx
+++ b/src/pages/accounts/AccountAnalysis.tsx
@@ -9,6 +9,7 @@ import {
   ListChecks,
   Map as MapIcon,
   Pencil,
+  Plane,
   Sparkles,
 } from 'lucide-react'
 import { useAuth } from '../../hooks/useAuth'
@@ -1266,6 +1267,12 @@ function AnalysisSidebar({
           to={`/accounts/${accountId}/clients/${clientId}/scheduler/templates`}
         >
           Routing templates
+        </SidebarItem>
+        <SidebarItem
+          icon={Plane}
+          to={`/accounts/${accountId}/clients/${clientId}/travel`}
+        >
+          Travel & trips
         </SidebarItem>
       </SidebarSection>
 

--- a/src/pages/accounts/TravelPlanner.tsx
+++ b/src/pages/accounts/TravelPlanner.tsx
@@ -1,0 +1,830 @@
+// Travel & trip planner page —
+// /accounts/:accountId/clients/:clientId/travel
+//
+// Surfaces every property the client serves with its assigned branch
+// + drive miles, lets the user group properties into trips, and
+// computes annual nights / miles / cost for each saved trip. The
+// "Suggest trips" action wraps the existing density-cluster math to
+// propose groupings the user can accept verbatim.
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useParams } from 'react-router-dom'
+import { Plus, Sparkles, Trash2, Pencil, MapPin, Route } from 'lucide-react'
+import { useAuth } from '../../hooks/useAuth'
+import AppShell from '../../components/layout/AppShell'
+import Button from '../../components/ui/Button'
+import { Badge } from '../../components/ui/Badge'
+import { Card, CardTitle, CardDescription } from '../../components/ui/Card'
+import { Input, FormField, Textarea } from '../../components/ui/Input'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '../../components/ui/Dialog'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '../../components/ui/Table'
+
+interface TravelProperty {
+  property_id: string
+  address_line1: string | null
+  city: string | null
+  state: string | null
+  lat: number | null
+  lng: number | null
+  assigned_branch: string | null
+  assigned_branch_city_state: string | null
+  miles_to_branch: number
+  drive_minutes_to_branch: number
+}
+
+interface ManualTripWithMetrics {
+  id: string
+  name: string
+  branch_name: string
+  property_ids: string[]
+  visits_per_year: number
+  notes: string | null
+  property_count: number
+  properties_missing_coords: number
+  miles_per_trip: number
+  annual_miles: number
+  one_way_drive_hours_to_centroid: number
+  is_overnight: boolean
+  nights_per_trip: number
+  annual_nights: number
+  annual_hotel_cost: number
+  annual_per_diem_cost: number
+  annual_lodging_cost: number
+}
+
+interface BranchInfo {
+  name: string
+  city_state: string | null
+  lat: number
+  lng: number
+}
+
+interface Suggestion {
+  suggested_name: string
+  branch_name: string
+  branch_city_state: string | null
+  property_ids: string[]
+  addresses: string[]
+  one_way_drive_hours_to_centroid: number
+  miles_per_trip_estimate: number
+  estimated_nights_per_trip: number
+  rationale: string
+}
+
+export default function TravelPlannerPage() {
+  const { accountId, clientId } = useParams<{ accountId: string; clientId: string }>()
+  const { getToken } = useAuth()
+  const [trips, setTrips] = useState<ManualTripWithMetrics[]>([])
+  const [properties, setProperties] = useState<TravelProperty[]>([])
+  const [branches, setBranches] = useState<BranchInfo[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [account, setAccount] = useState<{ name: string; display_name: string | null } | null>(null)
+  const [client, setClient] = useState<{ name: string; display_name: string | null } | null>(null)
+  const [creating, setCreating] = useState(false)
+  const [editing, setEditing] = useState<ManualTripWithMetrics | null>(null)
+  const [suggestions, setSuggestions] = useState<Suggestion[] | null>(null)
+  const [suggesting, setSuggesting] = useState(false)
+  const [propertyFilter, setPropertyFilter] = useState('')
+  const [branchFilter, setBranchFilter] = useState<string>('all')
+
+  const refresh = useCallback(async () => {
+    if (!clientId || !accountId) return
+    setLoading(true)
+    setError(null)
+    try {
+      const token = await getToken()
+      const [tripsRes, accRes, cliRes] = await Promise.all([
+        fetch(`/api/v1/clients/${clientId}/manual-trips`, {
+          headers: { Authorization: `Bearer ${token}` },
+        }),
+        fetch(`/api/accounts/${accountId}`, {
+          headers: { Authorization: `Bearer ${token}` },
+        }),
+        fetch(`/api/v1/clients/${clientId}`, {
+          headers: { Authorization: `Bearer ${token}` },
+        }),
+      ])
+      if (!tripsRes.ok) throw new Error(`HTTP ${tripsRes.status}`)
+      const tripsJson = await tripsRes.json()
+      setTrips(tripsJson.trips ?? [])
+      setProperties(tripsJson.properties ?? [])
+      setBranches(tripsJson.branches ?? [])
+      if (accRes.ok) {
+        const j = await accRes.json()
+        setAccount(j.account ?? j)
+      }
+      if (cliRes.ok) setClient(await cliRes.json())
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setLoading(false)
+    }
+  }, [accountId, clientId, getToken])
+
+  useEffect(() => {
+    refresh()
+  }, [refresh])
+
+  const propsInTrips = useMemo(() => {
+    const s = new Set<string>()
+    for (const t of trips) for (const id of t.property_ids) s.add(id)
+    return s
+  }, [trips])
+
+  const filteredProperties = useMemo(() => {
+    const q = propertyFilter.trim().toLowerCase()
+    return properties.filter((p) => {
+      if (branchFilter !== 'all' && p.assigned_branch !== branchFilter) return false
+      if (!q) return true
+      const hay = `${p.address_line1 ?? ''} ${p.city ?? ''} ${p.state ?? ''} ${p.assigned_branch_city_state ?? ''}`.toLowerCase()
+      return hay.includes(q)
+    })
+  }, [properties, propertyFilter, branchFilter])
+
+  const totalAnnualNights = trips.reduce((s, t) => s + t.annual_nights, 0)
+  const totalAnnualMiles = trips.reduce((s, t) => s + t.annual_miles, 0)
+  const totalAnnualLodging = trips.reduce((s, t) => s + t.annual_lodging_cost, 0)
+
+  const suggestTrips = async () => {
+    if (!clientId) return
+    setSuggesting(true)
+    setError(null)
+    try {
+      const token = await getToken()
+      const res = await fetch(`/api/v1/clients/${clientId}/manual-trips/suggest`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({
+          exclude_property_ids: Array.from(propsInTrips),
+        }),
+      })
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}))
+        throw new Error((j as any).error ?? `HTTP ${res.status}`)
+      }
+      const j = await res.json()
+      setSuggestions(j.suggestions ?? [])
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setSuggesting(false)
+    }
+  }
+
+  const acceptSuggestion = async (s: Suggestion) => {
+    if (!clientId) return
+    try {
+      const token = await getToken()
+      const res = await fetch(`/api/v1/clients/${clientId}/manual-trips`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({
+          name: s.suggested_name,
+          branch_name: s.branch_name,
+          property_ids: s.property_ids,
+          visits_per_year: 2,
+        }),
+      })
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}))
+        throw new Error((j as any).error ?? `HTTP ${res.status}`)
+      }
+      // Hide accepted suggestion from the list
+      setSuggestions((prev) =>
+        prev ? prev.filter((x) => x.suggested_name !== s.suggested_name) : prev
+      )
+      await refresh()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    }
+  }
+
+  const deleteTrip = async (tripId: string) => {
+    if (!clientId) return
+    if (!confirm('Delete this trip?')) return
+    try {
+      const token = await getToken()
+      const res = await fetch(`/api/v1/clients/${clientId}/manual-trips`, {
+        method: 'DELETE',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ trip_id: tripId }),
+      })
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}))
+        throw new Error((j as any).error ?? `HTTP ${res.status}`)
+      }
+      await refresh()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    }
+  }
+
+  return (
+    <AppShell
+      breadcrumb={[
+        { label: 'Accounts', to: '/accounts' },
+        { label: account?.display_name ?? account?.name ?? '…', to: `/accounts/${accountId}` },
+        { label: client?.display_name ?? client?.name ?? '…' },
+        { label: 'Travel & trips' },
+      ]}
+    >
+      <div className="mx-auto max-w-6xl px-6 py-10 space-y-6">
+        <header className="flex items-start justify-between gap-6 flex-wrap">
+          <div className="space-y-1 min-w-0">
+            <h1 className="text-2xl font-semibold tracking-tight text-fg">
+              Travel & trip planner
+            </h1>
+            <p className="text-sm text-fg-muted max-w-2xl">
+              Group properties into trips. The system computes nights,
+              fuel miles, and lodging cost from your trips. These override
+              the auto-clustered overnight calculation in Bid Pricing.
+            </p>
+          </div>
+          <div className="flex items-center gap-2">
+            <Button variant="secondary" onClick={suggestTrips} loading={suggesting}>
+              <Sparkles className="h-4 w-4" />
+              Suggest trips
+            </Button>
+            <Button onClick={() => setCreating(true)}>
+              <Plus className="h-4 w-4" />
+              New trip
+            </Button>
+          </div>
+        </header>
+
+        {error && (
+          <p className="text-sm text-danger">Error: {error}</p>
+        )}
+
+        {loading ? (
+          <p className="text-sm text-fg-muted">Loading…</p>
+        ) : (
+          <>
+            {/* Aggregate stats */}
+            <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+              <Card padding="sm">
+                <p className="text-[10px] uppercase tracking-wider text-fg-subtle">Trips</p>
+                <p className="mt-1 font-mono text-2xl font-semibold tabular-nums text-fg">
+                  {trips.length}
+                </p>
+              </Card>
+              <Card padding="sm">
+                <p className="text-[10px] uppercase tracking-wider text-fg-subtle">Annual nights</p>
+                <p className="mt-1 font-mono text-2xl font-semibold tabular-nums text-fg">
+                  {totalAnnualNights.toLocaleString()}
+                </p>
+              </Card>
+              <Card padding="sm">
+                <p className="text-[10px] uppercase tracking-wider text-fg-subtle">Annual miles</p>
+                <p className="mt-1 font-mono text-2xl font-semibold tabular-nums text-fg">
+                  {Math.round(totalAnnualMiles).toLocaleString()}
+                </p>
+              </Card>
+              <Card padding="sm">
+                <p className="text-[10px] uppercase tracking-wider text-fg-subtle">Annual lodging</p>
+                <p className="mt-1 font-mono text-2xl font-semibold tabular-nums text-fg">
+                  ${totalAnnualLodging.toLocaleString()}
+                </p>
+              </Card>
+            </div>
+
+            {/* Suggestions panel */}
+            {suggestions && suggestions.length > 0 && (
+              <Card padding="md" className="border-accent/40 bg-accent-subtle/40">
+                <div className="flex items-baseline justify-between gap-2 flex-wrap">
+                  <CardTitle>
+                    <Sparkles className="inline h-4 w-4 mr-1.5 text-accent" />
+                    Suggested trips
+                  </CardTitle>
+                  <button
+                    type="button"
+                    className="text-xs text-fg-subtle hover:text-fg"
+                    onClick={() => setSuggestions(null)}
+                  >
+                    Dismiss
+                  </button>
+                </div>
+                <CardDescription>
+                  Auto-clustered from properties not yet in a trip.
+                  Click "Accept" to save as-is or copy the IDs into a new
+                  manual trip if you want to adjust.
+                </CardDescription>
+                <ul className="mt-3 space-y-2">
+                  {suggestions.map((s, i) => (
+                    <li
+                      key={i}
+                      className="rounded-md border border-border bg-surface p-3"
+                    >
+                      <div className="flex items-baseline justify-between gap-3 flex-wrap">
+                        <div>
+                          <p className="font-semibold text-fg">{s.suggested_name}</p>
+                          <p className="text-xs text-fg-muted mt-0.5">
+                            {s.rationale}
+                          </p>
+                        </div>
+                        <Button size="sm" onClick={() => acceptSuggestion(s)}>
+                          Accept
+                        </Button>
+                      </div>
+                      <div className="mt-2 grid grid-cols-2 sm:grid-cols-4 gap-2 text-xs text-fg-muted">
+                        <div>
+                          <span className="text-fg-subtle">Properties:</span>{' '}
+                          <span className="font-tabular text-fg">{s.property_ids.length}</span>
+                        </div>
+                        <div>
+                          <span className="text-fg-subtle">Drive:</span>{' '}
+                          <span className="font-tabular text-fg">
+                            {s.one_way_drive_hours_to_centroid} hr
+                          </span>
+                        </div>
+                        <div>
+                          <span className="text-fg-subtle">Miles/trip:</span>{' '}
+                          <span className="font-tabular text-fg">
+                            {s.miles_per_trip_estimate}
+                          </span>
+                        </div>
+                        <div>
+                          <span className="text-fg-subtle">Nights/trip:</span>{' '}
+                          <span className="font-tabular text-fg">
+                            {s.estimated_nights_per_trip}
+                          </span>
+                        </div>
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              </Card>
+            )}
+            {suggestions && suggestions.length === 0 && (
+              <Card padding="md">
+                <p className="text-sm text-fg-muted">
+                  No more trip suggestions — every remote property is
+                  already in a saved trip, or no clusters meet the
+                  overnight threshold.
+                </p>
+              </Card>
+            )}
+
+            {/* Saved trips */}
+            <section className="space-y-2">
+              <h2 className="text-sm font-semibold text-fg">Saved trips ({trips.length})</h2>
+              {trips.length === 0 ? (
+                <Card padding="md">
+                  <p className="text-sm text-fg-muted">
+                    No trips saved yet. Click "Suggest trips" to auto-group
+                    your remote properties, or "New trip" to build one
+                    manually.
+                  </p>
+                </Card>
+              ) : (
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                  {trips.map((t) => (
+                    <Card key={t.id} padding="md">
+                      <div className="flex items-start justify-between gap-3">
+                        <div className="min-w-0 flex-1">
+                          <CardTitle>{t.name}</CardTitle>
+                          <p className="text-xs text-fg-muted mt-0.5">
+                            <Route className="inline h-3 w-3 mr-1" />
+                            from {t.branch_name} ·{' '}
+                            <span className="font-tabular">{t.property_count}</span>{' '}
+                            propert
+                            {t.property_count === 1 ? 'y' : 'ies'}
+                          </p>
+                        </div>
+                        <div className="flex gap-1">
+                          <button
+                            type="button"
+                            onClick={() => setEditing(t)}
+                            className="text-fg-subtle hover:text-accent"
+                          >
+                            <Pencil className="h-3.5 w-3.5" />
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => deleteTrip(t.id)}
+                            className="text-fg-subtle hover:text-danger"
+                          >
+                            <Trash2 className="h-3.5 w-3.5" />
+                          </button>
+                        </div>
+                      </div>
+                      {t.is_overnight ? (
+                        <Badge variant="warning" className="mt-2 text-[10px]">
+                          Overnight ({t.one_way_drive_hours_to_centroid} hr drive)
+                        </Badge>
+                      ) : (
+                        <Badge variant="outline" className="mt-2 text-[10px]">
+                          Day-trip
+                        </Badge>
+                      )}
+                      <dl className="mt-3 grid grid-cols-2 gap-2 text-xs">
+                        <Stat label="Visits/yr" value={t.visits_per_year} />
+                        <Stat label="Nights/trip" value={t.nights_per_trip} />
+                        <Stat label="Annual nights" value={t.annual_nights} />
+                        <Stat label="Annual miles" value={Math.round(t.annual_miles).toLocaleString()} />
+                        <Stat
+                          label="Annual lodging"
+                          value={`$${t.annual_lodging_cost.toLocaleString()}`}
+                        />
+                        <Stat label="Miles/trip" value={t.miles_per_trip} />
+                      </dl>
+                      {t.properties_missing_coords > 0 && (
+                        <p className="mt-2 text-[11px] text-warning">
+                          ⚠ {t.properties_missing_coords} propert
+                          {t.properties_missing_coords === 1 ? 'y has' : 'ies have'} missing
+                          lat/lng — excluded from miles + nights math.
+                        </p>
+                      )}
+                      {t.notes && (
+                        <p className="mt-2 text-xs italic text-fg-muted border-t border-border pt-2">
+                          {t.notes}
+                        </p>
+                      )}
+                    </Card>
+                  ))}
+                </div>
+              )}
+            </section>
+
+            {/* Property table */}
+            <section className="space-y-2">
+              <div className="flex items-baseline justify-between gap-3 flex-wrap">
+                <h2 className="text-sm font-semibold text-fg">
+                  Properties ({properties.length})
+                </h2>
+                <div className="flex items-center gap-2">
+                  <Input
+                    placeholder="Filter by address / city / state…"
+                    value={propertyFilter}
+                    onChange={(e) => setPropertyFilter(e.target.value)}
+                    className="max-w-xs h-8 text-xs"
+                  />
+                  <select
+                    value={branchFilter}
+                    onChange={(e) => setBranchFilter(e.target.value)}
+                    className="h-8 rounded-md border border-border bg-surface px-2 text-xs text-fg"
+                  >
+                    <option value="all">All branches</option>
+                    {branches.map((b) => (
+                      <option key={b.name} value={b.name}>
+                        {b.city_state || b.name}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              </div>
+              <div className="rounded-md border border-border bg-surface overflow-hidden">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Property</TableHead>
+                      <TableHead>Branch</TableHead>
+                      <TableHead className="text-right">Distance</TableHead>
+                      <TableHead className="text-right">Drive</TableHead>
+                      <TableHead>Trip</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {filteredProperties.slice(0, 200).map((p) => {
+                      const inTrip = trips.find((t) => t.property_ids.includes(p.property_id))
+                      return (
+                        <TableRow key={p.property_id}>
+                          <TableCell className="text-fg">
+                            <p className="font-medium">{p.address_line1 ?? '—'}</p>
+                            <p className="text-xs text-fg-subtle">
+                              {p.city}{p.city && p.state ? ', ' : ''}{p.state}
+                            </p>
+                          </TableCell>
+                          <TableCell className="text-xs text-fg-muted">
+                            <MapPin className="inline h-3 w-3 mr-0.5" />
+                            {p.assigned_branch_city_state ?? p.assigned_branch ?? '—'}
+                          </TableCell>
+                          <TableCell numeric className="text-xs">
+                            {p.miles_to_branch != null ? `${p.miles_to_branch} mi` : '—'}
+                          </TableCell>
+                          <TableCell numeric className="text-xs text-fg-muted">
+                            {p.drive_minutes_to_branch
+                              ? `${p.drive_minutes_to_branch} min`
+                              : '—'}
+                          </TableCell>
+                          <TableCell className="text-xs">
+                            {inTrip ? (
+                              <Badge variant="accent" className="text-[10px]">
+                                {inTrip.name}
+                              </Badge>
+                            ) : (
+                              <span className="text-fg-subtle italic">unassigned</span>
+                            )}
+                          </TableCell>
+                        </TableRow>
+                      )
+                    })}
+                  </TableBody>
+                </Table>
+                {filteredProperties.length > 200 && (
+                  <p className="px-4 py-2 text-xs text-fg-muted bg-surface-subtle">
+                    Showing first 200 of {filteredProperties.length}. Filter
+                    to narrow the list.
+                  </p>
+                )}
+              </div>
+            </section>
+          </>
+        )}
+      </div>
+
+      <TripDialog
+        open={creating || editing !== null}
+        onClose={() => {
+          setCreating(false)
+          setEditing(null)
+        }}
+        clientId={clientId!}
+        existingTrip={editing}
+        properties={properties}
+        branches={branches}
+        propsAlreadyInOtherTrips={
+          editing
+            ? new Set(
+                Array.from(propsInTrips).filter(
+                  (id) => !editing.property_ids.includes(id)
+                )
+              )
+            : propsInTrips
+        }
+        onSaved={() => {
+          setCreating(false)
+          setEditing(null)
+          refresh()
+        }}
+      />
+    </AppShell>
+  )
+}
+
+function Stat({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div>
+      <dt className="text-[10px] uppercase tracking-wider text-fg-subtle">{label}</dt>
+      <dd className="font-mono text-sm font-semibold tabular-nums text-fg">{value}</dd>
+    </div>
+  )
+}
+
+function TripDialog({
+  open,
+  onClose,
+  clientId,
+  existingTrip,
+  properties,
+  branches,
+  propsAlreadyInOtherTrips,
+  onSaved,
+}: {
+  open: boolean
+  onClose: () => void
+  clientId: string
+  existingTrip: ManualTripWithMetrics | null
+  properties: TravelProperty[]
+  branches: BranchInfo[]
+  propsAlreadyInOtherTrips: Set<string>
+  onSaved: () => void
+}) {
+  const { getToken } = useAuth()
+  const [name, setName] = useState('')
+  const [branchName, setBranchName] = useState('')
+  const [visitsPerYear, setVisitsPerYear] = useState('2')
+  const [notes, setNotes] = useState('')
+  const [selected, setSelected] = useState<Set<string>>(new Set())
+  const [filter, setFilter] = useState('')
+  const [saving, setSaving] = useState(false)
+  const [err, setErr] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (open) {
+      if (existingTrip) {
+        setName(existingTrip.name)
+        setBranchName(existingTrip.branch_name)
+        setVisitsPerYear(String(existingTrip.visits_per_year))
+        setNotes(existingTrip.notes ?? '')
+        setSelected(new Set(existingTrip.property_ids))
+      } else {
+        setName('')
+        setBranchName(branches[0]?.name ?? '')
+        setVisitsPerYear('2')
+        setNotes('')
+        setSelected(new Set())
+      }
+      setFilter('')
+      setErr(null)
+    }
+  }, [open, existingTrip, branches])
+
+  const filteredProps = useMemo(() => {
+    const q = filter.trim().toLowerCase()
+    return properties.filter((p) => {
+      if (propsAlreadyInOtherTrips.has(p.property_id)) return false
+      if (branchName && p.assigned_branch && p.assigned_branch !== branchName) {
+        // Don't filter strictly by branch — user might want to drag a
+        // property in from another branch. Just deprioritize visually.
+      }
+      if (!q) return true
+      const hay = `${p.address_line1 ?? ''} ${p.city ?? ''} ${p.state ?? ''}`.toLowerCase()
+      return hay.includes(q)
+    })
+  }, [properties, propsAlreadyInOtherTrips, filter, branchName])
+
+  const toggle = (id: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }
+
+  const save = async () => {
+    if (!name.trim()) {
+      setErr('Name is required')
+      return
+    }
+    if (!branchName) {
+      setErr('Branch is required')
+      return
+    }
+    if (selected.size === 0) {
+      setErr('Select at least one property')
+      return
+    }
+    setSaving(true)
+    setErr(null)
+    try {
+      const token = await getToken()
+      const payload = {
+        name: name.trim(),
+        branch_name: branchName,
+        property_ids: Array.from(selected),
+        visits_per_year: Math.max(1, Math.floor(Number(visitsPerYear) || 1)),
+        notes: notes.trim() || null,
+      }
+      const res = await fetch(`/api/v1/clients/${clientId}/manual-trips`, {
+        method: existingTrip ? 'PATCH' : 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify(
+          existingTrip ? { ...payload, trip_id: existingTrip.id } : payload
+        ),
+      })
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}))
+        throw new Error((j as any).error ?? `HTTP ${res.status}`)
+      }
+      onSaved()
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => !o && !saving && onClose()}>
+      <DialogContent className="max-w-3xl">
+        <DialogHeader>
+          <DialogTitle>{existingTrip ? 'Edit trip' : 'New trip'}</DialogTitle>
+          <DialogDescription>
+            Group properties served on the same trip. Drives nights / fuel
+            cost in Bid Pricing.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-3 max-h-[60vh] overflow-y-auto pr-1 -mr-1">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <FormField label="Name">
+              <Input value={name} onChange={(e) => setName(e.target.value)} placeholder="e.g. Albuquerque area" />
+            </FormField>
+            <FormField label="Branch">
+              <select
+                value={branchName}
+                onChange={(e) => setBranchName(e.target.value)}
+                className="h-9 w-full rounded-md border border-border bg-surface px-3 text-sm text-fg"
+              >
+                {branches.length === 0 && <option value="">(no branches)</option>}
+                {branches.map((b) => (
+                  <option key={b.name} value={b.name}>
+                    {b.city_state || b.name}
+                  </option>
+                ))}
+              </select>
+            </FormField>
+            <FormField label="Visits per year">
+              <Input
+                type="number"
+                min={1}
+                value={visitsPerYear}
+                onChange={(e) => setVisitsPerYear(e.target.value)}
+              />
+            </FormField>
+            <FormField label="Notes (optional)">
+              <Textarea rows={1} value={notes} onChange={(e) => setNotes(e.target.value)} />
+            </FormField>
+          </div>
+          <div className="space-y-2">
+            <div className="flex items-baseline justify-between gap-2">
+              <p className="text-xs font-semibold text-fg">
+                Properties ({selected.size} selected)
+              </p>
+              <Input
+                placeholder="Filter…"
+                value={filter}
+                onChange={(e) => setFilter(e.target.value)}
+                className="max-w-xs h-7 text-xs"
+              />
+            </div>
+            <div className="rounded-md border border-border max-h-[40vh] overflow-y-auto">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead className="w-8" />
+                    <TableHead>Property</TableHead>
+                    <TableHead>Branch</TableHead>
+                    <TableHead className="text-right">Distance</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {filteredProps.slice(0, 300).map((p) => {
+                    const isSel = selected.has(p.property_id)
+                    return (
+                      <TableRow key={p.property_id}>
+                        <TableCell className="w-8">
+                          <input
+                            type="checkbox"
+                            checked={isSel}
+                            onChange={() => toggle(p.property_id)}
+                            className="rounded border-border accent-accent"
+                          />
+                        </TableCell>
+                        <TableCell className="text-xs">
+                          <p className="font-medium text-fg">{p.address_line1 ?? '—'}</p>
+                          <p className="text-fg-subtle">
+                            {p.city}{p.city && p.state ? ', ' : ''}{p.state}
+                          </p>
+                        </TableCell>
+                        <TableCell className="text-xs text-fg-muted">
+                          {p.assigned_branch_city_state ?? p.assigned_branch ?? '—'}
+                        </TableCell>
+                        <TableCell numeric className="text-xs">
+                          {p.miles_to_branch} mi
+                        </TableCell>
+                      </TableRow>
+                    )
+                  })}
+                </TableBody>
+              </Table>
+              {filteredProps.length > 300 && (
+                <p className="px-3 py-2 text-xs text-fg-muted bg-surface-subtle">
+                  Showing first 300 of {filteredProps.length}. Filter to narrow.
+                </p>
+              )}
+            </div>
+          </div>
+        </div>
+        <DialogFooter>
+          {err && (
+            <p className="text-xs text-danger flex-1 sm:text-left text-center self-center">
+              {err}
+            </p>
+          )}
+          <Button variant="ghost" onClick={onClose} disabled={saving}>Cancel</Button>
+          <Button onClick={save} loading={saving}>
+            {existingTrip ? 'Save changes' : 'Create trip'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/supabase/migrations/20260501014921_phase_4_2_manual_trips.sql
+++ b/supabase/migrations/20260501014921_phase_4_2_manual_trips.sql
@@ -1,0 +1,23 @@
+-- Phase 4.2 — manual trip planner.
+--
+-- The overnight calculator auto-clusters properties using a drive-time
+-- threshold. The trip planner gives the user manual control: they
+-- group specific properties into a named trip, the system computes
+-- nights + miles + hotel cost for that trip, and Bid Pricing can use
+-- the manual trips as overrides instead of the auto-clusters.
+
+CREATE TABLE IF NOT EXISTS public.manual_trips (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  account_id      uuid NOT NULL REFERENCES public.accounts(id) ON DELETE CASCADE,
+  client_id       uuid NOT NULL REFERENCES public.clients(id) ON DELETE CASCADE,
+  name            text NOT NULL,
+  branch_name     text NOT NULL,
+  property_ids    uuid[] NOT NULL DEFAULT '{}',
+  visits_per_year int  NOT NULL DEFAULT 1,
+  notes           text,
+  created_at      timestamptz NOT NULL DEFAULT now(),
+  updated_at      timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS manual_trips_account_client_idx
+  ON public.manual_trips(account_id, client_id);


### PR DESCRIPTION
## Summary
Dedicated travel/trips page so hotel nights + trip miles are modeled explicitly per client, not inferred by clustering at bid time.

- **Migration**: `manual_trips` table (already pushed to remote)
- **API**: `GET/POST/PATCH/DELETE /api/v1/clients/[id]/manual-trips` returns `{ trips, properties, branches, hotel_config }` with server-computed metrics. `POST /manual-trips/suggest` density-clusters remote properties per nearest branch.
- **Page**: `/accounts/:accountId/clients/:clientId/travel` — stats cards (Trips / Annual nights / Annual miles / Annual lodging), suggested trips with Accept buttons, saved trips grid with edit/delete, properties table with branch + drive distance + trip assignment, filters + search.
- **Nav**: New "Travel & trips" item in the Scheduler section of the AccountAnalysis sidebar.

## Out of scope (intentional)
- Auto-clustering override at bid time (deferred — comes after live use validates the inputs)
- Sharing trip definitions across clients

## Test plan
- [ ] `npx tsc --noEmit` clean (verified locally)
- [ ] `npm run build` clean (verified locally)
- [ ] Page loads at `/accounts/:accountId/clients/:clientId/travel`
- [ ] Suggested trips populate when remote properties exist beyond the overnight threshold
- [ ] Create / edit / delete trips persists and recomputes metrics
- [ ] Sidebar link routes correctly from any analysis module

🤖 Generated with [Claude Code](https://claude.com/claude-code)