### PR TITLE
Rebrand RBM Geo → PortfolioIQ

### DIFF
--- a/api/embed/map.ts
+++ b/api/embed/map.ts
@@ -85,7 +85,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>RBM Geo Map</title>
+  <title>PortfolioIQ Map</title>
   <link href="https://api.mapbox.com/mapbox-gl-js/v3.9.0/mapbox-gl.css" rel="stylesheet" />
   <script src="https://api.mapbox.com/mapbox-gl-js/v3.9.0/mapbox-gl.js"></script>
   <style>

--- a/api/portfolio/[share_token].ts
+++ b/api/portfolio/[share_token].ts
@@ -73,7 +73,7 @@ h1{color:#111827;margin:0 0 .5rem}p{color:#6b7280;margin:0}</style></head>
 <head>
   <meta charset="UTF-8"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
-  <title>${portfolio.name} — RBM Geo</title>
+  <title>${portfolio.name} — PortfolioIQ</title>
   <link href="https://api.mapbox.com/mapbox-gl-js/v3.9.0/mapbox-gl.css" rel="stylesheet"/>
   <script src="https://api.mapbox.com/mapbox-gl-js/v3.9.0/mapbox-gl.js"></script>
   <style>

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>RBM Geo — Portfolio Intelligence</title>
+    <title>PortfolioIQ — Portfolio Intelligence</title>
 
     <!-- Geist + Geist Mono. Preconnect avoids a chained DNS+TLS handshake
          on first paint, which matters because the body's font-family falls

--- a/src/components/ui/Navbar.tsx
+++ b/src/components/ui/Navbar.tsx
@@ -40,7 +40,7 @@ export default function Navbar() {
           <svg className="w-6 h-6" fill="currentColor" viewBox="0 0 24 24">
             <path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z" />
           </svg>
-          RBM Geo
+          PortfolioIQ
         </Link>
         <div className="flex gap-1">
           {links.map((l) => (

--- a/src/lib/parcel/lookup.ts
+++ b/src/lib/parcel/lookup.ts
@@ -299,9 +299,9 @@ async function checkAndNotifyThreshold(
       const { Resend } = await import('resend')
       const resend = new Resend(process.env.RESEND_API_KEY)
       await resend.emails.send({
-        from: 'RBM Geo <noreply@rbm-geo.com>',
+        from: 'PortfolioIQ <noreply@rbm-geo.com>',
         to: email,
-        subject: `[RBM Geo] Buy county alert: ${county_name ?? county_fips} (${state})`,
+        subject: `[PortfolioIQ] Buy county alert: ${county_name ?? county_fips} (${state})`,
         html: `
           <p>County <strong>${county_name ?? county_fips}</strong> (${state}) has exceeded
           ${FALLBACK_THRESHOLD} Regrid API fallback calls in the last 90 days.</p>

--- a/src/pages/ForgotPassword.tsx
+++ b/src/pages/ForgotPassword.tsx
@@ -34,7 +34,7 @@ export default function ForgotPasswordPage() {
             <svg className="w-8 h-8" fill="currentColor" viewBox="0 0 24 24">
               <path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z" />
             </svg>
-            <span className="text-2xl font-bold text-white">RBM Geo</span>
+            <span className="text-2xl font-bold text-white">PortfolioIQ</span>
           </div>
         </div>
 

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -111,7 +111,7 @@ export default function LoginPage() {
             <svg className="w-8 h-8" fill="currentColor" viewBox="0 0 24 24">
               <path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z" />
             </svg>
-            <span className="text-2xl font-bold text-white">RBM Geo</span>
+            <span className="text-2xl font-bold text-white">PortfolioIQ</span>
           </div>
           <p className="text-gray-400 text-sm">Portfolio Intelligence Platform</p>
         </div>

--- a/src/pages/SharedPortfolio.tsx
+++ b/src/pages/SharedPortfolio.tsx
@@ -62,7 +62,7 @@ export default function SharedPortfolioPage() {
               <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
                 <path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7z" />
               </svg>
-              RBM Geo
+              PortfolioIQ
             </div>
             <h1 className="text-xl font-bold text-gray-900">{portfolio.name}</h1>
             {portfolio.description && <p className="text-gray-500 text-sm">{portfolio.description}</p>}

--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -20,7 +20,7 @@ export default function SignupPage() {
               <svg className="w-8 h-8" fill="currentColor" viewBox="0 0 24 24">
                 <path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z" />
               </svg>
-              <span className="text-2xl font-bold text-white">RBM Geo</span>
+              <span className="text-2xl font-bold text-white">PortfolioIQ</span>
             </div>
           </div>
           <div className="bg-gray-800 rounded-xl border border-gray-700 p-6 shadow-xl text-center">
@@ -58,7 +58,7 @@ export default function SignupPage() {
             <svg className="w-8 h-8" fill="currentColor" viewBox="0 0 24 24">
               <path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z" />
             </svg>
-            <span className="text-2xl font-bold text-white">RBM Geo</span>
+            <span className="text-2xl font-bold text-white">PortfolioIQ</span>
           </div>
           <p className="text-gray-400 text-sm">Portfolio Intelligence Platform</p>
         </div>

--- a/src/pages/UpdatePassword.tsx
+++ b/src/pages/UpdatePassword.tsx
@@ -51,7 +51,7 @@ export default function UpdatePasswordPage() {
             <svg className="w-8 h-8" fill="currentColor" viewBox="0 0 24 24">
               <path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z" />
             </svg>
-            <span className="text-2xl font-bold text-white">RBM Geo</span>
+            <span className="text-2xl font-bold text-white">PortfolioIQ</span>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
Replaces "RBM Geo" with "PortfolioIQ" in all user-visible text:

- Browser tab title (\`index.html\`)
- Login, Signup, ForgotPassword, UpdatePassword (auth pages)
- SharedPortfolio public page
- Top Navbar component
- Embed map page (\`api/embed/map.ts\`)
- Shared portfolio API title (\`api/portfolio/[share_token].ts\`)
- County-buy alert email display name + subject

The \`@rbm-geo.com\` email From-address domain is unchanged (real DNS record). The internal-only comment in \`src/components/layout/TopBar.tsx\` referencing the legacy brand is also untouched (historical context for code reviewers).

## Test plan
- [ ] Browser tab shows "PortfolioIQ — Portfolio Intelligence" on every page
- [ ] Login page shows "PortfolioIQ" header
- [ ] Signup, Forgot Password, Update Password pages show new brand
- [ ] Shared portfolio page shows "PortfolioIQ" in header

🤖 Generated with [Claude Code](https://claude.com/claude-code)