### PR TITLE
Custom filter renders real-value dropdown instead of free-form input

### DIFF
--- a/api/v1/custom-field-definitions/index.ts
+++ b/api/v1/custom-field-definitions/index.ts
@@ -15,13 +15,52 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   const db = createAdminClient()
 
   if (req.method === 'GET') {
-    const { account_id, client_id } = req.query
+    const { account_id, client_id, include_values } = req.query
     let query = db.from('custom_field_definitions').select('*').order('sort_order', { ascending: true })
     if (account_id) query = query.eq('account_id', String(account_id))
     if (client_id) query = query.eq('client_id', String(client_id))
     const { data, error } = await query
     if (error) return res.status(500).json({ error: error.message })
-    return res.status(200).json(data ?? [])
+    const defs = (data ?? []) as any[]
+
+    // When include_values=true and a client_id is provided, scan the
+    // client's service_locations.custom_fields and attach the distinct
+    // values per field. Operators want these as a dropdown rather than
+    // a free-form contains-match input — picking from real values is
+    // less error-prone than guessing what was imported.
+    if (include_values === 'true' && client_id && defs.length > 0) {
+      const SL_PAGE = 1000
+      const SL_MAX_PAGES = 50
+      const valuesByKey = new Map<string, Set<string>>()
+      for (const d of defs) valuesByKey.set(d.field_key, new Set())
+      for (let page = 0; page < SL_MAX_PAGES; page++) {
+        const from = page * SL_PAGE
+        const { data: slRows, error: slErr } = await db
+          .from('service_locations')
+          .select('custom_fields')
+          .eq('client_id', String(client_id))
+          .range(from, from + SL_PAGE - 1)
+        if (slErr) return res.status(500).json({ error: slErr.message })
+        const batch = (slRows ?? []) as Array<{ custom_fields: Record<string, unknown> | null }>
+        for (const r of batch) {
+          const cf = r.custom_fields ?? {}
+          for (const d of defs) {
+            const v = cf[d.field_key]
+            if (v == null) continue
+            const s = String(v).trim()
+            if (s.length === 0) continue
+            valuesByKey.get(d.field_key)?.add(s)
+          }
+        }
+        if (batch.length < SL_PAGE) break
+      }
+      for (const d of defs) {
+        const set = valuesByKey.get(d.field_key)
+        d.distinct_values = set ? Array.from(set).sort((a, b) => a.localeCompare(b)) : []
+      }
+    }
+
+    return res.status(200).json(defs)
   }
 
   if (req.method === 'POST') {

--- a/src/components/map/FilterSidebar.tsx
+++ b/src/components/map/FilterSidebar.tsx
@@ -16,6 +16,10 @@ interface CustomFieldDef {
   field_label: string
   field_type: 'text' | 'number' | 'date' | 'select'
   select_options: string[] | null
+  // Populated when fetched with ?include_values=true. Distinct values
+  // observed on this client's SLs — used to build a dropdown for free-
+  // form fields so operators pick from real data instead of guessing.
+  distinct_values?: string[]
   client_id: string | null
   appears_in_filters: boolean
   sort_order: number
@@ -65,7 +69,7 @@ export default function FilterSidebar({ filter, onChange }: FilterSidebarProps) 
       for (const cid of filter.clients) {
         try {
           const res = await fetch(
-            `/api/v1/custom-field-definitions?client_id=${cid}`,
+            `/api/v1/custom-field-definitions?client_id=${cid}&include_values=true`,
             { headers }
           )
           if (!res.ok) continue
@@ -92,13 +96,6 @@ export default function FilterSidebar({ filter, onChange }: FilterSidebarProps) 
   }, [filter.clients, getToken])
 
   const customFilter = filter.custom ?? {}
-
-  const setCustomText = (key: string, value: string) => {
-    const next = { ...customFilter }
-    if (value.trim() === '') delete next[key]
-    else next[key] = value
-    onChange({ ...filter, custom: next })
-  }
 
   const toggleCustomSelect = (key: string, value: string) => {
     const next = { ...customFilter }
@@ -209,38 +206,40 @@ export default function FilterSidebar({ filter, onChange }: FilterSidebarProps) 
         {/* Custom fields — only when a client is selected (defs are per-client). */}
         {customDefs.map((def) => {
           const value = customFilter[def.field_key]
-          if (def.field_type === 'select') {
-            const options = def.select_options ?? []
-            const selected = Array.isArray(value) ? value : []
+          // Pick the option list. Select fields use their explicit
+          // options; everything else falls back to distinct values
+          // observed on the client's SLs (auto-discovered).
+          const options =
+            def.field_type === 'select'
+              ? (def.select_options ?? [])
+              : (def.distinct_values ?? [])
+          const selected = Array.isArray(value) ? value : []
+
+          // No options at all — for text/number/date this means no
+          // values exist on any SL yet. Skip the section rather than
+          // rendering an empty list.
+          if (options.length === 0) {
             return (
               <FilterGroup key={def.id} label={def.field_label}>
-                <ul className="max-h-36 space-y-1 overflow-y-auto pr-1">
-                  {options.length === 0 ? (
-                    <li className="text-xs text-fg-subtle italic">No options defined.</li>
-                  ) : (
-                    options.map((opt) => (
-                      <FilterOption
-                        key={opt}
-                        checked={selected.includes(opt)}
-                        onToggle={() => toggleCustomSelect(def.field_key, opt)}
-                        label={opt}
-                      />
-                    ))
-                  )}
-                </ul>
+                <p className="text-xs text-fg-subtle italic">
+                  No values to filter by yet.
+                </p>
               </FilterGroup>
             )
           }
-          // text / number / date — single text input with contains-match
-          // semantics. Number/date refinement (range) is a follow-up.
+
           return (
             <FilterGroup key={def.id} label={def.field_label}>
-              <Input
-                type={def.field_type === 'date' ? 'date' : 'text'}
-                placeholder={def.field_type === 'number' ? 'Match contains…' : 'Contains…'}
-                value={typeof value === 'string' ? value : ''}
-                onChange={(e) => setCustomText(def.field_key, e.target.value)}
-              />
+              <ul className="max-h-36 space-y-1 overflow-y-auto pr-1">
+                {options.map((opt) => (
+                  <FilterOption
+                    key={opt}
+                    checked={selected.includes(opt)}
+                    onToggle={() => toggleCustomSelect(def.field_key, opt)}
+                    label={opt}
+                  />
+                ))}
+              </ul>
             </FilterGroup>
           )
         })}


### PR DESCRIPTION
## Summary
On the Map filter sidebar, custom-field filters for text/number/date fields rendered as a contains-match \`<input>\` — the operator had no way to see what values existed in the data, so the filter was effectively unusable without going back to the spreadsheet to look up valid strings.

## Fix
- \`/api/v1/custom-field-definitions\` GET accepts \`include_values=true\` (alongside \`client_id\`); when set, it scans the client's \`service_locations.custom_fields\` and attaches \`distinct_values\` per field (paged + deduped).
- FilterSidebar requests with \`include_values=true\`. Text/number/date fields render as multi-select checkbox lists using \`distinct_values\` from real data. Select fields still use their explicit \`select_options\`.
- Empty value lists render "No values to filter by yet" instead of an empty input.
- Filter semantics on the API side already handle \`string[]\` as any-of, so no engine changes needed.

## Test plan
- [ ] Define a custom text field on a client (e.g. "Region")
- [ ] Filter by that client on the Map → "Region" filter shows checkboxes for each distinct value (e.g. North/South/East/West) auto-discovered from imports
- [ ] Tick combinations → only matching properties render
- [ ] Field with no values yet → "No values to filter by yet"
- [ ] Select fields unchanged
- [ ] tsc clean (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)