### PR TITLE
Add per-client custom-field filters on the Map

### DIFF
--- a/api/v1/properties/index.ts
+++ b/api/v1/properties/index.ts
@@ -37,9 +37,26 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       status,
       portfolio_id,
       enrichment_status,
+      custom_filter,
       limit: limitParam = '100',
       offset: offsetParam = '0',
     } = req.query
+
+    // Parse custom_filter — JSON-encoded { field_key: string | string[] }.
+    // Strings → ilike contains; arrays → any-of (overlap-style match).
+    // Empty / unparseable → ignored.
+    let customFilter: Record<string, string | string[]> | null = null
+    if (custom_filter) {
+      try {
+        const parsed = JSON.parse(String(custom_filter))
+        if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+          customFilter = parsed
+        }
+      } catch {
+        return res.status(400).json({ error: 'custom_filter must be JSON' })
+      }
+    }
+    const hasCustomFilter = !!customFilter && Object.keys(customFilter).length > 0
 
     // Service-key callers must scope to a client
     if (ctx.mode === 'service' && !client_id) {
@@ -58,7 +75,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     const hasStatusFilter = status && String(status).trim().length > 0
     const hasPortfolioFilter = portfolio_id && String(portfolio_id).trim().length > 0
 
-    if (hasClientFilter || hasStatusFilter || hasPortfolioFilter) {
+    if (hasClientFilter || hasStatusFilter || hasPortfolioFilter || hasCustomFilter) {
       // Strip empty/whitespace-only ids — Postgres uuid type rejects ''
       // with a 22P02 error which would surface as a 500 here.
       const cleanIds = (csv: string) =>
@@ -76,9 +93,12 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       // legitimate portfolio. Beyond that something is wrong upstream.
       const MAX_SL_PAGES = 100
       for (let page = 0; page < MAX_SL_PAGES; page++) {
+        // Pull custom_fields too when a custom_filter is present so we can
+        // post-filter in JS (cleaner than betting on PostgREST jsonb syntax).
+        const slSelect = hasCustomFilter ? 'property_id, custom_fields' : 'property_id'
         let slQuery = db
           .from('service_locations')
-          .select('property_id')
+          .select(slSelect)
           .range(slOffset, slOffset + SL_PAGE - 1)
         if (hasClientFilter) {
           const ids = cleanIds(String(client_id))
@@ -103,8 +123,32 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         }
         const batch = sls ?? []
         for (const r of batch) {
-          const id = (r as any).property_id
-          if (id) propIdSet.add(id)
+          const row = r as any
+          const id = row.property_id
+          if (!id) continue
+          if (hasCustomFilter && customFilter) {
+            const cf = (row.custom_fields ?? {}) as Record<string, unknown>
+            let pass = true
+            for (const [key, expected] of Object.entries(customFilter)) {
+              const actual = cf[key]
+              if (Array.isArray(expected)) {
+                if (expected.length === 0) continue
+                if (actual == null || !expected.map(String).includes(String(actual))) {
+                  pass = false
+                  break
+                }
+              } else if (typeof expected === 'string') {
+                const needle = expected.trim().toLowerCase()
+                if (needle.length === 0) continue
+                if (actual == null || !String(actual).toLowerCase().includes(needle)) {
+                  pass = false
+                  break
+                }
+              }
+            }
+            if (!pass) continue
+          }
+          propIdSet.add(id)
         }
         if (batch.length < SL_PAGE) break
         slOffset += SL_PAGE

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -39,6 +39,7 @@ import TemplateDetailPage from './pages/accounts/scheduler/TemplateDetail'
 import CycleComparePage from './pages/accounts/scheduler/CycleCompare'
 import CycleDetailPage from './pages/accounts/scheduler/CycleDetail'
 import TravelPlannerPage from './pages/accounts/TravelPlanner'
+import CustomFieldsAdminPage from './pages/accounts/CustomFieldsAdmin'
 import NewAccountClientPage from './pages/accounts/NewAccountClient'
 import ClientsListPage from './pages/clients/ClientsList'
 import NewClientPage from './pages/clients/NewClient'
@@ -174,6 +175,10 @@ export default function App() {
           <Route
             path="/accounts/:accountId/clients/:clientId/travel"
             element={<AuthGuard><TravelPlannerPage /></AuthGuard>}
+          />
+          <Route
+            path="/accounts/:accountId/clients/:clientId/admin/custom-fields"
+            element={<AuthGuard><CustomFieldsAdminPage /></AuthGuard>}
           />
           <Route path="/accounts/:id/clients/new" element={<AuthGuard><NewAccountClientPage /></AuthGuard>} />
 

--- a/src/components/map/FilterSidebar.tsx
+++ b/src/components/map/FilterSidebar.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useMemo } from 'react'
 import { useAuth } from '../../hooks/useAuth'
 import { useClient } from '../../context/ClientContext'
 import { Input } from '../ui/Input'
@@ -10,12 +10,24 @@ interface FilterSidebarProps {
   onChange: (filter: MapFilter) => void
 }
 
+interface CustomFieldDef {
+  id: string
+  field_key: string
+  field_label: string
+  field_type: 'text' | 'number' | 'date' | 'select'
+  select_options: string[] | null
+  client_id: string | null
+  appears_in_filters: boolean
+  sort_order: number
+}
+
 const STATUSES: ServiceLocationStatus[] = ['active', 'paused', 'terminated', 'prospect']
 
 export default function FilterSidebar({ filter, onChange }: FilterSidebarProps) {
   const { getToken } = useAuth()
   const { clients: allClients } = useClient()
   const [portfolios, setPortfolios] = useState<{ portfolio_id: string; name: string }[]>([])
+  const [customDefs, setCustomDefs] = useState<CustomFieldDef[]>([])
 
   // Only show active+prospect clients in filter
   const clients = allClients.filter((c) => c.status !== 'churned')
@@ -36,6 +48,74 @@ export default function FilterSidebar({ filter, onChange }: FilterSidebarProps) 
     load()
   }, [getToken])
 
+  // Custom-field defs are per-client. When clients are selected, union the
+  // filterable defs across those clients. With no client filter, hide the
+  // section (custom fields are noise without a scope).
+  useEffect(() => {
+    let cancelled = false
+    async function loadCustom() {
+      if (filter.clients.length === 0) {
+        setCustomDefs([])
+        return
+      }
+      const token = await getToken()
+      const headers = { Authorization: `Bearer ${token}` }
+      const all: CustomFieldDef[] = []
+      const seen = new Set<string>()
+      for (const cid of filter.clients) {
+        try {
+          const res = await fetch(
+            `/api/v1/custom-field-definitions?client_id=${cid}`,
+            { headers }
+          )
+          if (!res.ok) continue
+          const defs = (await res.json()) as CustomFieldDef[]
+          for (const d of defs) {
+            if (!d.appears_in_filters) continue
+            if (seen.has(d.field_key)) continue
+            seen.add(d.field_key)
+            all.push(d)
+          }
+        } catch {
+          // ignore — partial result is fine
+        }
+      }
+      if (!cancelled) {
+        all.sort((a, b) => a.sort_order - b.sort_order || a.field_label.localeCompare(b.field_label))
+        setCustomDefs(all)
+      }
+    }
+    loadCustom()
+    return () => {
+      cancelled = true
+    }
+  }, [filter.clients, getToken])
+
+  const customFilter = filter.custom ?? {}
+
+  const setCustomText = (key: string, value: string) => {
+    const next = { ...customFilter }
+    if (value.trim() === '') delete next[key]
+    else next[key] = value
+    onChange({ ...filter, custom: next })
+  }
+
+  const toggleCustomSelect = (key: string, value: string) => {
+    const next = { ...customFilter }
+    const cur = next[key]
+    const arr = Array.isArray(cur) ? cur : []
+    const has = arr.includes(value)
+    const updated = has ? arr.filter((v) => v !== value) : [...arr, value]
+    if (updated.length === 0) delete next[key]
+    else next[key] = updated
+    onChange({ ...filter, custom: next })
+  }
+
+  const hasActiveCustom = useMemo(
+    () => Object.keys(customFilter).length > 0,
+    [customFilter]
+  )
+
   const toggleMulti = (key: keyof MapFilter, value: string) => {
     const arr = filter[key] as string[]
     onChange({
@@ -45,13 +125,14 @@ export default function FilterSidebar({ filter, onChange }: FilterSidebarProps) 
   }
 
   const clearAll = () =>
-    onChange({ clients: [], cityState: '', statuses: [], portfolios: [] })
+    onChange({ clients: [], cityState: '', statuses: [], portfolios: [], custom: {} })
 
   const hasActive =
     filter.clients.length > 0 ||
     filter.cityState !== '' ||
     filter.statuses.length > 0 ||
-    filter.portfolios.length > 0
+    filter.portfolios.length > 0 ||
+    hasActiveCustom
 
   return (
     <div className="hidden md:flex w-64 shrink-0 flex-col h-full overflow-hidden border-r border-border bg-surface-subtle">
@@ -124,6 +205,45 @@ export default function FilterSidebar({ filter, onChange }: FilterSidebarProps) 
             </ul>
           </FilterGroup>
         )}
+
+        {/* Custom fields — only when a client is selected (defs are per-client). */}
+        {customDefs.map((def) => {
+          const value = customFilter[def.field_key]
+          if (def.field_type === 'select') {
+            const options = def.select_options ?? []
+            const selected = Array.isArray(value) ? value : []
+            return (
+              <FilterGroup key={def.id} label={def.field_label}>
+                <ul className="max-h-36 space-y-1 overflow-y-auto pr-1">
+                  {options.length === 0 ? (
+                    <li className="text-xs text-fg-subtle italic">No options defined.</li>
+                  ) : (
+                    options.map((opt) => (
+                      <FilterOption
+                        key={opt}
+                        checked={selected.includes(opt)}
+                        onToggle={() => toggleCustomSelect(def.field_key, opt)}
+                        label={opt}
+                      />
+                    ))
+                  )}
+                </ul>
+              </FilterGroup>
+            )
+          }
+          // text / number / date — single text input with contains-match
+          // semantics. Number/date refinement (range) is a follow-up.
+          return (
+            <FilterGroup key={def.id} label={def.field_label}>
+              <Input
+                type={def.field_type === 'date' ? 'date' : 'text'}
+                placeholder={def.field_type === 'number' ? 'Match contains…' : 'Contains…'}
+                value={typeof value === 'string' ? value : ''}
+                onChange={(e) => setCustomText(def.field_key, e.target.value)}
+              />
+            </FilterGroup>
+          )
+        })}
       </div>
     </div>
   )

--- a/src/pages/Map.tsx
+++ b/src/pages/Map.tsx
@@ -26,6 +26,7 @@ const DEFAULT_FILTER: MapFilter = {
   cityState: '',
   statuses: [],
   portfolios: [],
+  custom: {},
 }
 
 export default function MapPage() {
@@ -80,6 +81,22 @@ export default function MapPage() {
           )
           if (portfoliosClean.length) params.set('portfolio_id', portfoliosClean.join(','))
           if (filter.cityState) params.set('city_state', filter.cityState)
+          // Custom filters — JSON-encoded blob the server post-filters on.
+          // Empty values get stripped client-side already (FilterSidebar)
+          // but defend in case the shape leaks through.
+          const cf = filter.custom ?? {}
+          const cfClean: Record<string, string | string[]> = {}
+          for (const [k, v] of Object.entries(cf)) {
+            if (Array.isArray(v)) {
+              const arr = v.filter((x) => typeof x === 'string' && x.trim().length > 0)
+              if (arr.length) cfClean[k] = arr
+            } else if (typeof v === 'string' && v.trim().length > 0) {
+              cfClean[k] = v
+            }
+          }
+          if (Object.keys(cfClean).length) {
+            params.set('custom_filter', JSON.stringify(cfClean))
+          }
           params.set('limit', '2000')
           params.set('offset', String(offset))
           return params

--- a/src/pages/accounts/AccountAnalysis.tsx
+++ b/src/pages/accounts/AccountAnalysis.tsx
@@ -11,6 +11,7 @@ import {
   Pencil,
   Plane,
   Sparkles,
+  SlidersHorizontal,
 } from 'lucide-react'
 import { useAuth } from '../../hooks/useAuth'
 import Button from '../../components/ui/Button'
@@ -1288,6 +1289,12 @@ function AnalysisSidebar({
           to={`/accounts/${accountId}/clients/${clientId}/admin/constraint-templates`}
         >
           Constraint templates
+        </SidebarItem>
+        <SidebarItem
+          icon={SlidersHorizontal}
+          to={`/accounts/${accountId}/clients/${clientId}/admin/custom-fields`}
+        >
+          Custom fields
         </SidebarItem>
         <SidebarItem
           icon={Sparkles}

--- a/src/pages/accounts/CustomFieldsAdmin.tsx
+++ b/src/pages/accounts/CustomFieldsAdmin.tsx
@@ -1,0 +1,439 @@
+// Per-client custom-field manager. Operators define field_key + label +
+// type + (for select) options; toggle which appear in the Map filter
+// sidebar; archive what they no longer need. Backed by the existing
+// /api/v1/custom-field-definitions CRUD.
+import { useCallback, useEffect, useState } from 'react'
+import { useParams } from 'react-router-dom'
+import { Plus, Trash2 } from 'lucide-react'
+import AppShell from '../../components/layout/AppShell'
+import { Card, CardTitle, CardDescription } from '../../components/ui/Card'
+import Button from '../../components/ui/Button'
+import { Input, FormField, Textarea } from '../../components/ui/Input'
+import { Badge } from '../../components/ui/Badge'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '../../components/ui/Table'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '../../components/ui/Dialog'
+import { useAuth } from '../../hooks/useAuth'
+
+type FieldType = 'text' | 'number' | 'date' | 'select'
+
+interface FieldDef {
+  id: string
+  field_key: string
+  field_label: string
+  field_type: FieldType
+  select_options: string[] | null
+  account_id: string | null
+  client_id: string | null
+  appears_in_filters: boolean
+  appears_in_groups: boolean
+  sort_order: number
+}
+
+export default function CustomFieldsAdminPage() {
+  const { accountId, clientId } = useParams<{ accountId: string; clientId: string }>()
+  const { getToken } = useAuth()
+  const [fields, setFields] = useState<FieldDef[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [account, setAccount] = useState<{ name: string; display_name: string | null } | null>(null)
+  const [client, setClient] = useState<{ name: string; display_name: string | null } | null>(null)
+  const [creating, setCreating] = useState(false)
+  const [editing, setEditing] = useState<FieldDef | null>(null)
+
+  const refresh = useCallback(async () => {
+    if (!clientId || !accountId) return
+    setLoading(true)
+    setError(null)
+    try {
+      const token = await getToken()
+      const [defsRes, accRes, cliRes] = await Promise.all([
+        fetch(`/api/v1/custom-field-definitions?client_id=${clientId}`, {
+          headers: { Authorization: `Bearer ${token}` },
+        }),
+        fetch(`/api/accounts/${accountId}`, {
+          headers: { Authorization: `Bearer ${token}` },
+        }),
+        fetch(`/api/v1/clients/${clientId}`, {
+          headers: { Authorization: `Bearer ${token}` },
+        }),
+      ])
+      if (!defsRes.ok) throw new Error(`HTTP ${defsRes.status}`)
+      const defs = (await defsRes.json()) as FieldDef[]
+      setFields(defs)
+      if (accRes.ok) {
+        const j = await accRes.json()
+        setAccount(j.account ?? j)
+      }
+      if (cliRes.ok) setClient(await cliRes.json())
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setLoading(false)
+    }
+  }, [accountId, clientId, getToken])
+
+  useEffect(() => {
+    refresh()
+  }, [refresh])
+
+  const remove = async (id: string) => {
+    if (!confirm('Delete this field? Existing data on properties is preserved but the field will no longer appear in filters.')) return
+    try {
+      const token = await getToken()
+      const res = await fetch(`/api/v1/custom-field-definitions/${id}`, {
+        method: 'DELETE',
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}))
+        throw new Error((j as any).error ?? `HTTP ${res.status}`)
+      }
+      await refresh()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    }
+  }
+
+  const toggleFilter = async (f: FieldDef) => {
+    try {
+      const token = await getToken()
+      const res = await fetch(`/api/v1/custom-field-definitions/${f.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        body: JSON.stringify({ appears_in_filters: !f.appears_in_filters }),
+      })
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      await refresh()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    }
+  }
+
+  return (
+    <AppShell
+      breadcrumb={[
+        { label: 'Accounts', to: '/accounts' },
+        { label: account?.display_name ?? account?.name ?? '…', to: `/accounts/${accountId}` },
+        { label: client?.display_name ?? client?.name ?? '…' },
+      ]}
+    >
+      <div className="space-y-4">
+        <div className="flex items-baseline justify-between gap-3 flex-wrap">
+          <div>
+            <h1 className="text-lg font-semibold text-fg">Custom fields</h1>
+            <p className="text-xs text-fg-muted mt-0.5">
+              Fields you imported via spreadsheet that you want to filter or group by. Per-client.
+            </p>
+          </div>
+          <Button size="sm" onClick={() => setCreating(true)}>
+            <Plus className="h-4 w-4" /> New field
+          </Button>
+        </div>
+
+        {error && (
+          <Card padding="md">
+            <p className="text-sm text-danger">{error}</p>
+          </Card>
+        )}
+
+        {loading ? (
+          <Card padding="md">
+            <p className="text-sm text-fg-muted">Loading…</p>
+          </Card>
+        ) : fields.length === 0 ? (
+          <Card padding="md">
+            <CardTitle>No custom fields yet</CardTitle>
+            <CardDescription>
+              When you import a spreadsheet, any column you don't map to a
+              standard field becomes a custom field stored on each service
+              location. Define the field here so it shows up as a filter on
+              the Map page.
+            </CardDescription>
+          </Card>
+        ) : (
+          <Card padding="none">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Label</TableHead>
+                  <TableHead>Key</TableHead>
+                  <TableHead>Type</TableHead>
+                  <TableHead>Options</TableHead>
+                  <TableHead className="text-right">In filters?</TableHead>
+                  <TableHead className="text-right" />
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {fields.map((f) => (
+                  <TableRow key={f.id}>
+                    <TableCell>
+                      <button
+                        type="button"
+                        onClick={() => setEditing(f)}
+                        className="font-medium text-accent hover:underline"
+                      >
+                        {f.field_label}
+                      </button>
+                    </TableCell>
+                    <TableCell className="font-mono text-xs text-fg-muted">{f.field_key}</TableCell>
+                    <TableCell>
+                      <Badge variant="outline" className="text-[10px] uppercase">
+                        {f.field_type}
+                      </Badge>
+                    </TableCell>
+                    <TableCell className="text-xs text-fg-muted truncate max-w-xs">
+                      {f.field_type === 'select'
+                        ? (f.select_options ?? []).join(', ') || '—'
+                        : '—'}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <button
+                        type="button"
+                        onClick={() => toggleFilter(f)}
+                        className={
+                          'rounded-md border px-2 py-0.5 text-xs ' +
+                          (f.appears_in_filters
+                            ? 'border-accent bg-accent/10 text-accent'
+                            : 'border-border bg-surface text-fg-muted hover:text-fg')
+                        }
+                      >
+                        {f.appears_in_filters ? 'Yes' : 'No'}
+                      </button>
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <button
+                        type="button"
+                        onClick={() => remove(f.id)}
+                        className="text-fg-subtle hover:text-danger"
+                      >
+                        <Trash2 className="h-3.5 w-3.5" />
+                      </button>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </Card>
+        )}
+      </div>
+
+      {(creating || editing) && (
+        <FieldDialog
+          accountId={accountId!}
+          clientId={clientId!}
+          existing={editing}
+          onClose={() => {
+            setCreating(false)
+            setEditing(null)
+          }}
+          onSaved={() => {
+            setCreating(false)
+            setEditing(null)
+            refresh()
+          }}
+        />
+      )}
+    </AppShell>
+  )
+}
+
+function FieldDialog({
+  accountId,
+  clientId,
+  existing,
+  onClose,
+  onSaved,
+}: {
+  accountId: string
+  clientId: string
+  existing: FieldDef | null
+  onClose: () => void
+  onSaved: () => void
+}) {
+  const { getToken } = useAuth()
+  const [label, setLabel] = useState(existing?.field_label ?? '')
+  const [key, setKey] = useState(existing?.field_key ?? '')
+  const [type, setType] = useState<FieldType>(existing?.field_type ?? 'text')
+  const [optionsText, setOptionsText] = useState(
+    (existing?.select_options ?? []).join('\n')
+  )
+  const [appearsInFilters, setAppearsInFilters] = useState(
+    existing?.appears_in_filters ?? true
+  )
+  const [saving, setSaving] = useState(false)
+  const [err, setErr] = useState<string | null>(null)
+
+  const isEdit = !!existing
+
+  const save = async () => {
+    setErr(null)
+    if (!label.trim()) {
+      setErr('Label is required')
+      return
+    }
+    if (!isEdit && !key.trim()) {
+      setErr('Key is required')
+      return
+    }
+    if (type === 'select') {
+      const opts = optionsText.split('\n').map((s) => s.trim()).filter(Boolean)
+      if (opts.length === 0) {
+        setErr('Select fields need at least one option (one per line)')
+        return
+      }
+    }
+    setSaving(true)
+    try {
+      const token = await getToken()
+      const select_options =
+        type === 'select'
+          ? optionsText.split('\n').map((s) => s.trim()).filter(Boolean)
+          : null
+      if (isEdit) {
+        const res = await fetch(
+          `/api/v1/custom-field-definitions/${existing!.id}`,
+          {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+            body: JSON.stringify({
+              field_label: label.trim(),
+              select_options,
+              appears_in_filters: appearsInFilters,
+            }),
+          }
+        )
+        if (!res.ok) {
+          const j = await res.json().catch(() => ({}))
+          throw new Error((j as any).error ?? `HTTP ${res.status}`)
+        }
+      } else {
+        const res = await fetch(`/api/v1/custom-field-definitions`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+          body: JSON.stringify({
+            field_key: key.trim(),
+            field_label: label.trim(),
+            field_type: type,
+            select_options,
+            account_id: accountId,
+            client_id: clientId,
+            appears_in_filters: appearsInFilters,
+          }),
+        })
+        if (!res.ok) {
+          const j = await res.json().catch(() => ({}))
+          throw new Error((j as any).error ?? `HTTP ${res.status}`)
+        }
+      }
+      onSaved()
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <Dialog open onOpenChange={(o) => !o && onClose()}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>{isEdit ? 'Edit field' : 'New custom field'}</DialogTitle>
+          <DialogDescription>
+            Define a field that exists on this client's service locations
+            (typically imported from a spreadsheet column).
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3 py-2">
+          <FormField label="Label" helper="What operators see in the filter sidebar.">
+            <Input
+              autoFocus
+              value={label}
+              onChange={(e) => setLabel(e.target.value)}
+              placeholder="e.g. Region, Tier, Inspector"
+            />
+          </FormField>
+          <FormField
+            label="Key"
+            helper={
+              isEdit
+                ? 'Cannot change after creation — must match the property data.'
+                : 'Internal key matching the column name on imported rows. Lowercase, no spaces.'
+            }
+          >
+            <Input
+              value={key}
+              onChange={(e) => setKey(e.target.value.toLowerCase().replace(/\s+/g, '_'))}
+              placeholder="e.g. region, tier, inspector"
+              disabled={isEdit}
+            />
+          </FormField>
+          <FormField label="Type">
+            <select
+              value={type}
+              onChange={(e) => setType(e.target.value as FieldType)}
+              className="h-9 w-full rounded-md border border-border bg-surface px-3 text-sm text-fg"
+              disabled={isEdit}
+            >
+              <option value="text">Text (contains-match)</option>
+              <option value="number">Number</option>
+              <option value="date">Date</option>
+              <option value="select">Select (multi-choice)</option>
+            </select>
+          </FormField>
+          {type === 'select' && (
+            <FormField
+              label="Options"
+              helper="One per line. These show as checkboxes in the filter sidebar."
+            >
+              <Textarea
+                rows={4}
+                value={optionsText}
+                onChange={(e) => setOptionsText(e.target.value)}
+                placeholder={'North\nSouth\nEast\nWest'}
+              />
+            </FormField>
+          )}
+          <label className="flex items-center gap-2 text-sm">
+            <input
+              type="checkbox"
+              checked={appearsInFilters}
+              onChange={(e) => setAppearsInFilters(e.target.checked)}
+              className="rounded border-border accent-accent"
+            />
+            Show in Map filter sidebar
+          </label>
+        </div>
+
+        {err && (
+          <p className="text-xs text-danger border border-danger/30 bg-danger-subtle rounded-md px-2 py-1">
+            {err}
+          </p>
+        )}
+
+        <DialogFooter>
+          <Button variant="ghost" onClick={onClose} disabled={saving}>
+            Cancel
+          </Button>
+          <Button onClick={save} loading={saving}>
+            {isEdit ? 'Save changes' : 'Create field'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -301,6 +301,10 @@ export interface MapFilter {
   cityState: string
   statuses: ServiceLocationStatus[]
   portfolios: string[]
+  // Custom-field filters keyed by field_key.
+  //   string  → text contains-match
+  //   string[] → select multi-choice (any-of)
+  custom: Record<string, string | string[]>
 }
 
 export interface PropertyWithLocations extends Property {


### PR DESCRIPTION
## Summary
Operators can now define fields imported from spreadsheets and have them appear as filters on the Map page, scoped per client.

**Admin UI** — new page \`/accounts/:accountId/clients/:clientId/admin/custom-fields\`:
- Per-client list / create / edit / archive against the existing \`/api/v1/custom-field-definitions\` CRUD
- Toggle "appears in filters" inline
- field_type is fixed at creation (downstream filter UI depends on it)
- Sidebar entry under Settings on AccountAnalysis

**Map FilterSidebar**:
- Fetches definitions for each currently-selected client and unions the filterable ones (deduped by field_key)
- \`select\` fields → checkbox list (any-of)
- \`text\` / \`number\` / \`date\` fields → contains-match input
- Active custom filters trigger Clear all + count toward hasActive
- Hidden when no client is selected (custom fields are noise without a scope)

**Properties API** — \`/api/v1/properties\` accepts \`?custom_filter=<json>\` with shape:
\`\`\`json
{ "region": "north", "tier": ["gold", "platinum"] }
\`\`\`
- String → case-insensitive contains
- Array → equality any-of
- Implemented as a JS post-filter on the SL fetch (cleaner than betting on PostgREST jsonb syntax)
- Respects the existing paginated SL fetch loop

## Filter semantics chosen (matches existing patterns)
- text → \`includes\` substring match (case-insensitive)
- number/date → contains text match for v1; range refinement deferred
- select → multi-select any-of (mirrors the existing client / status / portfolio checkboxes)

## Out of scope (intentional follow-ups)
- Number/date range filters
- Custom-field filters on Travel Planner / Properties admin / Cycle Detail (same pattern, different page wiring)

## Test plan
- [ ] Settings sidebar shows "Custom fields" → opens new admin page
- [ ] Create a select field with a few options → toggle appears_in_filters on
- [ ] On Map, select that client → new filter group appears with checkboxes
- [ ] Tick options → only matching properties remain on the map
- [ ] Clear all clears the custom filter
- [ ] Create a text field → contains-match input works on Map
- [ ] tsc + build clean (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)