### PR TITLE
Fix travel planner branch label + uncap property list

### DIFF
--- a/src/pages/accounts/TravelPlanner.tsx
+++ b/src/pages/accounts/TravelPlanner.tsx
@@ -508,7 +508,7 @@ export default function TravelPlannerPage() {
                     </TableRow>
                   </TableHeader>
                   <TableBody>
-                    {filteredProperties.slice(0, 200).map((p) => {
+                    {filteredProperties.map((p) => {
                       const inTrip = trips.find((t) => t.property_ids.includes(p.property_id))
                       return (
                         <TableRow key={p.property_id}>
@@ -520,7 +520,7 @@ export default function TravelPlannerPage() {
                           </TableCell>
                           <TableCell className="text-xs text-fg-muted">
                             <MapPin className="inline h-3 w-3 mr-0.5" />
-                            {p.assigned_branch_city_state ?? p.assigned_branch ?? '—'}
+                            {p.assigned_branch_city_state || p.assigned_branch || '—'}
                           </TableCell>
                           <TableCell numeric className="text-xs">
                             {p.miles_to_branch != null ? `${p.miles_to_branch} mi` : '—'}
@@ -544,12 +544,6 @@ export default function TravelPlannerPage() {
                     })}
                   </TableBody>
                 </Table>
-                {filteredProperties.length > 200 && (
-                  <p className="px-4 py-2 text-xs text-fg-muted bg-surface-subtle">
-                    Showing first 200 of {filteredProperties.length}. Filter
-                    to narrow the list.
-                  </p>
-                )}
               </div>
             </section>
           </>


### PR DESCRIPTION
## Summary
Two small Travel Planner fixes:

- Properties assigned to an existing-infrastructure branch (e.g. Frisco) showed only the map-pin icon with no name. Cause: those branches are saved with \`city_state: ''\`, and the cell used \`??\` which only falls back on null. Switched to \`||\` so empty strings fall through to the branch name.
- Removed the 200-row cap on the properties table — users want to see all properties at once.

## Test plan
- [ ] Travel page → Properties table → all branches show their label
- [ ] Property row count matches total client property count (no truncation)
- [ ] tsc clean (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)