### PR TITLE
Add advisory chat drawer on Cycle Detail

### DIFF
--- a/api/scheduler/cycles/[cycleId]/chat.ts
+++ b/api/scheduler/cycles/[cycleId]/chat.ts
@@ -1,0 +1,208 @@
+// POST /api/scheduler/cycles/[cycleId]/chat
+//
+// Phase 4.5 — advisory cycle chat. Loads the cycle's full context (visits,
+// crew_days, utilization, template metadata, branches, unplaced) and
+// passes a condensed system prompt + the user's message history to
+// Anthropic's API. The agent can suggest moves but cannot execute —
+// users still go to the existing scheduler UI to apply changes.
+//
+// Body: { messages: [{ role: 'user' | 'assistant', content: string }] }
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import Anthropic from '@anthropic-ai/sdk'
+import { createAdminClient } from '../../../_lib/supabase.js'
+import { authenticateRequest } from '../../../_lib/auth.js'
+
+export const config = { maxDuration: 60 }
+
+const CHAT_MODEL = 'claude-sonnet-4-5'
+const MAX_TOKENS = 1500
+
+interface ChatMessage {
+  role: 'user' | 'assistant'
+  content: string
+}
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'POST') return res.status(405).json({ error: 'Method not allowed' })
+  try {
+    await authenticateRequest(req)
+  } catch (err: any) {
+    return res.status(err.statusCode ?? 401).json({ error: err.message ?? 'Unauthorized' })
+  }
+  const cycleId = req.query.cycleId as string
+  if (!cycleId) return res.status(400).json({ error: 'cycleId required' })
+
+  const body = (req.body ?? {}) as { messages?: ChatMessage[] }
+  const messages = Array.isArray(body.messages) ? body.messages : []
+  if (messages.length === 0) return res.status(400).json({ error: 'messages required' })
+
+  const apiKey = process.env.ANTHROPIC_API_KEY
+  if (!apiKey) {
+    return res.status(500).json({ error: 'ANTHROPIC_API_KEY not configured' })
+  }
+
+  const db = createAdminClient()
+
+  // ── Load cycle context ────────────────────────────────────────────
+  const { data: cycle } = await db
+    .from('cycle_instances')
+    .select('*')
+    .eq('id', cycleId)
+    .maybeSingle()
+  if (!cycle) return res.status(404).json({ error: 'Cycle not found' })
+
+  // Page through visits + crew_days (PostgREST cap protection).
+  const PAGE = 1000
+  const visits: any[] = []
+  for (let p = 0; p < 50; p++) {
+    const { data } = await db
+      .from('scheduled_visits')
+      .select('id, status, scheduled_date, hours_per_visit_total, unplaced_reason, service_locations(display_name, property:properties(address_line1))')
+      .eq('cycle_instance_id', cycleId)
+      .range(p * PAGE, (p + 1) * PAGE - 1)
+    const batch = data ?? []
+    visits.push(...batch)
+    if (batch.length < PAGE) break
+  }
+  const crewDays: any[] = []
+  for (let p = 0; p < 50; p++) {
+    const { data } = await db
+      .from('crew_day_routes')
+      .select('id, crew_index, crew_label, scheduled_date, day_type, total_work_minutes, total_drive_minutes, total_day_minutes, route, trip_label')
+      .eq('cycle_instance_id', cycleId)
+      .range(p * PAGE, (p + 1) * PAGE - 1)
+    const batch = data ?? []
+    crewDays.push(...batch)
+    if (batch.length < PAGE) break
+  }
+
+  // Template — for branches, crew_count, pacing_analysis, warnings, required count.
+  let template: any = null
+  if (cycle.template_id) {
+    const { data } = await db
+      .from('routing_templates')
+      .select('*')
+      .eq('id', cycle.template_id)
+      .maybeSingle()
+    template = data ?? null
+  }
+
+  // ── Build system prompt ───────────────────────────────────────────
+  const placed = visits.filter((v) => v.status === 'placed').length
+  const completed = visits.filter((v) => v.status === 'completed').length
+  const unplaced = visits.filter((v) => v.status === 'unplaced')
+  const required = template?.total_visits_required_per_cycle ?? visits.length
+
+  // Crew-day classification.
+  const crewDaysByCrew = new Map<number, any[]>()
+  for (const cd of crewDays) {
+    const arr = crewDaysByCrew.get(cd.crew_index) ?? []
+    arr.push(cd)
+    crewDaysByCrew.set(cd.crew_index, arr)
+  }
+  const perCrew: Array<{
+    crew_index: number
+    crew_label: string
+    days: number
+    work_hours: number
+    drive_hours: number
+    end_date: string
+    pair_rate: number
+  }> = []
+  for (const [crewIdx, list] of crewDaysByCrew) {
+    list.sort((a, b) => (a.scheduled_date ?? '').localeCompare(b.scheduled_date ?? ''))
+    const workHours = list.reduce((s, d) => s + (d.total_work_minutes ?? 0) / 60, 0)
+    const driveHours = list.reduce((s, d) => s + (d.total_drive_minutes ?? 0) / 60, 0)
+    const paired = list.filter((d) => Array.isArray(d.route) && d.route.length >= 2).length
+    perCrew.push({
+      crew_index: crewIdx,
+      crew_label: list[0]?.crew_label ?? `Crew ${crewIdx + 1}`,
+      days: list.length,
+      work_hours: Math.round(workHours * 10) / 10,
+      drive_hours: Math.round(driveHours * 10) / 10,
+      end_date: list[list.length - 1]?.scheduled_date ?? '',
+      pair_rate: list.length > 0 ? Math.round((paired / list.length) * 100) : 0,
+    })
+  }
+  perCrew.sort((a, b) => a.crew_index - b.crew_index)
+
+  // Unplaced summary — at most 25 with reasons grouped.
+  const unplacedSample = unplaced.slice(0, 25).map((v) => ({
+    address:
+      v.service_locations?.property?.address_line1 ??
+      v.service_locations?.display_name ??
+      v.id,
+    reason: v.unplaced_reason ?? 'unknown',
+  }))
+
+  const systemPrompt = `You are a senior scheduling analyst helping a janitorial bid team refine a cycle's crew schedule. You can READ the cycle's data and SUGGEST changes, but you CANNOT execute them — direct the user to the scheduler UI to apply any move.
+
+Cycle: ${cycle.cycle_number ? `#${cycle.cycle_number}` : cycle.id}
+Date range: ${cycle.start_date} → ${cycle.end_date}
+Crew count (template): ${template?.crew_count ?? 'unknown'}
+
+Coverage:
+- Required visits per cycle (template): ${required}
+- Visits in DB: ${visits.length}
+- Placed: ${placed}
+- Completed: ${completed}
+- Unplaced (in cycle, status=unplaced): ${unplaced.length}
+- Dropped before reaching cycle (template build couldn't fit): ${Math.max(0, required - visits.length)}
+
+Per-crew:
+${perCrew
+  .map(
+    (c) =>
+      `- ${c.crew_label}: ${c.days} workdays, ${c.work_hours}h work + ${c.drive_hours}h drive, ${c.pair_rate}% paired, ends ${c.end_date}`
+  )
+  .join('\n')}
+
+${
+  template?.pacing_analysis
+    ? `Pacing analysis:
+- Crew end-workday spread: ${template.pacing_analysis.crew_end_workday_spread} (target ≤${template.pacing_analysis.target_spread_workdays})
+- Global pair rate: ${template.pacing_analysis.pairing_stats?.pair_rate_pct}% (${template.pacing_analysis.pairing_stats?.paired_days} paired / ${template.pacing_analysis.pairing_stats?.total_workdays} total)
+`
+    : ''
+}${
+  Array.isArray(template?.warnings) && template.warnings.length > 0
+    ? `Engine warnings:
+${template.warnings.map((w: any) => `- ${w.message}${w.suggested_action ? ` (try: ${w.suggested_action})` : ''}`).join('\n')}
+`
+    : ''
+}${
+  unplacedSample.length > 0
+    ? `Unplaced sample (${unplaced.length} total, showing first ${unplacedSample.length}):
+${unplacedSample.map((u) => `- ${u.address} — ${u.reason}`).join('\n')}
+`
+    : ''
+}
+
+Rules:
+- Cite specific numbers from above; never invent metrics.
+- For move suggestions, name the property and the target day/crew. Tell the user to use the existing scheduler Move UI to apply it.
+- For deeper questions you can't answer with this data, say so plainly.
+- Keep responses tight — the user is scanning, not reading.
+- If the user asks "what would help?", lead with the highest-leverage change (usually crew imbalance, large unplaced batches, or low pair rate).`
+
+  // ── Call Anthropic ────────────────────────────────────────────────
+  const anthropic = new Anthropic({ apiKey })
+  try {
+    const response = await anthropic.messages.create({
+      model: CHAT_MODEL,
+      max_tokens: MAX_TOKENS,
+      system: systemPrompt,
+      messages: messages.map((m) => ({
+        role: m.role,
+        content: m.content,
+      })),
+    })
+    const text = response.content
+      .filter((b: any) => b.type === 'text')
+      .map((b: any) => b.text)
+      .join('\n')
+    return res.status(200).json({ message: text, usage: response.usage })
+  } catch (err: any) {
+    return res.status(500).json({ error: err?.message ?? 'Chat failed' })
+  }
+}

--- a/src/components/scheduler/CycleChatDrawer.tsx
+++ b/src/components/scheduler/CycleChatDrawer.tsx
@@ -1,0 +1,182 @@
+// Phase 4.5 — Cycle chat drawer.
+// Slide-out from the right with a message list + input. Calls
+// /api/scheduler/cycles/[cycleId]/chat which builds a system prompt
+// from the cycle's actual data (visits, crew_days, pacing, unplaced).
+// Conversation is component-local — no DB persistence in v1.
+import { useEffect, useRef, useState } from 'react'
+import { MessageSquare, Send, X } from 'lucide-react'
+import Button from '../ui/Button'
+import { Textarea } from '../ui/Input'
+import { useAuth } from '../../hooks/useAuth'
+
+interface ChatMessage {
+  role: 'user' | 'assistant'
+  content: string
+}
+
+interface Props {
+  cycleId: string
+  cycleLabel?: string | null
+}
+
+export default function CycleChatDrawer({ cycleId, cycleLabel }: Props) {
+  const { getToken } = useAuth()
+  const [open, setOpen] = useState(false)
+  const [messages, setMessages] = useState<ChatMessage[]>([])
+  const [input, setInput] = useState('')
+  const [sending, setSending] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const listRef = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    if (listRef.current) {
+      listRef.current.scrollTop = listRef.current.scrollHeight
+    }
+  }, [messages, sending])
+
+  const send = async () => {
+    const text = input.trim()
+    if (!text || sending) return
+    const next = [...messages, { role: 'user' as const, content: text }]
+    setMessages(next)
+    setInput('')
+    setSending(true)
+    setError(null)
+    try {
+      const token = await getToken()
+      const res = await fetch(`/api/scheduler/cycles/${cycleId}/chat`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ messages: next }),
+      })
+      const json = await res.json().catch(() => ({}))
+      if (!res.ok) {
+        throw new Error((json as any).error ?? `HTTP ${res.status}`)
+      }
+      setMessages((prev) => [...prev, { role: 'assistant', content: (json as any).message ?? '' }])
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e))
+    } finally {
+      setSending(false)
+    }
+  }
+
+  return (
+    <>
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={() => setOpen(true)}
+        title="Chat with this cycle"
+      >
+        <MessageSquare className="h-4 w-4" /> Chat
+      </Button>
+
+      {open && (
+        <>
+          <div
+            className="fixed inset-0 z-40 bg-black/30"
+            onClick={() => setOpen(false)}
+          />
+          <aside
+            className="fixed right-0 top-0 z-50 flex h-full w-full max-w-md flex-col border-l border-border bg-surface shadow-xl"
+            style={{ backgroundColor: 'var(--color-bg-elevated, #ffffff)' }}
+          >
+            <header className="flex items-center justify-between border-b border-border px-4 py-3">
+              <div>
+                <h2 className="text-sm font-semibold text-fg">Chat with cycle</h2>
+                <p className="text-[11px] text-fg-muted">
+                  {cycleLabel ?? 'Advisory only — agent suggests, you apply moves in the scheduler.'}
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={() => setOpen(false)}
+                className="text-fg-subtle hover:text-fg"
+              >
+                <X className="h-4 w-4" />
+              </button>
+            </header>
+
+            <div ref={listRef} className="flex-1 overflow-y-auto px-4 py-3 space-y-3">
+              {messages.length === 0 && (
+                <div className="rounded-md border border-border bg-surface-subtle p-3 text-xs text-fg-muted">
+                  Ask about idle days, over/under-utilized crews, why properties
+                  are unplaced, or what to change to compress the cycle.
+                  <ul className="mt-2 space-y-1">
+                    {[
+                      'Which crew is most over-utilized?',
+                      'Why are these properties unplaced?',
+                      'What would help reduce the crew end-day spread?',
+                      'Where can I double up properties on the same day?',
+                    ].map((q) => (
+                      <li key={q}>
+                        <button
+                          type="button"
+                          onClick={() => setInput(q)}
+                          className="text-accent hover:underline text-left"
+                        >
+                          {q}
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+              {messages.map((m, i) => (
+                <div
+                  key={i}
+                  className={
+                    m.role === 'user'
+                      ? 'rounded-md bg-accent/10 border border-accent/20 px-3 py-2 text-sm text-fg whitespace-pre-wrap'
+                      : 'rounded-md bg-surface-subtle border border-border px-3 py-2 text-sm text-fg whitespace-pre-wrap'
+                  }
+                >
+                  {m.content}
+                </div>
+              ))}
+              {sending && (
+                <div className="rounded-md bg-surface-subtle border border-border px-3 py-2 text-xs text-fg-muted italic">
+                  Thinking…
+                </div>
+              )}
+              {error && (
+                <div className="rounded-md border border-danger/30 bg-danger-subtle px-3 py-2 text-xs text-danger">
+                  {error}
+                </div>
+              )}
+            </div>
+
+            <footer className="border-t border-border p-3">
+              <div className="flex items-end gap-2">
+                <Textarea
+                  rows={2}
+                  value={input}
+                  onChange={(e) => setInput(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' && !e.shiftKey) {
+                      e.preventDefault()
+                      send()
+                    }
+                  }}
+                  placeholder="Ask about this cycle…"
+                  disabled={sending}
+                  className="flex-1 text-sm"
+                />
+                <Button onClick={send} disabled={sending || !input.trim()} size="sm">
+                  <Send className="h-3.5 w-3.5" />
+                </Button>
+              </div>
+              <p className="mt-1 text-[10px] text-fg-subtle">
+                Enter to send · Shift+Enter for newline · conversation is not saved
+              </p>
+            </footer>
+          </aside>
+        </>
+      )}
+    </>
+  )
+}

--- a/src/pages/accounts/scheduler/CycleDetail.tsx
+++ b/src/pages/accounts/scheduler/CycleDetail.tsx
@@ -22,6 +22,7 @@ import GanttView, { type UtilDay } from '../../../components/scheduler/GanttView
 import CalendarView from '../../../components/scheduler/CalendarView'
 import CycleMapView from '../../../components/scheduler/CycleMapView'
 import HistoryDrawer from '../../../components/scheduler/HistoryDrawer'
+import CycleChatDrawer from '../../../components/scheduler/CycleChatDrawer'
 import StatusBar, { type SaveState } from '../../../components/scheduler/StatusBar'
 
 interface Cycle {
@@ -420,7 +421,13 @@ export default function CycleDetailPage() {
                 </Link>
               )}
             </div>
-            <ViewSwitcher value={view} onChange={setView} />
+            <div className="flex items-center gap-2">
+              <CycleChatDrawer
+                cycleId={cycleId!}
+                cycleLabel={cycle.cycle_number ? `Cycle #${cycle.cycle_number}` : null}
+              />
+              <ViewSwitcher value={view} onChange={setView} />
+            </div>
           </div>
         </header>
 


### PR DESCRIPTION
## Summary
Slide-out chat panel on the Cycle Detail page that talks to \`claude-sonnet-4-5\` with the cycle's actual data baked into the system prompt — required vs placed visit counts, per-crew workdays / work hours / drive hours / pair rate / end date, pacing analysis, engine warnings, and a sample of unplaced visits with reasons.

The agent is **advisory only**. It can suggest "move property X from Crew 1 to Crew 2 on day Y" but cannot execute moves — users still apply changes via the existing scheduler UI.

## Backend — \`POST /api/scheduler/cycles/[cycleId]/chat\`
- \`authenticateRequest\` + \`createAdminClient\`
- Loads visits + crew_days with paged Supabase fetches (PostgREST cap-safe)
- Builds a system prompt with the numbers
- Forwards messages to Anthropic SDK; returns text
- No streaming for v1; \`maxDuration: 60\`
- Body: \`{ messages: [{ role, content }] }\`

## Frontend — \`CycleChatDrawer\`
- Slide-out from right, message list, textarea, prompt-starter quick links
- Conversation in component state only (no DB persistence v1)
- Wired next to ViewSwitcher in the cycle detail toolbar

## Out of scope (intentional follow-ups)
- Conversation history persistence
- Agent tool-calling (move/lock/unlock visits) — would need careful UX
- Multi-cycle / cross-client comparisons

## Requirements
- \`ANTHROPIC_API_KEY\` in env (already used by the existing \`/api/analyses/.../chat\` endpoint, so no new infra)

## Test plan
- [ ] Cycle Detail toolbar shows a Chat button next to the view switcher
- [ ] Click → drawer opens; sample prompts visible
- [ ] Ask "Which crew is most over-utilized?" → answer cites specific crew labels and hours
- [ ] Ask "Why are these properties unplaced?" → answer references actual reason codes
- [ ] Drawer closes on backdrop click
- [ ] tsc + build clean (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)