### PR TITLE
Surface enrichment errors on dropped properties + linkable addresses

### DIFF
--- a/api/scheduler/templates/[templateId]/regenerate.ts
+++ b/api/scheduler/templates/[templateId]/regenerate.ts
@@ -289,12 +289,45 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     })
 
     if (propertiesMissingCoords.length > 0) {
+      const missingPropIds = Array.from(
+        new Set(propertiesMissingCoords.map((p) => p.property_id))
+      )
+      const enrichmentInfo = new Map<string, { status: string | null; errors: any; last: string | null }>()
+      for (let i = 0; i < missingPropIds.length; i += 250) {
+        const chunk = missingPropIds.slice(i, i + 250)
+        const { data } = await db
+          .from('properties')
+          .select('id, enrichment_status, enrichment_errors, last_enriched_at')
+          .in('id', chunk)
+        for (const r of (data ?? []) as any[]) {
+          enrichmentInfo.set(r.id, {
+            status: r.enrichment_status ?? null,
+            errors: r.enrichment_errors ?? null,
+            last: r.last_enriched_at ?? null,
+          })
+        }
+      }
+      const formatErr = (info: { status: string | null; errors: any; last: string | null } | undefined) => {
+        if (!info) return 'No enrichment record found for this property.'
+        const errMsg =
+          info.errors?.geocode ??
+          info.errors?.error ??
+          (typeof info.errors === 'string' ? info.errors : null)
+        const stamp = info.last ? ` (last attempted ${info.last.slice(0, 10)})` : ''
+        if (info.status === 'failed') {
+          return `Enrichment failed${stamp}: ${errMsg ?? 'unknown error — re-run enrichment to capture details.'}`
+        }
+        if (info.status === 'pending') {
+          return `Pending enrichment — never been geocoded${stamp}. Run enrichment from the Map page or property detail.`
+        }
+        return `Status: ${info.status ?? 'unknown'}${stamp}. ${errMsg ?? 'No coordinates and no error logged — likely never enriched.'}`
+      }
       const missingUnplaced = propertiesMissingCoords.map((p) => ({
         service_location_id: p.service_location_id,
         property_id: p.property_id,
         address: p.address,
         reason: 'not_geocoded',
-        detail: 'Property has no latitude/longitude — geocode the address before this property can be routed.',
+        detail: formatErr(enrichmentInfo.get(p.property_id)),
       }))
       result.unplaced_visits = [...(result.unplaced_visits ?? []), ...missingUnplaced]
       result.total_visits_required_per_cycle += propertiesMissingCoords.length

--- a/api/scheduler/templates/index.ts
+++ b/api/scheduler/templates/index.ts
@@ -347,14 +347,50 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
       // Splice in the missing-coords properties so the cycle UI surfaces
       // them. They never reached the engine — the user needs to know
-      // because the only fix is geocoding the address.
+      // because the only fix is geocoding the address. Look up each
+      // property's enrichment_status + enrichment_errors so the detail
+      // tells the operator WHY geocoding failed (often Google's address
+      // validator returned ZERO_RESULTS for a bad/incomplete address).
       if (propertiesMissingCoords.length > 0) {
+        const missingPropIds = Array.from(
+          new Set(propertiesMissingCoords.map((p) => p.property_id))
+        )
+        const enrichmentInfo = new Map<string, { status: string | null; errors: any; last: string | null }>()
+        for (let i = 0; i < missingPropIds.length; i += 250) {
+          const chunk = missingPropIds.slice(i, i + 250)
+          const { data } = await db
+            .from('properties')
+            .select('id, enrichment_status, enrichment_errors, last_enriched_at')
+            .in('id', chunk)
+          for (const r of (data ?? []) as any[]) {
+            enrichmentInfo.set(r.id, {
+              status: r.enrichment_status ?? null,
+              errors: r.enrichment_errors ?? null,
+              last: r.last_enriched_at ?? null,
+            })
+          }
+        }
+        const formatErr = (info: { status: string | null; errors: any; last: string | null } | undefined) => {
+          if (!info) return 'No enrichment record found for this property.'
+          const errMsg =
+            info.errors?.geocode ??
+            info.errors?.error ??
+            (typeof info.errors === 'string' ? info.errors : null)
+          const stamp = info.last ? ` (last attempted ${info.last.slice(0, 10)})` : ''
+          if (info.status === 'failed') {
+            return `Enrichment failed${stamp}: ${errMsg ?? 'unknown error — re-run enrichment to capture details.'}`
+          }
+          if (info.status === 'pending') {
+            return `Pending enrichment — never been geocoded${stamp}. Run enrichment from the Map page or property detail.`
+          }
+          return `Status: ${info.status ?? 'unknown'}${stamp}. ${errMsg ?? 'No coordinates and no error logged — likely never enriched.'}`
+        }
         const missingUnplaced = propertiesMissingCoords.map((p) => ({
           service_location_id: p.service_location_id,
           property_id: p.property_id,
           address: p.address,
           reason: 'not_geocoded',
-          detail: 'Property has no latitude/longitude — geocode the address before this property can be routed.',
+          detail: formatErr(enrichmentInfo.get(p.property_id)),
         }))
         result.unplaced_visits = [...(result.unplaced_visits ?? []), ...missingUnplaced]
         result.total_visits_required_per_cycle += propertiesMissingCoords.length

--- a/src/pages/accounts/scheduler/CycleDetail.tsx
+++ b/src/pages/accounts/scheduler/CycleDetail.tsx
@@ -88,6 +88,7 @@ export default function CycleDetailPage() {
   const [templateCrewCount, setTemplateCrewCount] = useState<number | null>(null)
   const [templateUnplaced, setTemplateUnplaced] = useState<Array<{
     service_location_id?: string
+    property_id?: string
     address?: string
     reason?: string
     detail?: string
@@ -519,13 +520,22 @@ export default function CycleDetailPage() {
                       </ul>
                     </div>
                   )}
-                  <ul className="mt-2 max-h-48 overflow-y-auto rounded border border-border bg-surface divide-y divide-border">
+                  <ul className="mt-2 max-h-64 overflow-y-auto rounded border border-border bg-surface divide-y divide-border">
                     {templateUnplaced.map((u, i) => (
-                      <li key={u.service_location_id ?? i} className="px-2 py-1">
-                        <p className="font-medium text-fg truncate">
-                          {u.address ?? u.service_location_id ?? '—'}
-                        </p>
-                        <p className="text-[11px] text-fg-muted truncate">
+                      <li key={u.service_location_id ?? i} className="px-2 py-1.5">
+                        {u.property_id ? (
+                          <Link
+                            to={`/properties/${u.property_id}`}
+                            className="font-medium text-accent hover:underline"
+                          >
+                            {u.address ?? u.service_location_id ?? '—'}
+                          </Link>
+                        ) : (
+                          <p className="font-medium text-fg">
+                            {u.address ?? u.service_location_id ?? '—'}
+                          </p>
+                        )}
+                        <p className="text-[11px] text-fg-muted">
                           {u.detail ?? u.reason ?? 'unknown'}
                         </p>
                       </li>


### PR DESCRIPTION
## What's actually happening
The "9 still need enrichment" loop happens because Google's geocoding API returns no results for those addresses on every retry. \`api/properties/[propertyId]/enrich.ts\`:

1. Validates the address via Google Address Validation
2. Geocodes via Google Geocoding
3. If geo succeeds → \`status='enriched'\`, lat/lng saved
4. If geo returns null → \`status='failed'\`, \`enrichment_errors: { geocode: 'No geocoding results' }\`, no coords
5. If exception → \`status='failed'\`, error message stored

Common causes for "No geocoding results":
- Address typo or wrong city/state/zip combo
- PO Box (Google doesn't geocode them)
- Incomplete address (missing city/state/zip)
- Unit-only (apartment number without building street)
- Non-existent / brand-new construction Google hasn't indexed

The user keeps clicking "Enrich pending" but the same 9 fail the same way. They need to **fix the addresses**, not just retry enrichment — and they couldn't see why.

## Fix
Template build (and regenerate) now looks up \`enrichment_status\` + \`enrichment_errors\` + \`last_enriched_at\` for each missing-coords property and threads the specific reason into the dropped-properties banner detail. Examples:

- \`"Enrichment failed (last attempted 2026-04-30): No geocoding results"\`
- \`"Pending enrichment — never been geocoded. Run enrichment from the Map page or property detail."\`
- \`"Status: failed (last attempted 2026-04-29): Validation timed out"\`

Each address in the dropped-list is now a \`Link\` to \`/properties/[id]\` so operators can jump straight there to fix the address record + re-enrich.

## Test plan
- [ ] Regenerate Cycle 2 → expander shows specific error per property (not generic "geocode the address")
- [ ] Click an address → navigates to property detail
- [ ] Properties with no enrichment record at all → "No enrichment record found" message
- [ ] tsc clean (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)