### PR TITLE
Fix trip-nights math + add Edit on suggested trips

### DIFF
--- a/api/v1/clients/[id]/manual-trips.ts
+++ b/api/v1/clients/[id]/manual-trips.ts
@@ -313,7 +313,10 @@ function annotateTrip(
   // for crew_size + work_hours; v1 keeps it simple and explicit.
   const isOvernight =
     oneWayHours > (hotelConfig?.overnight_trigger_one_way_hours ?? 3)
-  const nightsPerTrip = isOvernight ? Math.max(1, validProps.length) : 0
+  // Crew cleans one property on the arrival day and one on the departure
+  // day, so hotel nights = mid days only = property_count - 2 (floor of 1
+  // when the trip is overnight at all).
+  const nightsPerTrip = isOvernight ? Math.max(1, validProps.length - 2) : 0
   const annualNights = nightsPerTrip * Math.max(1, trip.visits_per_year ?? 1)
   const annualMiles = totalDriveMiles * Math.max(1, trip.visits_per_year ?? 1)
 

--- a/api/v1/clients/[id]/manual-trips/suggest.ts
+++ b/api/v1/clients/[id]/manual-trips/suggest.ts
@@ -188,7 +188,9 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         centroid_lng: cLng,
         one_way_drive_hours_to_centroid: Math.round(oneWayHours * 100) / 100,
         miles_per_trip_estimate: Math.round(milesEstimate * 10) / 10,
-        estimated_nights_per_trip: Math.max(1, inCluster.length),
+        // Clean one on arrival day, one on departure day → hotel nights
+        // = mid days = property_count - 2 (floor of 1).
+        estimated_nights_per_trip: Math.max(1, inCluster.length - 2),
         rationale: `${inCluster.length} properties within ${clusterRadius} mi of each other, ${Math.round(oneWayHours * 10) / 10} hr drive from ${branch.name}.`,
       })
     }

--- a/src/pages/accounts/TravelPlanner.tsx
+++ b/src/pages/accounts/TravelPlanner.tsx
@@ -96,6 +96,7 @@ export default function TravelPlannerPage() {
   const [client, setClient] = useState<{ name: string; display_name: string | null } | null>(null)
   const [creating, setCreating] = useState(false)
   const [editing, setEditing] = useState<ManualTripWithMetrics | null>(null)
+  const [editingSuggestion, setEditingSuggestion] = useState<Suggestion | null>(null)
   const [suggestions, setSuggestions] = useState<Suggestion[] | null>(null)
   const [suggesting, setSuggesting] = useState(false)
   const [propertyFilter, setPropertyFilter] = useState('')
@@ -345,9 +346,18 @@ export default function TravelPlannerPage() {
                             {s.rationale}
                           </p>
                         </div>
-                        <Button size="sm" onClick={() => acceptSuggestion(s)}>
-                          Accept
-                        </Button>
+                        <div className="inline-flex gap-2">
+                          <Button
+                            size="sm"
+                            variant="ghost"
+                            onClick={() => setEditingSuggestion(s)}
+                          >
+                            <Pencil className="h-3 w-3" /> Edit
+                          </Button>
+                          <Button size="sm" onClick={() => acceptSuggestion(s)}>
+                            Accept
+                          </Button>
+                        </div>
                       </div>
                       <div className="mt-2 grid grid-cols-2 sm:grid-cols-4 gap-2 text-xs text-fg-muted">
                         <div>
@@ -551,13 +561,15 @@ export default function TravelPlannerPage() {
       </div>
 
       <TripDialog
-        open={creating || editing !== null}
+        open={creating || editing !== null || editingSuggestion !== null}
         onClose={() => {
           setCreating(false)
           setEditing(null)
+          setEditingSuggestion(null)
         }}
         clientId={clientId!}
         existingTrip={editing}
+        suggestionPrefill={editingSuggestion}
         properties={properties}
         branches={branches}
         propsAlreadyInOtherTrips={
@@ -570,8 +582,15 @@ export default function TravelPlannerPage() {
             : propsInTrips
         }
         onSaved={() => {
+          if (editingSuggestion) {
+            const acceptedName = editingSuggestion.suggested_name
+            setSuggestions((prev) =>
+              prev ? prev.filter((x) => x.suggested_name !== acceptedName) : prev
+            )
+          }
           setCreating(false)
           setEditing(null)
+          setEditingSuggestion(null)
           refresh()
         }}
       />
@@ -593,6 +612,7 @@ function TripDialog({
   onClose,
   clientId,
   existingTrip,
+  suggestionPrefill,
   properties,
   branches,
   propsAlreadyInOtherTrips,
@@ -602,6 +622,7 @@ function TripDialog({
   onClose: () => void
   clientId: string
   existingTrip: ManualTripWithMetrics | null
+  suggestionPrefill: Suggestion | null
   properties: TravelProperty[]
   branches: BranchInfo[]
   propsAlreadyInOtherTrips: Set<string>
@@ -625,6 +646,12 @@ function TripDialog({
         setVisitsPerYear(String(existingTrip.visits_per_year))
         setNotes(existingTrip.notes ?? '')
         setSelected(new Set(existingTrip.property_ids))
+      } else if (suggestionPrefill) {
+        setName(suggestionPrefill.suggested_name)
+        setBranchName(suggestionPrefill.branch_name)
+        setVisitsPerYear('2')
+        setNotes('')
+        setSelected(new Set(suggestionPrefill.property_ids))
       } else {
         setName('')
         setBranchName(branches[0]?.name ?? '')
@@ -635,7 +662,7 @@ function TripDialog({
       setFilter('')
       setErr(null)
     }
-  }, [open, existingTrip, branches])
+  }, [open, existingTrip, suggestionPrefill, branches])
 
   const filteredProps = useMemo(() => {
     const q = filter.trim().toLowerCase()


### PR DESCRIPTION
## Summary
**Nights formula was wrong.** The crew cleans one property on the day they arrive and one on the day they leave, so hotel nights = property_count − 2 (floor 1), not property_count. A 6-property trip is now correctly 4 nights instead of 6. Applied to both the saved-trip annotation and the /suggest endpoint.

**No way to edit a suggestion before accepting it.** Each suggested trip now has an "Edit" button next to "Accept" that opens the trip dialog pre-filled with the suggestion's name, branch, and properties — adjust anything (rename, drop/add properties, change visits/year, add notes) and save. Save creates the trip and removes the suggestion from the list. "Accept" still works for one-click save.

## Test plan
- [ ] Suggest trips on a client with 6+ remote properties → suggestion shows Nights/trip = 4 (not 6)
- [ ] Click Edit on a suggestion → dialog opens with name, branch, and 6 properties pre-selected
- [ ] Adjust + Save → new trip appears in saved list, suggestion disappears
- [ ] Existing saved trips show recomputed nights = max(1, properties - 2)
- [ ] tsc clean (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)