### PR TITLE
Fix clipped Set-location button + add visible CTA banner

### DIFF
--- a/src/components/analysis/BuildSelectionModal.tsx
+++ b/src/components/analysis/BuildSelectionModal.tsx
@@ -230,8 +230,32 @@ export default function BuildSelectionModal({
           </DialogDescription>
         </DialogHeader>
 
+        {/* Empty-row CTA — direct affordance so the user doesn't have
+            to find the inline "Set location" button on a wide table. */}
+        {(() => {
+          const firstEmpty = rows.findIndex((r) => r.kind === 'empty')
+          if (firstEmpty < 0) return null
+          const emptyCount = rows.filter((r) => r.kind === 'empty').length
+          return (
+            <div className="flex items-center justify-between gap-3 rounded-md border border-warning/30 bg-warning-subtle px-3 py-2">
+              <p className="text-sm text-fg">
+                <span className="font-semibold">
+                  {emptyCount} row{emptyCount === 1 ? '' : 's'} need
+                  {emptyCount === 1 ? 's' : ''} a location.
+                </span>{' '}
+                <span className="text-fg-muted">
+                  Click below to set the location for row {firstEmpty + 1}.
+                </span>
+              </p>
+              <Button size="sm" onClick={() => setActivePicker(firstEmpty)}>
+                Set location for row {firstEmpty + 1}
+              </Button>
+            </div>
+          )
+        })()}
+
         {/* Branch rows */}
-        <div className="rounded-md border border-border bg-surface overflow-hidden">
+        <div className="rounded-md border border-border bg-surface overflow-x-auto">
           <Table>
             <TableHeader>
               <TableRow>


### PR DESCRIPTION
## Summary
The previous fix made the "Set location" button visually prominent (filled accent button instead of tiny text link), but the table wrapper still had \`overflow-hidden\` — at typical widths the action column was being clipped at the right edge of the dialog, so users still couldn't see or click any button on empty rows.

## Changes
- Table wrapper: \`overflow-hidden\` → \`overflow-x-auto\` so the column is always reachable.
- New banner above the table when any row lacks a location: yellow background, "N rows need a location" message, and a "Set location for row N" button that opens the picker directly. The user no longer has to find an in-row button at all.

## Test plan
- [ ] Open Crew Strategy → switch K from 3→4 → banner appears at top with "Set location for row 4"
- [ ] Click banner button → location picker opens immediately
- [ ] After all rows filled → banner disappears
- [ ] In-row button still visible/works at any reasonable dialog width

🤖 Generated with [Claude Code](https://claude.com/claude-code)