### PR TITLE
Add square footage to Travel & Trips

### DIFF
--- a/api/v1/clients/[id]/manual-trips.ts
+++ b/api/v1/clients/[id]/manual-trips.ts
@@ -33,6 +33,7 @@ interface PropertyRow {
   state: string | null
   latitude: number | null
   longitude: number | null
+  serviceable_sqft: number | null
 }
 
 interface TripRow {
@@ -182,15 +183,24 @@ async function loadTripsAndProperties(
       .eq('account_id', accountId)
       .eq('client_id', clientId)
       .order('created_at', { ascending: true }),
+    // Pull SLs once with serviceable_sqft so we can sum per property
+    // (a property may have multiple SLs on this client).
     db
       .from('service_locations')
-      .select('property_id')
+      .select('property_id, serviceable_sqft')
       .eq('client_id', clientId),
   ])
   const trips = ((tripsRes.data ?? []) as TripRow[])
-  const propIds = Array.from(
-    new Set(((slRes.data ?? []) as { property_id: string }[]).map((r) => r.property_id))
-  )
+  const slRows = (slRes.data ?? []) as { property_id: string; serviceable_sqft: number | null }[]
+  const sqftByProperty = new Map<string, number>()
+  for (const r of slRows) {
+    if (r.serviceable_sqft == null) continue
+    sqftByProperty.set(
+      r.property_id,
+      (sqftByProperty.get(r.property_id) ?? 0) + r.serviceable_sqft
+    )
+  }
+  const propIds = Array.from(new Set(slRows.map((r) => r.property_id)))
   let properties: PropertyRow[] = []
   // Chunk to stay under PostgREST's URL length limit on huge clients.
   for (let i = 0; i < propIds.length; i += 250) {
@@ -199,7 +209,12 @@ async function loadTripsAndProperties(
       .from('properties')
       .select('id, address_line1, city, state, latitude, longitude')
       .in('id', chunk)
-    for (const p of data ?? []) properties.push(p as PropertyRow)
+    for (const p of data ?? []) {
+      properties.push({
+        ...(p as Omit<PropertyRow, 'serviceable_sqft'>),
+        serviceable_sqft: sqftByProperty.get((p as any).id) ?? null,
+      })
+    }
   }
   return { trips, properties }
 }
@@ -245,6 +260,7 @@ function annotateProperties(
       state: p.state,
       lat: p.latitude,
       lng: p.longitude,
+      serviceable_sqft: p.serviceable_sqft,
       assigned_branch: branch?.name ?? null,
       assigned_branch_city_state: branch?.city_state ?? null,
       miles_to_branch: Math.round(miles * 10) / 10,
@@ -331,10 +347,16 @@ function annotateTrip(
     : 0
   const annualLodgingCost = annualHotelCost + annualPerDiemCost
 
+  const totalSqft = tripProps.reduce(
+    (sum, p) => sum + (p.serviceable_sqft ?? 0),
+    0
+  )
+
   return {
     ...trip,
     property_count: tripProps.length,
     properties_missing_coords: tripProps.length - validProps.length,
+    total_sqft: totalSqft,
     miles_per_trip: Math.round(totalDriveMiles * 10) / 10,
     annual_miles: Math.round(annualMiles * 10) / 10,
     one_way_drive_hours_to_centroid: Math.round(oneWayHours * 100) / 100,

--- a/api/v1/clients/[id]/manual-trips/suggest.ts
+++ b/api/v1/clients/[id]/manual-trips/suggest.ts
@@ -28,6 +28,7 @@ interface PropertyRow {
   state: string | null
   latitude: number | null
   longitude: number | null
+  serviceable_sqft: number | null
 }
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
@@ -70,14 +71,24 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     ? Math.max(5, Number(body.cluster_radius_miles))
     : DEFAULT_CLUSTER_RADIUS_MILES
 
-  // Pull all properties that have at least one SL on this client.
+  // Pull all properties that have at least one SL on this client,
+  // along with serviceable_sqft so we can sum it per cluster.
   const { data: slRows } = await db
     .from('service_locations')
-    .select('property_id')
+    .select('property_id, serviceable_sqft')
     .eq('client_id', clientId)
-  const propIds = Array.from(
-    new Set((slRows ?? []).map((r) => (r as any).property_id as string))
-  ).filter((id) => !exclude.has(id))
+  const slData = (slRows ?? []) as { property_id: string; serviceable_sqft: number | null }[]
+  const sqftByProperty = new Map<string, number>()
+  for (const r of slData) {
+    if (r.serviceable_sqft == null) continue
+    sqftByProperty.set(
+      r.property_id,
+      (sqftByProperty.get(r.property_id) ?? 0) + r.serviceable_sqft
+    )
+  }
+  const propIds = Array.from(new Set(slData.map((r) => r.property_id))).filter(
+    (id) => !exclude.has(id)
+  )
   if (propIds.length === 0) {
     return res.status(200).json({ suggestions: [] })
   }
@@ -88,7 +99,12 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       .from('properties')
       .select('id, address_line1, city, state, latitude, longitude')
       .in('id', chunk)
-    for (const p of data ?? []) properties.push(p as PropertyRow)
+    for (const p of data ?? []) {
+      properties.push({
+        ...(p as Omit<PropertyRow, 'serviceable_sqft'>),
+        serviceable_sqft: sqftByProperty.get((p as any).id) ?? null,
+      })
+    }
   }
 
   // 1. Bucket each property into "remote enough to suggest as a trip"
@@ -134,6 +150,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     one_way_drive_hours_to_centroid: number
     miles_per_trip_estimate: number
     estimated_nights_per_trip: number
+    total_sqft: number
     rationale: string
   }
   const suggestions: Suggestion[] = []
@@ -176,6 +193,11 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         ? `${firstCity} ${firstState}`
         : firstCity || firstState || 'cluster'
 
+      const clusterSqft = inCluster.reduce(
+        (sum, p) => sum + (p.serviceable_sqft ?? 0),
+        0
+      )
+
       suggestions.push({
         suggested_name: `${labelLoc} (${inCluster.length} properties)`,
         branch_name: branch.name,
@@ -188,6 +210,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         centroid_lng: cLng,
         one_way_drive_hours_to_centroid: Math.round(oneWayHours * 100) / 100,
         miles_per_trip_estimate: Math.round(milesEstimate * 10) / 10,
+        total_sqft: clusterSqft,
         // Clean one on arrival day, one on departure day → hotel nights
         // = mid days = property_count - 2 (floor of 1).
         estimated_nights_per_trip: Math.max(1, inCluster.length - 2),

--- a/src/pages/accounts/TravelPlanner.tsx
+++ b/src/pages/accounts/TravelPlanner.tsx
@@ -39,6 +39,7 @@ interface TravelProperty {
   state: string | null
   lat: number | null
   lng: number | null
+  serviceable_sqft: number | null
   assigned_branch: string | null
   assigned_branch_city_state: string | null
   miles_to_branch: number
@@ -54,6 +55,7 @@ interface ManualTripWithMetrics {
   notes: string | null
   property_count: number
   properties_missing_coords: number
+  total_sqft: number
   miles_per_trip: number
   annual_miles: number
   one_way_drive_hours_to_centroid: number
@@ -81,6 +83,7 @@ interface Suggestion {
   one_way_drive_hours_to_centroid: number
   miles_per_trip_estimate: number
   estimated_nights_per_trip: number
+  total_sqft: number
   rationale: string
 }
 
@@ -359,10 +362,18 @@ export default function TravelPlannerPage() {
                           </Button>
                         </div>
                       </div>
-                      <div className="mt-2 grid grid-cols-2 sm:grid-cols-4 gap-2 text-xs text-fg-muted">
+                      <div className="mt-2 grid grid-cols-2 sm:grid-cols-5 gap-2 text-xs text-fg-muted">
                         <div>
                           <span className="text-fg-subtle">Properties:</span>{' '}
                           <span className="font-tabular text-fg">{s.property_ids.length}</span>
+                        </div>
+                        <div>
+                          <span className="text-fg-subtle">Avg sq ft:</span>{' '}
+                          <span className="font-tabular text-fg">
+                            {s.property_ids.length > 0
+                              ? Math.round(s.total_sqft / s.property_ids.length).toLocaleString()
+                              : '—'}
+                          </span>
                         </div>
                         <div>
                           <span className="text-fg-subtle">Drive:</span>{' '}
@@ -460,7 +471,48 @@ export default function TravelPlannerPage() {
                           value={`$${t.annual_lodging_cost.toLocaleString()}`}
                         />
                         <Stat label="Miles/trip" value={t.miles_per_trip} />
+                        <Stat
+                          label="Avg sq ft / site"
+                          value={
+                            t.property_count > 0
+                              ? Math.round(t.total_sqft / t.property_count).toLocaleString()
+                              : '—'
+                          }
+                        />
+                        <Stat
+                          label="Total sq ft"
+                          value={t.total_sqft.toLocaleString()}
+                        />
                       </dl>
+                      <details className="group mt-3 text-xs">
+                        <summary className="cursor-pointer text-accent hover:underline list-none [&::-webkit-details-marker]:hidden">
+                          <span className="group-open:hidden">▸ Show {t.property_count} site{t.property_count === 1 ? '' : 's'}</span>
+                          <span className="hidden group-open:inline">▾ Hide sites</span>
+                        </summary>
+                        <ul className="mt-2 divide-y divide-border rounded-md border border-border">
+                          {t.property_ids
+                            .map((pid) => properties.find((p) => p.property_id === pid))
+                            .filter((p): p is TravelProperty => !!p)
+                            .map((p) => (
+                              <li
+                                key={p.property_id}
+                                className="flex items-center justify-between gap-2 px-2 py-1.5"
+                              >
+                                <span className="truncate text-fg">
+                                  {p.address_line1 ?? '—'}
+                                  <span className="ml-1 text-fg-subtle">
+                                    {p.city}{p.city && p.state ? ', ' : ''}{p.state}
+                                  </span>
+                                </span>
+                                <span className="font-tabular text-fg-muted whitespace-nowrap">
+                                  {p.serviceable_sqft != null
+                                    ? `${p.serviceable_sqft.toLocaleString()} sq ft`
+                                    : '—'}
+                                </span>
+                              </li>
+                            ))}
+                        </ul>
+                      </details>
                       {t.properties_missing_coords > 0 && (
                         <p className="mt-2 text-[11px] text-warning">
                           ⚠ {t.properties_missing_coords} propert
@@ -512,6 +564,7 @@ export default function TravelPlannerPage() {
                     <TableRow>
                       <TableHead>Property</TableHead>
                       <TableHead>Branch</TableHead>
+                      <TableHead className="text-right">Sq ft</TableHead>
                       <TableHead className="text-right">Distance</TableHead>
                       <TableHead className="text-right">Drive</TableHead>
                       <TableHead>Trip</TableHead>
@@ -531,6 +584,11 @@ export default function TravelPlannerPage() {
                           <TableCell className="text-xs text-fg-muted">
                             <MapPin className="inline h-3 w-3 mr-0.5" />
                             {p.assigned_branch_city_state || p.assigned_branch || '—'}
+                          </TableCell>
+                          <TableCell numeric className="text-xs">
+                            {p.serviceable_sqft != null
+                              ? p.serviceable_sqft.toLocaleString()
+                              : '—'}
                           </TableCell>
                           <TableCell numeric className="text-xs">
                             {p.miles_to_branch != null ? `${p.miles_to_branch} mi` : '—'}


### PR DESCRIPTION
## Summary
Operators need square-footage visibility on Travel & Trips to judge whether multiple small buildings can be doubled up within a single trip day.

**API**
- \`GET /api/v1/clients/[id]/manual-trips\` joins \`service_locations.serviceable_sqft\` summed per property_id and surfaces it on each annotated property. Each saved trip's annotation gets a new \`total_sqft\`.
- \`POST /manual-trips/suggest\` returns \`total_sqft\` per cluster.

**UI**
- Properties table: new "Sq ft" column.
- Saved trip card: "Avg sq ft / site" + "Total sq ft" stats, plus a collapsible "Show N sites" panel listing each property with its individual sq ft (per the user's request — summary on the card, detail on expand).
- Suggestion card: new "Avg sq ft" metric.

## Test plan
- [ ] Travel page loads, properties table shows Sq ft column populated for clients with serviceable_sqft on their SLs
- [ ] Saved trip card shows Avg sq ft and Total sq ft
- [ ] Click "Show N sites" → list of each property with its sq ft
- [ ] Suggestion card shows Avg sq ft
- [ ] tsc clean (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)