### PR TITLE
Fix template build truncating to 500 properties

### DIFF
--- a/api/scheduler/templates/[templateId]/regenerate.ts
+++ b/api/scheduler/templates/[templateId]/regenerate.ts
@@ -82,11 +82,27 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     .update({ status: 'optimizing', updated_at: new Date().toISOString() })
     .eq('id', templateId)
 
-  // Re-load offerings + property hours + cohorts
-  const { data: slRows } = await db
-    .from('service_locations')
-    .select('id, property_id, service_offering_id, serviceable_sqft, hours_per_visit_override, building_size_class_override, property:properties(id, address_line1, latitude, longitude)')
-    .in('id', slIds)
+  // Re-load offerings + property hours + cohorts. Page through chunks
+  // — PostgREST silently caps a single fetch and large clients can
+  // exceed it (truncated to 500 in practice).
+  const SL_CHUNK = 250
+  const SL_PAGE = 1000
+  const slRows: any[] = []
+  for (let i = 0; i < slIds.length; i += SL_CHUNK) {
+    const idChunk = slIds.slice(i, i + SL_CHUNK)
+    let pageOffset = 0
+    for (let p = 0; p < 50; p++) {
+      const { data } = await db
+        .from('service_locations')
+        .select('id, property_id, service_offering_id, serviceable_sqft, hours_per_visit_override, building_size_class_override, property:properties(id, address_line1, latitude, longitude)')
+        .in('id', idChunk)
+        .range(pageOffset, pageOffset + SL_PAGE - 1)
+      const batch = data ?? []
+      slRows.push(...batch)
+      if (batch.length < SL_PAGE) break
+      pageOffset += SL_PAGE
+    }
+  }
   const { data: offeringRows } = await db
     .from('service_offerings')
     .select('id, name, is_routed, offering_role, visit_interval_years, attaches_to_offering_ids, uses_cohort_rotation')
@@ -149,11 +165,25 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
   const allOfferingMap = await loadAccountOfferings(db, accountId, clientId)
   const propIds = Array.from(new Set(routed.map((r) => r.sl.property_id)))
-  const { data: propRows } = await db
-    .from('properties')
-    .select('*, service_locations(*)')
-    .in('id', propIds)
-  const visits = computePropertyVisitHours((propRows ?? []) as any, allOfferingMap, {
+  const PROP_CHUNK = 250
+  const PROP_PAGE = 1000
+  const propRows: any[] = []
+  for (let i = 0; i < propIds.length; i += PROP_CHUNK) {
+    const idChunk = propIds.slice(i, i + PROP_CHUNK)
+    let pageOffset = 0
+    for (let p = 0; p < 50; p++) {
+      const { data } = await db
+        .from('properties')
+        .select('*, service_locations(*)')
+        .in('id', idChunk)
+        .range(pageOffset, pageOffset + PROP_PAGE - 1)
+      const batch = data ?? []
+      propRows.push(...batch)
+      if (batch.length < PROP_PAGE) break
+      pageOffset += PROP_PAGE
+    }
+  }
+  const visits = computePropertyVisitHours(propRows as any, allOfferingMap, {
     project_clean_base_hours: constraints.project_clean_base_hours,
     project_clean_hours_per_sqft: constraints.project_clean_hours_per_sqft,
     upholstery_solo_hours: constraints.upholstery_solo_hours,

--- a/api/scheduler/templates/index.ts
+++ b/api/scheduler/templates/index.ts
@@ -72,11 +72,28 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     }
     const branches = sel.branches.map((b) => ({ name: b.name, lat: b.lat, lng: b.lng }))
 
-    // Fetch SLs + properties + offerings
-    const { data: slRows } = await db
-      .from('service_locations')
-      .select('id, property_id, service_offering_id, serviceable_sqft, hours_per_visit_override, building_size_class_override, property:properties(id, address_line1, latitude, longitude)')
-      .in('id', slIds)
+    // Fetch SLs + properties + offerings. Chunk by 250 ids (URL length
+    // safety) AND page each chunk because PostgREST silently caps page
+    // size — combined this query previously truncated at 500 SLs even
+    // when slIds had 500+ entries, dropping the rest from the schedule.
+    const SL_CHUNK = 250
+    const SL_PAGE = 1000
+    const slRows: any[] = []
+    for (let i = 0; i < slIds.length; i += SL_CHUNK) {
+      const idChunk = slIds.slice(i, i + SL_CHUNK)
+      let pageOffset = 0
+      for (let p = 0; p < 50; p++) {
+        const { data } = await db
+          .from('service_locations')
+          .select('id, property_id, service_offering_id, serviceable_sqft, hours_per_visit_override, building_size_class_override, property:properties(id, address_line1, latitude, longitude)')
+          .in('id', idChunk)
+          .range(pageOffset, pageOffset + SL_PAGE - 1)
+        const batch = data ?? []
+        slRows.push(...batch)
+        if (batch.length < SL_PAGE) break
+        pageOffset += SL_PAGE
+      }
+    }
     const { data: offeringRows } = await db
       .from('service_offerings')
       .select('id, name, is_routed, offering_role, visit_interval_years, attaches_to_offering_ids, uses_cohort_rotation')
@@ -158,10 +175,24 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     const allOfferingMap = await loadAccountOfferings(db, accountId, clientId)
     // Property-hours expects properties with their service_locations attached.
     const propIds = Array.from(new Set(routed.map((r) => r.sl.property_id)))
-    const { data: propRows } = await db
-      .from('properties')
-      .select('*, service_locations(*)')
-      .in('id', propIds)
+    const PROP_CHUNK = 250
+    const PROP_PAGE = 1000
+    const propRows: any[] = []
+    for (let i = 0; i < propIds.length; i += PROP_CHUNK) {
+      const idChunk = propIds.slice(i, i + PROP_CHUNK)
+      let pageOffset = 0
+      for (let p = 0; p < 50; p++) {
+        const { data } = await db
+          .from('properties')
+          .select('*, service_locations(*)')
+          .in('id', idChunk)
+          .range(pageOffset, pageOffset + PROP_PAGE - 1)
+        const batch = data ?? []
+        propRows.push(...batch)
+        if (batch.length < PROP_PAGE) break
+        pageOffset += PROP_PAGE
+      }
+    }
     const visits = computePropertyVisitHours(
       (propRows ?? []) as any,
       allOfferingMap,


### PR DESCRIPTION
## Summary
The Phase 4.4 cycle came back with exactly 500 visits when 509 were expected. PR #180 paginated the cycle GET but didn't fix it — the actual cap was upstream in template build, not in cycle fetch.

## Root cause
Both \`POST /api/scheduler/templates\` and \`POST /api/scheduler/templates/[templateId]/regenerate\` loaded \`service_locations\` and \`properties\` via single \`.in('id', ids)\` calls. PostgREST silently caps page size (500 in this project's config), so when \`slIds\` had 500+ entries the build only saw the first 500. Cycle gen then only had 500 properties to schedule, the rest never made it into the schedule.

## Fix
Both endpoints now page each fetch in **250-id × 1000-row chunks**:
- 250-id chunks keep the \`.in()\` filter under PostgREST's URL length cap
- 1000-row pages loop until a short batch comes back

Same pattern \`/api/v1/properties\` already uses.

## Existing cycles need regeneration
The dropped properties don't auto-recover — regenerate the affected cycle.

## Test plan
- [ ] Regenerate JLL Cycle 2 → all 509 properties schedule (not 500)
- [ ] Smaller clients still work (single chunk + single page case)
- [ ] tsc clean (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)