### PR TITLE
Fix cycle generation putting visits on weekends

### DIFF
--- a/api/_lib/scheduler/generate-cycle-instance.ts
+++ b/api/_lib/scheduler/generate-cycle-instance.ts
@@ -142,8 +142,14 @@ export async function generateCycleInstance(
 
   for (const trip of trips) {
     for (const day of trip.days ?? []) {
+      // dayOffset is a working-day count (the routing engine sequences
+      // trips back-to-back on workdays, not calendar days). crew-utilization
+      // also bucketizes by workdays. Cycle gen previously used addDays
+      // which counts calendar days, landing visits on Sat/Sun and creating
+      // a mismatch between Calendar view (workday-bucketized) and List view
+      // (raw DB rows).
       const dayOffset = (trip.relative_start_day ?? 0) + ((day.trip_day_number ?? 1) - 1)
-      const scheduledDate = addDays(startDate, dayOffset)
+      const scheduledDate = addWorkdays(startDate, dayOffset)
       if (scheduledDate > endDate) continue
 
       const crewDayRouteId = crypto.randomUUID()
@@ -289,6 +295,24 @@ function addDays(date: string, n: number): string {
   const [y, m, d] = date.split('-').map(Number)
   const dt = new Date(Date.UTC(y, m - 1, d))
   dt.setUTCDate(dt.getUTCDate() + n)
+  return dt.toISOString().slice(0, 10)
+}
+
+// Advance N working days (Mon-Fri) from a YYYY-MM-DD date. If the start
+// date itself is a weekend, rolls forward to the next Monday before
+// counting workdays — so cycle gen never returns a weekend date.
+function addWorkdays(date: string, n: number): string {
+  const [y, m, d] = date.split('-').map(Number)
+  const dt = new Date(Date.UTC(y, m - 1, d))
+  while (dt.getUTCDay() === 0 || dt.getUTCDay() === 6) {
+    dt.setUTCDate(dt.getUTCDate() + 1)
+  }
+  let remaining = n
+  while (remaining > 0) {
+    dt.setUTCDate(dt.getUTCDate() + 1)
+    const dow = dt.getUTCDay()
+    if (dow !== 0 && dow !== 6) remaining--
+  }
   return dt.toISOString().slice(0, 10)
 }
 


### PR DESCRIPTION
## Summary
Calendar view (correctly) showed M-F only, but List view showed visits scheduled on Saturdays and Sundays. The two views disagreed because the schedule itself was wrong — visits were being saved on weekend dates.

## Root cause
The routing engine sequences trips by **working-day count**:
- \`relative_start_day\` and \`trip_day_number\` are workday indices, not calendar-day indices
- \`crew-utilization.ts\` builds the day calendar skipping Sat/Sun (line 121-122)

But \`generate-cycle-instance.ts\` mapped \`dayOffset → calendar date\` with \`addDays(startDate, dayOffset)\`, which counts calendar days. A 5-day trip starting Monday landed days 6+7 on Sat+Sun. The DB stored those weekend visits, List view rendered them, Calendar view filtered them out → mismatch.

## Fix
Replace \`addDays\` with \`addWorkdays\` in cycle gen. The helper:
- Rolls a weekend \`startDate\` forward to the next Monday (so day 0 is never a weekend)
- Counts only Mon-Fri days when advancing N

Templates and crew-utilization don't need changes — they were already workday-correct.

## Important: existing cycles need regeneration
Already-generated cycles still have weekend rows in \`crew_day_routes\` and \`scheduled_visits\`. To pick up the fix, regenerate the affected cycles via the existing \`/api/scheduler/templates/[templateId]/regenerate\` endpoint or the UI affordance.

## Test plan
- [ ] Generate a cycle on a client with a M-F day_of_week constraint
- [ ] List view: every \`scheduled_date\` is a Mon-Fri
- [ ] Calendar view: same trips appear on M-F cells, no orphan weekend visits
- [ ] If \`startDate\` is intentionally a Saturday: day 0 falls on the next Monday (not the Saturday itself)
- [ ] tsc clean (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)