### PR TITLE
Phase 4.4 — aggressive pairing + steady-pace load distribution

### DIFF
--- a/api/_lib/scheduler/build-routing-template.ts
+++ b/api/_lib/scheduler/build-routing-template.ts
@@ -162,6 +162,34 @@ export interface TemplateBuildResult {
       classified: 'local' | 'remote'
     }>
   }
+  // Phase 4.4 — pairing + pacing analysis surfaced for the cycle summary.
+  pacing_analysis: {
+    per_crew: Array<{
+      crew_index: number
+      crew_label: string
+      total_visits: number
+      total_workdays_used: number
+      single_stop_days: number
+      paired_days: number
+      pair_rate_pct: number
+      cycle_end_workday: number
+      days_idle_at_end: number
+    }>
+    crew_end_workday_spread: number
+    target_spread_workdays: number
+    pairing_stats: {
+      total_workdays: number
+      single_stop_days: number
+      paired_days: number
+      pair_rate_pct: number
+    }
+  }
+  warnings: Array<{
+    type: 'crew_load_imbalance' | 'crew_end_date_spread' | 'pairing_underutilized'
+    message: string
+    affected_crews?: number[]
+    suggested_action?: string
+  }>
 }
 
 const DAYS_PER_YEAR = 365
@@ -681,6 +709,127 @@ export function buildRoutingTemplate(input: BuildTemplateInput): TemplateBuildRe
     )
   }
 
+  // ── 7. Phase 4.4 — pacing post-process + stats ────────────────────
+  // Spread each crew's trips across the cycle so they end within ±10
+  // workdays of the latest crew. Operates in workday space (the same
+  // unit relative_start_day is in); cycle gen later maps to calendars.
+  const tripsByCrew = new Map<number, any[]>()
+  for (const t of trips) {
+    const arr = tripsByCrew.get(t.crew_index) ?? []
+    arr.push(t)
+    tripsByCrew.set(t.crew_index, arr)
+  }
+  // Natural end workday = relative_start_day + duration_days for the latest trip.
+  const naturalEndByCrew = new Map<number, number>()
+  for (const [crewIdx, list] of tripsByCrew) {
+    const end = list.reduce((m, t) => Math.max(m, (t.relative_start_day ?? 0) + (t.duration_days ?? 0)), 0)
+    naturalEndByCrew.set(crewIdx, end)
+  }
+  const latestNaturalEnd = Math.max(0, ...Array.from(naturalEndByCrew.values()))
+  // Stretch every crew's trips so their LAST trip ends at latestNaturalEnd
+  // (or as close as the cycle horizon allows). Distribute the slack as
+  // idle gaps proportional to trip durations between consecutive trips.
+  for (const [crewIdx, list] of tripsByCrew) {
+    if (list.length === 0) continue
+    list.sort((a, b) => (a.relative_start_day ?? 0) - (b.relative_start_day ?? 0))
+    const naturalEnd = naturalEndByCrew.get(crewIdx) ?? 0
+    if (naturalEnd >= latestNaturalEnd) continue
+    const slack = Math.min(latestNaturalEnd - naturalEnd, Math.max(0, cycleDays - naturalEnd))
+    if (slack <= 0) continue
+    // Distribute slack across the gaps after each trip except the last.
+    // For N trips → N-1 gap slots; if there's 1 trip, just delay it.
+    const slots = Math.max(1, list.length - 1)
+    const baseGap = Math.floor(slack / slots)
+    const remainder = slack - baseGap * slots
+    let cursor = list[0].relative_start_day ?? 0
+    if (list.length === 1) {
+      list[0].relative_start_day = cursor + slack
+    } else {
+      for (let i = 0; i < list.length; i++) {
+        list[i].relative_start_day = cursor
+        cursor += list[i].duration_days ?? 0
+        if (i < list.length - 1) {
+          cursor += baseGap + (i < remainder ? 1 : 0)
+        }
+      }
+    }
+  }
+
+  // Pair-rate + idle-tail stats. After pacing, "natural end" for slow
+  // crews moves up toward the latest crew's end.
+  const pacingPerCrew: TemplateBuildResult['pacing_analysis']['per_crew'] = []
+  let globalSingleStop = 0
+  let globalPaired = 0
+  for (const c of crews) {
+    const list = tripsByCrew.get(c.index) ?? []
+    let workdaysUsed = 0
+    let visits = 0
+    let single = 0
+    let paired = 0
+    let lastEnd = 0
+    for (const t of list) {
+      const dur = t.duration_days ?? 0
+      workdaysUsed += dur
+      lastEnd = Math.max(lastEnd, (t.relative_start_day ?? 0) + dur)
+      for (const day of t.days ?? []) {
+        const stops = (day.stops ?? []).length
+        visits += stops
+        if (stops <= 1) single++
+        else paired++
+      }
+    }
+    globalSingleStop += single
+    globalPaired += paired
+    const totalDays = single + paired
+    pacingPerCrew.push({
+      crew_index: c.index,
+      crew_label: c.label,
+      total_visits: visits,
+      total_workdays_used: workdaysUsed,
+      single_stop_days: single,
+      paired_days: paired,
+      pair_rate_pct: totalDays > 0 ? Math.round((paired / totalDays) * 1000) / 10 : 0,
+      cycle_end_workday: lastEnd,
+      days_idle_at_end: Math.max(0, latestNaturalEnd - lastEnd),
+    })
+  }
+  const endWorkdays = pacingPerCrew.map((p) => p.cycle_end_workday).filter((n) => n > 0)
+  const crewEndSpread =
+    endWorkdays.length > 1 ? Math.max(...endWorkdays) - Math.min(...endWorkdays) : 0
+  const TARGET_SPREAD = 10
+  const totalDaysGlobal = globalSingleStop + globalPaired
+  const pacing_analysis: TemplateBuildResult['pacing_analysis'] = {
+    per_crew: pacingPerCrew,
+    crew_end_workday_spread: crewEndSpread,
+    target_spread_workdays: TARGET_SPREAD,
+    pairing_stats: {
+      total_workdays: totalDaysGlobal,
+      single_stop_days: globalSingleStop,
+      paired_days: globalPaired,
+      pair_rate_pct: totalDaysGlobal > 0
+        ? Math.round((globalPaired / totalDaysGlobal) * 1000) / 10
+        : 0,
+    },
+  }
+
+  const warnings: TemplateBuildResult['warnings'] = []
+  if (crewEndSpread > TARGET_SPREAD) {
+    const slowest = pacingPerCrew.reduce((a, b) => (a.cycle_end_workday < b.cycle_end_workday ? b : a))
+    const fastest = pacingPerCrew.reduce((a, b) => (a.cycle_end_workday > b.cycle_end_workday ? b : a))
+    warnings.push({
+      type: 'crew_end_date_spread',
+      message: `Crew end-workdays spread ${crewEndSpread} (target ≤${TARGET_SPREAD}). ${slowest.crew_label} ends ${crewEndSpread}d after ${fastest.crew_label}.`,
+      affected_crews: [slowest.crew_index, fastest.crew_index],
+      suggested_action: 're-cluster property assignments across crews to equalize load',
+    })
+  }
+  if (totalDaysGlobal > 20 && pacing_analysis.pairing_stats.pair_rate_pct < 20) {
+    warnings.push({
+      type: 'pairing_underutilized',
+      message: `Pair rate ${pacing_analysis.pairing_stats.pair_rate_pct}% — most days are single-stop. Geography may not have many close pairs, or in_day_pairing_max_drive_minutes is tight.`,
+    })
+  }
+
   return {
     cycle_length_days: cycleDays,
     cycle_length_label: cycleResult.cycle_length_label,
@@ -728,6 +877,8 @@ export function buildRoutingTemplate(input: BuildTemplateInput): TemplateBuildRe
       // First 10 sample classifications for user audit on the cycle UI.
       sample: classificationAudit.slice(0, 10),
     },
+    pacing_analysis,
+    warnings,
   }
 }
 

--- a/api/_lib/scheduler/route-day.ts
+++ b/api/_lib/scheduler/route-day.ts
@@ -205,17 +205,25 @@ export function routeDay(input: DayRoutingInput): DayRoutingResult {
         : 0
       if (workEndMin + returnDriveMin > workEnd) continue
 
-      // Phase 4.3 — pairing rule: combined-sqft + drive-radius check.
-      // The second slot is only filled when both buildings are within
-      // maxPairDriveMin of each other AND their combined serviceable
-      // sqft is at most maxCombinedSqft.
+      // Phase 4.4 — aggressive pairing: drop the combined-sqft gate and
+      // rely on the time-fit check above. The drive-minute cap stays as
+      // a hard gate; size class becomes a soft tiebreaker (see scoring
+      // below). Two standard properties at 4-5 hr each fit in a single
+      // day with room to spare and the previous rule blocked them.
+      let pairingTiebreakerPenalty = 0
       if (route.length >= 1) {
         if (driveMin > maxPairDriveMin) continue
+        // Soft tiebreaker: prefer small+small pairings when multiple
+        // candidates fit. Penalty only differentiates between equally
+        // valid pairings; never blocks a fit.
         const firstStop = route[0]
         const firstProp = candidates.find((c) => c.id === firstStop.service_location_id)
-        const firstSqft = firstProp?.serviceable_sqft ?? 0
-        const candidateSqft = p.serviceable_sqft ?? 0
-        if (firstSqft + candidateSqft > maxCombinedSqft) continue
+        const isSmall = (sqft: number) => sqft > 0 && sqft <= maxCombinedSqft / 2
+        const firstSmall = isSmall(firstProp?.serviceable_sqft ?? 0)
+        const candidateSmall = isSmall(p.serviceable_sqft ?? 0)
+        if (!(firstSmall && candidateSmall)) {
+          pairingTiebreakerPenalty = 5
+        }
       }
 
       // Soft-constraint penalty at this proposed schedule
@@ -236,7 +244,8 @@ export function routeDay(input: DayRoutingInput): DayRoutingResult {
         }
       }
 
-      // Score: depends on objective
+      // Score: depends on objective. Tiebreaker penalty added on top
+      // for non-small+small pairings (Phase 4.4).
       let score: number
       if (input.preferences.objective === 'minimize_drive') {
         score = driveMin + softPenalty * 30 * input.preferences.soft_constraint_weight
@@ -247,6 +256,7 @@ export function routeDay(input: DayRoutingInput): DayRoutingResult {
       } else {
         score = driveMin + softPenalty * 20 * input.preferences.soft_constraint_weight
       }
+      score += pairingTiebreakerPenalty
 
       if (score < bestScore) {
         bestScore = score

--- a/api/scheduler/templates/[templateId]/regenerate.ts
+++ b/api/scheduler/templates/[templateId]/regenerate.ts
@@ -277,6 +277,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         soft_constraint_violations: result.soft_constraint_violations,
         optimization_score: result.optimization_score,
         optimizer_notes: result.optimizer_notes,
+        pacing_analysis: result.pacing_analysis,
+        warnings: result.warnings,
       })
       .eq('id', templateId)
     const { data: full } = await db.from('routing_templates').select('*').eq('id', templateId).single()

--- a/api/scheduler/templates/index.ts
+++ b/api/scheduler/templates/index.ts
@@ -327,6 +327,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           soft_constraint_violations: result.soft_constraint_violations,
           optimization_score: result.optimization_score,
           optimizer_notes: result.optimizer_notes,
+          pacing_analysis: result.pacing_analysis,
+          warnings: result.warnings,
         })
         .eq('id', templateId)
 

--- a/src/pages/accounts/scheduler/CycleDetail.tsx
+++ b/src/pages/accounts/scheduler/CycleDetail.tsx
@@ -81,6 +81,8 @@ export default function CycleDetailPage() {
   const [view, setView] = useState<CycleViewKind>('gantt')
   const [saveState, setSaveState] = useState<SaveState>('saved')
   const [optimizationScore, setOptimizationScore] = useState<number | null>(null)
+  const [pacing, setPacing] = useState<any | null>(null)
+  const [pacingWarnings, setPacingWarnings] = useState<Array<{ type: string; message: string }>>([])
   const [branches, setBranches] = useState<Array<{ name: string; lat: number; lng: number }>>([])
   const [selectedVisitIds, setSelectedVisitIds] = useState<Set<string>>(new Set())
 
@@ -110,6 +112,10 @@ export default function CycleDetailPage() {
         if (tplRes.ok) {
           const tpl = await tplRes.json()
           setOptimizationScore(tpl.template?.optimization_score ?? null)
+          setPacing(tpl.template?.pacing_analysis ?? null)
+          setPacingWarnings(
+            Array.isArray(tpl.template?.warnings) ? tpl.template.warnings : []
+          )
           setBranches(
             (tpl.template?.branches ?? []).map((b: any) => ({
               name: b.name,
@@ -453,6 +459,57 @@ export default function CycleDetailPage() {
             tone={optimizationScore != null && optimizationScore >= 80 ? 'success' : 'default'}
           />
         </div>
+
+        {/* Phase 4.4 — pairing + pacing summary */}
+        {pacing && (
+          <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
+            <Stat
+              label="Pair rate"
+              value={`${pacing.pairing_stats?.pair_rate_pct ?? 0}%`}
+              sub={`${pacing.pairing_stats?.paired_days ?? 0} paired · ${pacing.pairing_stats?.single_stop_days ?? 0} single`}
+              tone={
+                (pacing.pairing_stats?.pair_rate_pct ?? 0) >= 40
+                  ? 'success'
+                  : (pacing.pairing_stats?.pair_rate_pct ?? 0) >= 20
+                    ? 'warning'
+                    : 'default'
+              }
+            />
+            <Stat
+              label="Crew end-day spread"
+              value={`${pacing.crew_end_workday_spread ?? 0} days`}
+              sub={`target ≤${pacing.target_spread_workdays ?? 10}`}
+              tone={
+                (pacing.crew_end_workday_spread ?? 0) <= (pacing.target_spread_workdays ?? 10)
+                  ? 'success'
+                  : 'warning'
+              }
+            />
+            <Stat
+              label="Crews used"
+              value={String((pacing.per_crew ?? []).length)}
+              sub={(pacing.per_crew ?? [])
+                .map((p: any) => `${p.crew_label ?? `Crew ${p.crew_index + 1}`}: ${p.pair_rate_pct}% paired`)
+                .join(' · ')}
+            />
+          </div>
+        )}
+
+        {pacingWarnings.length > 0 && (
+          <div className="space-y-2">
+            {pacingWarnings.map((w, i) => (
+              <div
+                key={i}
+                className="rounded-md border border-warning/30 bg-warning-subtle px-3 py-2 text-xs text-fg"
+              >
+                <span className="font-semibold">⚠ {w.message}</span>
+                {(w as any).suggested_action && (
+                  <span className="ml-1 text-fg-muted">— {(w as any).suggested_action}</span>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
 
         {/* View switcher content */}
         {view === 'gantt' && (

--- a/supabase/migrations/20260501194619_phase_4_4_pacing_analysis.sql
+++ b/supabase/migrations/20260501194619_phase_4_4_pacing_analysis.sql
@@ -1,0 +1,8 @@
+-- Phase 4.4 — pacing analysis on routing templates.
+-- pacing_analysis: per-crew pair rates + end-workday spread.
+-- warnings: structured warnings the cycle UI surfaces (load imbalance,
+-- pairing underutilized, etc.). Both are jsonb so the engine can extend
+-- the shape without further migrations.
+ALTER TABLE public.routing_templates
+  ADD COLUMN IF NOT EXISTS pacing_analysis jsonb,
+  ADD COLUMN IF NOT EXISTS warnings jsonb NOT NULL DEFAULT '[]'::jsonb;


### PR DESCRIPTION
## Summary
Two engine improvements driven by Cycle 2 analysis (97.6% single-stop days, 24-day crew end spread):

**Aggressive pairing** (\`route-day.ts\`)
- Dropped the Phase 4.3 combined-sqft hard gate. Time-fit (work + drive ≤ work_end) and drive-minute cap are the only hard gates; the 2-buildings/day cap stays.
- \`size_class='small'\` becomes a soft tiebreaker — score penalizes non-small+small pairings by +5 so equally-valid pairings prefer two smalls. Never blocks a fit.
- Two standard properties at 4-5 hr each now pair freely.

**Steady-pace load distribution** (\`build-routing-template.ts\`)
- New post-process spreads each crew's trips so all crews end within ±10 workdays of the latest. Operates in workday space (the unit \`relative_start_day\` already uses); idle gaps inserted proportional to remaining slack.
- Single-trip crews: start_day pushed back. Multi-trip crews: gaps distributed evenly between trips.
- Slack bounded by cycle horizon so crews never push past \`cycle_end_date\`.

**Output stats** (new on \`TemplateBuildResult\`)
\`\`\`
pacing_analysis: {
  per_crew: [{ crew_index, crew_label, total_visits, total_workdays_used,
               single_stop_days, paired_days, pair_rate_pct,
               cycle_end_workday, days_idle_at_end }],
  crew_end_workday_spread: number,
  target_spread_workdays: 10,
  pairing_stats: { total_workdays, single_stop_days, paired_days, pair_rate_pct },
}
warnings: [{ type, message, affected_crews?, suggested_action? }]
\`\`\`

**Persistence**: migration adds \`pacing_analysis\` + \`warnings\` jsonb columns to \`routing_templates\`. Both create + regenerate endpoints write them.

**UI** (\`CycleDetail\`): new row of stats — Pair rate, Crew end-day spread, Crews used (with per-crew pair-rate strip). Warning chips render above the view switcher.

## Existing cycles need regeneration
This PR only changes engine + persistence. To see new pair rates and pacing, regenerate the affected routing templates (existing endpoint).

## Out of scope (deferred — call them out in a follow-up if needed)
- Per-crew Gantt breakdown UI (rows showing each crew's end + paired days)
- Cross-crew rebalancing of property assignments (auto-redistribute properties)
- 3+ buildings per day cap relaxation

## Test plan
- [ ] Regenerate JLL Cycle 2 → pair rate ≥40% (was 2.4%), end spread ≤10 days (was 24)
- [ ] Per-crew avg work hr/day rises from 5.9 toward 8+
- [ ] Total crew-days drop from 497 toward <400
- [ ] Try \`crew_count=3\` after that — either succeeds with sane utilization or fails with clear infeasibility
- [ ] Two 8-hr properties don't pair (combined work > max day)
- [ ] One 4-hr + one 5-hr → pair (no longer blocked by size class)
- [ ] Drive 31 min between → blocked
- [ ] Pacing post-process never pushes a crew past cycle_end_date
- [ ] Warnings render in cycle summary when spread >10 or pair rate <20% with meaningful day count
- [ ] tsc + build clean (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)