### PR TITLE
Make Access + Operations constraint types clickable

### DIFF
--- a/src/components/property/AddConstraintDialog.tsx
+++ b/src/components/property/AddConstraintDialog.tsx
@@ -18,8 +18,6 @@ import {
   SelectTrigger,
   SelectValue,
   SelectContent,
-  SelectGroup,
-  SelectLabel,
   SelectItem,
 } from '../ui/Select'
 import { Textarea, FormField } from '../ui/Input'
@@ -143,15 +141,10 @@ export default function AddConstraintDialog({
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
-                {CONSTRAINT_GROUPS.map((g) => (
-                  <SelectGroup key={g.label}>
-                    <SelectLabel>{g.label}</SelectLabel>
-                    {g.types.map((t) => (
-                      <SelectItem key={t} value={t}>
-                        {CONSTRAINT_LABELS[t]}
-                      </SelectItem>
-                    ))}
-                  </SelectGroup>
+                {CONSTRAINT_GROUPS.flatMap((g) => g.types).map((t) => (
+                  <SelectItem key={t} value={t}>
+                    {CONSTRAINT_LABELS[t]}
+                  </SelectItem>
                 ))}
               </SelectContent>
             </Select>

--- a/src/components/property/EditTemplateDialog.tsx
+++ b/src/components/property/EditTemplateDialog.tsx
@@ -19,8 +19,6 @@ import {
   SelectTrigger,
   SelectValue,
   SelectContent,
-  SelectGroup,
-  SelectLabel,
   SelectItem,
 } from '../ui/Select'
 import { Input, Textarea, FormField } from '../ui/Input'
@@ -232,13 +230,8 @@ export default function EditTemplateDialog({
               <Select value={draftType} onValueChange={(v) => changeDraftType(v as ConstraintType)}>
                 <SelectTrigger><SelectValue /></SelectTrigger>
                 <SelectContent>
-                  {CONSTRAINT_GROUPS.map((g) => (
-                    <SelectGroup key={g.label}>
-                      <SelectLabel>{g.label}</SelectLabel>
-                      {g.types.map((t) => (
-                        <SelectItem key={t} value={t}>{CONSTRAINT_LABELS[t]}</SelectItem>
-                      ))}
-                    </SelectGroup>
+                  {CONSTRAINT_GROUPS.flatMap((g) => g.types).map((t) => (
+                    <SelectItem key={t} value={t}>{CONSTRAINT_LABELS[t]}</SelectItem>
                   ))}
                 </SelectContent>
               </Select>


### PR DESCRIPTION
## Summary
The constraint-type dropdown nested 6 types under Schedule / Access / Operations group headers using Radix \`SelectGroup\` + \`SelectLabel\`. \`SelectLabel\` is purely decorative — not selectable. Since Access and Operations each had only one item, their headers visually duplicated the lone item below, and clicking the header (which users naturally tried) did nothing.

Flattened the list. All 6 types now render as plain rows you can click directly.

## Test plan
- [ ] Open Add Constraint dialog → Type dropdown → all 6 options selectable, no \"Schedule\" / \"Access\" / \"Operations\" headers
- [ ] Open Edit Template dialog → same fix
- [ ] tsc clean (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)