### PR TITLE
Add Split-trip on Travel & Trips

### DIFF
--- a/api/v1/clients/[id]/manual-trips/split.ts
+++ b/api/v1/clients/[id]/manual-trips/split.ts
@@ -1,0 +1,186 @@
+// POST /api/v1/clients/[id]/manual-trips/split
+//
+// Split one saved trip into N smaller trips. Properties are grouped
+// geographically by sorting along the dominant lat/lng axis and chunking
+// into N roughly-equal-size sub-clusters. Original trip is deleted; new
+// trips are created with a "(i of N)" suffix on the name.
+//
+// Body: { trip_id: string, num_splits: number }
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { createAdminClient } from '../../../../_lib/supabase.js'
+import { authenticateRequest } from '../../../../_lib/auth.js'
+
+export const config = { maxDuration: 30 }
+
+interface TripRow {
+  id: string
+  account_id: string
+  client_id: string
+  name: string
+  branch_name: string
+  property_ids: string[]
+  visits_per_year: number
+  notes: string | null
+}
+
+interface PropertyRow {
+  id: string
+  latitude: number | null
+  longitude: number | null
+}
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+  try {
+    await authenticateRequest(req)
+  } catch (err: any) {
+    return res.status(err.statusCode ?? 401).json({ error: err.message ?? 'Unauthorized' })
+  }
+  const clientId = req.query.id as string
+  if (!clientId) return res.status(400).json({ error: 'client id required' })
+
+  const body = (req.body ?? {}) as Record<string, unknown>
+  const tripId = typeof body.trip_id === 'string' ? body.trip_id : null
+  const numSplits = Number(body.num_splits)
+  if (!tripId) return res.status(400).json({ error: 'trip_id required' })
+  if (!Number.isFinite(numSplits) || numSplits < 2 || numSplits > 20) {
+    return res.status(400).json({ error: 'num_splits must be between 2 and 20' })
+  }
+
+  const db = createAdminClient()
+
+  const { data: clientRow } = await db
+    .from('clients')
+    .select('account_id')
+    .eq('id', clientId)
+    .maybeSingle()
+  const accountId = (clientRow as any)?.account_id as string | undefined
+  if (!accountId) return res.status(404).json({ error: 'Client not found' })
+
+  const { data: tripData, error: tripErr } = await db
+    .from('manual_trips')
+    .select('*')
+    .eq('id', tripId)
+    .eq('account_id', accountId)
+    .eq('client_id', clientId)
+    .maybeSingle()
+  if (tripErr) return res.status(500).json({ error: tripErr.message })
+  if (!tripData) return res.status(404).json({ error: 'Trip not found' })
+  const trip = tripData as TripRow
+
+  if (trip.property_ids.length < 2) {
+    return res
+      .status(400)
+      .json({ error: 'Trip must have at least 2 properties to split' })
+  }
+  // Cap splits at the property count — splitting 5 props into 8 trips makes
+  // no sense.
+  const k = Math.min(numSplits, trip.property_ids.length)
+
+  // Pull lat/lng for each property in chunks (PostgREST URL limit).
+  const properties: PropertyRow[] = []
+  for (let i = 0; i < trip.property_ids.length; i += 250) {
+    const chunk = trip.property_ids.slice(i, i + 250)
+    const { data } = await db
+      .from('properties')
+      .select('id, latitude, longitude')
+      .in('id', chunk)
+    for (const p of data ?? []) properties.push(p as PropertyRow)
+  }
+
+  // Build the split groups.
+  const groups = sortChunkSplit(properties, k)
+
+  // Create new trips one-by-one (small N, sequential is fine and gives us
+  // explicit error handling per insert).
+  const createdIds: string[] = []
+  for (let i = 0; i < groups.length; i++) {
+    const ids = groups[i]
+    const { data: inserted, error: insertErr } = await db
+      .from('manual_trips')
+      .insert({
+        account_id: accountId,
+        client_id: clientId,
+        name: `${trip.name} (${i + 1} of ${groups.length})`,
+        branch_name: trip.branch_name,
+        property_ids: ids,
+        visits_per_year: trip.visits_per_year,
+        notes: trip.notes,
+      })
+      .select('id')
+      .single()
+    if (insertErr) {
+      // Roll back: delete any trips we already created.
+      if (createdIds.length > 0) {
+        await db.from('manual_trips').delete().in('id', createdIds)
+      }
+      return res.status(500).json({
+        error: `Split failed on group ${i + 1}: ${insertErr.message}`,
+      })
+    }
+    createdIds.push((inserted as any).id as string)
+  }
+
+  // Delete the original trip last so failure leaves the original intact.
+  const { error: delErr } = await db
+    .from('manual_trips')
+    .delete()
+    .eq('id', tripId)
+    .eq('account_id', accountId)
+    .eq('client_id', clientId)
+  if (delErr) {
+    // Original still exists, new trips also exist — surface the partial
+    // state so the user can clean up.
+    return res.status(500).json({
+      error: `Created ${createdIds.length} new trips but failed to delete original: ${delErr.message}`,
+      created_trip_ids: createdIds,
+    })
+  }
+
+  return res.status(200).json({
+    new_trip_ids: createdIds,
+    deleted_trip_id: tripId,
+  })
+}
+
+// Split properties into k roughly-balanced groups by sorting along the
+// dominant lat/lng axis and chunking. Properties without coords land at
+// the end of the sort and get distributed into whichever chunk has room.
+// O(n log n). Good geographic locality for elongated clusters; perfect
+// balance on counts.
+function sortChunkSplit(props: PropertyRow[], k: number): string[][] {
+  if (props.length === 0) return []
+  if (k <= 1) return [props.map((p) => p.id)]
+
+  // Pick the axis with the larger range so the split makes geographic
+  // sense for the cluster's actual shape.
+  const lats = props.map((p) => p.latitude).filter((v): v is number => v != null)
+  const lngs = props.map((p) => p.longitude).filter((v): v is number => v != null)
+  const latRange = lats.length ? Math.max(...lats) - Math.min(...lats) : 0
+  const lngRange = lngs.length ? Math.max(...lngs) - Math.min(...lngs) : 0
+  const sortByLat = latRange >= lngRange
+
+  const sorted = [...props].sort((a, b) => {
+    const av = sortByLat ? a.latitude : a.longitude
+    const bv = sortByLat ? b.latitude : b.longitude
+    if (av == null && bv == null) return 0
+    if (av == null) return 1
+    if (bv == null) return -1
+    return av - bv
+  })
+
+  const baseSize = Math.floor(props.length / k)
+  const remainder = props.length % k
+  const groups: string[][] = []
+  let cursor = 0
+  for (let i = 0; i < k; i++) {
+    // Distribute the remainder across the first `remainder` groups so
+    // sizes differ by at most 1.
+    const size = baseSize + (i < remainder ? 1 : 0)
+    groups.push(sorted.slice(cursor, cursor + size).map((p) => p.id))
+    cursor += size
+  }
+  return groups
+}

--- a/src/pages/accounts/TravelPlanner.tsx
+++ b/src/pages/accounts/TravelPlanner.tsx
@@ -8,7 +8,7 @@
 // propose groupings the user can accept verbatim.
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useParams } from 'react-router-dom'
-import { Plus, Sparkles, Trash2, Pencil, MapPin, Route } from 'lucide-react'
+import { Plus, Sparkles, Trash2, Pencil, MapPin, Route, Split } from 'lucide-react'
 import { useAuth } from '../../hooks/useAuth'
 import AppShell from '../../components/layout/AppShell'
 import Button from '../../components/ui/Button'
@@ -100,6 +100,7 @@ export default function TravelPlannerPage() {
   const [creating, setCreating] = useState(false)
   const [editing, setEditing] = useState<ManualTripWithMetrics | null>(null)
   const [editingSuggestion, setEditingSuggestion] = useState<Suggestion | null>(null)
+  const [splitting, setSplitting] = useState<ManualTripWithMetrics | null>(null)
   const [suggestions, setSuggestions] = useState<Suggestion[] | null>(null)
   const [suggesting, setSuggesting] = useState(false)
   const [propertyFilter, setPropertyFilter] = useState('')
@@ -436,6 +437,16 @@ export default function TravelPlannerPage() {
                           </p>
                         </div>
                         <div className="flex gap-1">
+                          {t.property_count >= 2 && (
+                            <button
+                              type="button"
+                              onClick={() => setSplitting(t)}
+                              title="Split into multiple trips"
+                              className="text-fg-subtle hover:text-accent"
+                            >
+                              <Split className="h-3.5 w-3.5" />
+                            </button>
+                          )}
                           <button
                             type="button"
                             onClick={() => setEditing(t)}
@@ -649,6 +660,16 @@ export default function TravelPlannerPage() {
           setCreating(false)
           setEditing(null)
           setEditingSuggestion(null)
+          refresh()
+        }}
+      />
+
+      <SplitTripDialog
+        trip={splitting}
+        clientId={clientId!}
+        onClose={() => setSplitting(null)}
+        onSplit={() => {
+          setSplitting(null)
           refresh()
         }}
       />
@@ -901,6 +922,118 @@ function TripDialog({
           <Button variant="ghost" onClick={onClose} disabled={saving}>Cancel</Button>
           <Button onClick={save} loading={saving}>
             {existingTrip ? 'Save changes' : 'Create trip'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function SplitTripDialog({
+  trip,
+  clientId,
+  onClose,
+  onSplit,
+}: {
+  trip: ManualTripWithMetrics | null
+  clientId: string
+  onClose: () => void
+  onSplit: () => void
+}) {
+  const { getToken } = useAuth()
+  // Default split = ceil(properties / 5) — typical week-of-work upper bound.
+  const defaultSplits = trip ? Math.max(2, Math.ceil(trip.property_count / 5)) : 2
+  const [numSplits, setNumSplits] = useState(String(defaultSplits))
+  const [splitting, setSplitting] = useState(false)
+  const [err, setErr] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (trip) {
+      setNumSplits(String(Math.max(2, Math.ceil(trip.property_count / 5))))
+      setErr(null)
+    }
+  }, [trip])
+
+  if (!trip) return null
+
+  const n = Math.max(2, Math.min(trip.property_count, Math.floor(Number(numSplits) || 2)))
+  const baseSize = Math.floor(trip.property_count / n)
+  const remainder = trip.property_count % n
+  const sizePreview =
+    remainder === 0
+      ? `${baseSize} properties each`
+      : `${baseSize}–${baseSize + 1} properties each`
+
+  const submit = async () => {
+    setSplitting(true)
+    setErr(null)
+    try {
+      const token = await getToken()
+      const res = await fetch(
+        `/api/v1/clients/${clientId}/manual-trips/split`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({ trip_id: trip.id, num_splits: n }),
+        }
+      )
+      const j = await res.json().catch(() => ({}))
+      if (!res.ok) {
+        throw new Error((j as any).error ?? `HTTP ${res.status}`)
+      }
+      onSplit()
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e))
+    } finally {
+      setSplitting(false)
+    }
+  }
+
+  return (
+    <Dialog open onOpenChange={(o) => !o && onClose()}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Split "{trip.name}"</DialogTitle>
+          <DialogDescription>
+            Group this trip's {trip.property_count} properties into smaller
+            trips. Each split is created as its own trip with the same
+            branch and visits/year — you can edit each one individually
+            afterward.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3 py-2">
+          <FormField label="Number of trips">
+            <Input
+              type="number"
+              min={2}
+              max={Math.min(20, trip.property_count)}
+              value={numSplits}
+              onChange={(e) => setNumSplits(e.target.value)}
+            />
+          </FormField>
+          <p className="text-xs text-fg-muted">
+            Result: <span className="font-semibold text-fg">{n}</span> trips,{' '}
+            {sizePreview}. Properties are grouped geographically along the
+            cluster's longest axis so each sub-trip stays compact.
+          </p>
+        </div>
+
+        {err && (
+          <p className="text-xs text-danger border border-danger/30 bg-danger-subtle rounded-md px-2 py-1">
+            {err}
+          </p>
+        )}
+
+        <DialogFooter>
+          <Button variant="ghost" onClick={onClose} disabled={splitting}>
+            Cancel
+          </Button>
+          <Button onClick={submit} loading={splitting}>
+            Split into {n} trips
           </Button>
         </DialogFooter>
       </DialogContent>


### PR DESCRIPTION
## Summary
Operators don't actually send a crew out for 20 days at a time, so big trips need to be broken into multiple shorter ones. This adds a split affordance to each saved trip card.

**Backend** — new endpoint \`POST /api/v1/clients/[id]/manual-trips/split\`:
- Body: \`{ trip_id, num_splits }\` (num_splits clamped to [2, 20] and capped at the trip's property count)
- Sorts the trip's properties along the dominant lat/lng axis (whichever has the larger range) and chunks into num_splits roughly-equal-size groups — sizes differ by at most 1.
- Creates N new trips named "<original> (i of N)" carrying over branch, visits/year, and notes.
- Deletes the original trip last so a partial failure leaves the original intact.

**Frontend**:
- New Split icon button on each saved trip card (only when ≥2 properties)
- \`SplitTripDialog\` — number-of-trips input with live preview ("4 trips, 5 properties each"), defaults to ceil(props / 5)
- After split: dialog closes, trip list refreshes with the new sub-trips visible

## Out of scope
- Manual property assignment to specific sub-trips (use the existing Edit on each result if you want to fine-tune)
- Re-merging split trips (delete and recreate if you change your mind)

## Test plan
- [ ] Create a trip with ~20 properties → click Split → enter 4 → 4 new trips appear, original is gone, each has 5 properties
- [ ] Each split trip has the same branch and visits/year as original
- [ ] Geographic locality: looking at a map, sub-trips should not overlap heavily
- [ ] Edit a sub-trip → can rename / add / remove properties normally
- [ ] tsc + build clean (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)