### PR TITLE
Surface ungeocoded properties as unplaced instead of silently dropping

### DIFF
--- a/api/scheduler/templates/[templateId]/regenerate.ts
+++ b/api/scheduler/templates/[templateId]/regenerate.ts
@@ -238,7 +238,16 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         (r.sl as any).building_size_class_override ?? null,
       eligible_addons: eligibleAddons,
     }
-  }).filter((p) => Number.isFinite(p.lat) && Number.isFinite(p.lng))
+  })
+
+  // Same split as the create path: missing-coords properties get
+  // surfaced as unplaced rather than silently dropped.
+  const propertiesMissingCoords = propertiesForBuild.filter(
+    (p) => !Number.isFinite(p.lat) || !Number.isFinite(p.lng)
+  )
+  const propertiesForEngine = propertiesForBuild.filter(
+    (p) => Number.isFinite(p.lat) && Number.isFinite(p.lng)
+  )
 
   try {
     const tplConfig = (tpl.config ?? {}) as Record<string, unknown>
@@ -266,7 +275,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     const result = buildRoutingTemplate({
       account_id: accountId,
       client_id: clientId,
-      routed_properties: propertiesForBuild,
+      routed_properties: propertiesForEngine,
       branches,
       crew_count: crewCount,
       config: cfg as any,
@@ -278,6 +287,18 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       },
       cycle_start_year: new Date().getUTCFullYear(),
     })
+
+    if (propertiesMissingCoords.length > 0) {
+      const missingUnplaced = propertiesMissingCoords.map((p) => ({
+        service_location_id: p.service_location_id,
+        property_id: p.property_id,
+        address: p.address,
+        reason: 'not_geocoded',
+        detail: 'Property has no latitude/longitude — geocode the address before this property can be routed.',
+      }))
+      result.unplaced_visits = [...(result.unplaced_visits ?? []), ...missingUnplaced]
+      result.total_visits_required_per_cycle += propertiesMissingCoords.length
+    }
 
     const status = result.total_visits_per_cycle === 0 ? 'failed' : 'active'
     await db

--- a/api/scheduler/templates/index.ts
+++ b/api/scheduler/templates/index.ts
@@ -259,7 +259,19 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           (r.sl as any).building_size_class_override ?? null,
         eligible_addons: eligibleAddons,
       }
-    }).filter((p) => Number.isFinite(p.lat) && Number.isFinite(p.lng))
+    })
+
+    // Capture properties that have no lat/lng — they can't enter the
+    // routing engine but the operator needs to see them in the cycle's
+    // unplaced list with a clear reason. Previously these were filtered
+    // out silently and the user couldn't tell why N properties were
+    // missing from the cycle.
+    const propertiesMissingCoords = propertiesForBuild.filter(
+      (p) => !Number.isFinite(p.lat) || !Number.isFinite(p.lng)
+    )
+    const propertiesForEngine = propertiesForBuild.filter(
+      (p) => Number.isFinite(p.lat) && Number.isFinite(p.lng)
+    )
 
     // Insert template row up front in 'optimizing' state.
     const cycleStartYear = (body.cycle_start_year as number | undefined) ?? new Date().getUTCFullYear()
@@ -320,7 +332,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       const result = buildRoutingTemplate({
         account_id: accountId,
         client_id: clientId,
-        routed_properties: propertiesForBuild,
+        routed_properties: propertiesForEngine,
         branches,
         crew_count: crewCount,
         config: cfg,
@@ -332,6 +344,21 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         },
         cycle_start_year: cycleStartYear,
       })
+
+      // Splice in the missing-coords properties so the cycle UI surfaces
+      // them. They never reached the engine — the user needs to know
+      // because the only fix is geocoding the address.
+      if (propertiesMissingCoords.length > 0) {
+        const missingUnplaced = propertiesMissingCoords.map((p) => ({
+          service_location_id: p.service_location_id,
+          property_id: p.property_id,
+          address: p.address,
+          reason: 'not_geocoded',
+          detail: 'Property has no latitude/longitude — geocode the address before this property can be routed.',
+        }))
+        result.unplaced_visits = [...(result.unplaced_visits ?? []), ...missingUnplaced]
+        result.total_visits_required_per_cycle += propertiesMissingCoords.length
+      }
 
       const status = result.total_visits_per_cycle === 0 ? 'failed' : 'active'
       await db


### PR DESCRIPTION
## Summary
The 9 missing properties from Cycle 2 were properties without \`lat\`/\`lng\` — the template-build entry filtered them out **before** calling the routing engine, so the engine never tagged them unplaced. \`template.unplaced_visits\` came back empty and the coverage banner had nothing to show.

## Fix
Both \`POST /scheduler/templates\` and \`POST /scheduler/templates/[templateId]/regenerate\` now split routed properties into two buckets:

- \`propertiesForEngine\` — has lat/lng → routed normally
- \`propertiesMissingCoords\` — no lat/lng → spliced into the engine's \`unplaced_visits\` with:
  - \`reason: 'not_geocoded'\`
  - \`detail: 'Property has no latitude/longitude — geocode the address before this property can be routed.'\`

\`total_visits_required_per_cycle\` is bumped by the missing-coord count so the coverage math still adds up. The 38 idle days the user saw is **not** an engine bug — those days exist because the engine couldn't have routed the 9 ungeocoded properties to anywhere; the day-loop terminated correctly.

## What the user will see now
- Coverage banner: "9 of 509 visits couldn't be scheduled with crew_count=4"
- "Show 9 dropped properties" expander → list of addresses with reason "not_geocoded"
- Reason breakdown: "9× Property has no latitude/longitude — geocode the address before this property can be routed."

Action: re-enrich those addresses (or fix them on the property record) and regenerate.

## Test plan
- [ ] Regenerate a template that has any ungeocoded properties → unplaced_visits contains them with reason='not_geocoded'
- [ ] CycleDetail banner expander shows them with addresses + reason
- [ ] Templates without ungeocoded properties → unchanged behavior (no spurious unplaced rows)
- [ ] tsc clean (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)