### PR TITLE
Fix cycle gen silently dropping overflow visits + show them in UI

### DIFF
--- a/api/_lib/scheduler/generate-cycle-instance.ts
+++ b/api/_lib/scheduler/generate-cycle-instance.ts
@@ -140,6 +140,12 @@ export async function generateCycleInstance(
     }
   }
 
+  // Visits whose mapped workday falls past cycle_end_date — typically
+  // because Phase 4.4 pacing spread trips out and the last few workdays
+  // landed in the next calendar month past the cycle horizon. We don't
+  // silently drop these any more; capture them and insert as unplaced
+  // rows further down so the cycle UI surfaces them.
+  const overflowVisits: Array<{ stop: any; tripLabel: string; scheduledDate: string }> = []
   for (const trip of trips) {
     for (const day of trip.days ?? []) {
       // dayOffset is a working-day count (the routing engine sequences
@@ -150,7 +156,16 @@ export async function generateCycleInstance(
       // (raw DB rows).
       const dayOffset = (trip.relative_start_day ?? 0) + ((day.trip_day_number ?? 1) - 1)
       const scheduledDate = addWorkdays(startDate, dayOffset)
-      if (scheduledDate > endDate) continue
+      if (scheduledDate > endDate) {
+        for (const stop of day.stops ?? []) {
+          overflowVisits.push({
+            stop,
+            tripLabel: trip.trip_label ?? trip.trip_id,
+            scheduledDate,
+          })
+        }
+        continue
+      }
 
       const crewDayRouteId = crypto.randomUUID()
       crewDayRoutes.push({
@@ -208,6 +223,27 @@ export async function generateCycleInstance(
         })
       }
     }
+  }
+
+  // Phase 4.4-fix — overflow visits (workday past cycle_end_date) get
+  // surfaced as unplaced so the operator knows the engine couldn't
+  // squeeze them in. They have valid stop data (property_id, hours, etc.)
+  // so we can build full unplaced rows.
+  for (const ov of overflowVisits) {
+    if (!ov.stop?.property_id || !ov.stop?.service_location_id) continue
+    scheduledVisits.push({
+      cycle_instance_id: cycleInstanceId,
+      template_id: templateId,
+      service_location_id: ov.stop.service_location_id,
+      property_id: ov.stop.property_id,
+      visit_number_in_cycle: ov.stop.visit_number_in_cycle ?? 1,
+      status: 'unplaced',
+      unplaced_reason: `Trip "${ov.tripLabel}" extended past cycle end (target workday mapped to ${ov.scheduledDate}). Add a crew, extend the cycle, or rebalance to fit this visit.`,
+      hours_per_visit_base: ov.stop.hours_per_visit_base ?? 0,
+      hours_per_visit_total:
+        (ov.stop.hours_per_visit_base ?? 0) +
+        ((ov.stop.attached_addons ?? []).reduce((s: number, a: any) => s + (a.hours ?? 0), 0)),
+    })
   }
 
   // Surface unplaced visits as scheduled_visits with status='unplaced'.

--- a/src/pages/accounts/scheduler/CycleDetail.tsx
+++ b/src/pages/accounts/scheduler/CycleDetail.tsx
@@ -535,12 +535,29 @@ export default function CycleDetailPage() {
             tone === 'danger'
               ? 'border-danger/40 bg-danger-subtle text-fg'
               : 'border-warning/40 bg-warning-subtle text-fg'
-          // Cluster the unplaced reasons so the user can spot patterns
-          // ("8 of 9 say trip ran out of cycle days for cluster X").
+          // Combine sources: template's pre-engine unplaced (e.g. missing
+          // coords) AND cycle-level unplaced rows (overflow + unplaceable
+          // residue). Either path produces a property the operator needs
+          // to see, so merge them into one list.
+          type DroppedRow = { property_id?: string; address: string; reason: string }
+          const cycleUnplacedRows: DroppedRow[] = unplacedVisits.map((v) => ({
+            property_id: (v as any).property_id ?? undefined,
+            address:
+              v.service_locations?.property?.address_line1 ??
+              v.service_locations?.display_name ??
+              v.service_location_id ??
+              '—',
+            reason: v.unplaced_reason ?? 'unknown',
+          }))
+          const templateUnplacedRows: DroppedRow[] = templateUnplaced.map((u) => ({
+            property_id: u.property_id,
+            address: u.address ?? u.service_location_id ?? '—',
+            reason: u.detail ?? u.reason ?? 'unknown',
+          }))
+          const allDropped: DroppedRow[] = [...cycleUnplacedRows, ...templateUnplacedRows]
           const reasonCounts = new Map<string, number>()
-          for (const u of templateUnplaced) {
-            const key = (u.detail ?? u.reason ?? 'unknown').toString()
-            reasonCounts.set(key, (reasonCounts.get(key) ?? 0) + 1)
+          for (const u of allDropped) {
+            reasonCounts.set(u.reason, (reasonCounts.get(u.reason) ?? 0) + 1)
           }
           const reasonRows = Array.from(reasonCounts.entries()).sort((a, b) => b[1] - a[1])
 
@@ -567,11 +584,11 @@ export default function CycleDetailPage() {
                 )}
               </ul>
 
-              {templateUnplaced.length > 0 && (
+              {allDropped.length > 0 && (
                 <details className="text-xs">
                   <summary className="cursor-pointer text-accent hover:underline">
-                    Show {templateUnplaced.length} dropped propert
-                    {templateUnplaced.length === 1 ? 'y' : 'ies'}
+                    Show {allDropped.length} dropped propert
+                    {allDropped.length === 1 ? 'y' : 'ies'}
                   </summary>
                   {reasonRows.length > 0 && (
                     <div className="mt-2 rounded border border-border bg-surface px-2 py-1.5">
@@ -589,23 +606,19 @@ export default function CycleDetailPage() {
                     </div>
                   )}
                   <ul className="mt-2 max-h-64 overflow-y-auto rounded border border-border bg-surface divide-y divide-border">
-                    {templateUnplaced.map((u, i) => (
-                      <li key={u.service_location_id ?? i} className="px-2 py-1.5">
+                    {allDropped.map((u, i) => (
+                      <li key={i} className="px-2 py-1.5">
                         {u.property_id ? (
                           <Link
                             to={`/properties/${u.property_id}`}
                             className="font-medium text-accent hover:underline"
                           >
-                            {u.address ?? u.service_location_id ?? '—'}
+                            {u.address}
                           </Link>
                         ) : (
-                          <p className="font-medium text-fg">
-                            {u.address ?? u.service_location_id ?? '—'}
-                          </p>
+                          <p className="font-medium text-fg">{u.address}</p>
                         )}
-                        <p className="text-[11px] text-fg-muted">
-                          {u.detail ?? u.reason ?? 'unknown'}
-                        </p>
+                        <p className="text-[11px] text-fg-muted">{u.reason}</p>
                       </li>
                     ))}
                   </ul>

--- a/src/pages/accounts/scheduler/CycleDetail.tsx
+++ b/src/pages/accounts/scheduler/CycleDetail.tsx
@@ -88,6 +88,7 @@ export default function CycleDetailPage() {
   const [templateCrewCount, setTemplateCrewCount] = useState<number | null>(null)
   const [templateOptimizedAt, setTemplateOptimizedAt] = useState<string | null>(null)
   const [regeneratingTemplate, setRegeneratingTemplate] = useState(false)
+  const [regeneratingCycle, setRegeneratingCycle] = useState(false)
   const [templateUnplaced, setTemplateUnplaced] = useState<Array<{
     service_location_id?: string
     property_id?: string
@@ -155,6 +156,40 @@ export default function CycleDetailPage() {
   }, [cycleId, getToken])
 
   useEffect(() => { load() }, [load])
+
+  // Re-derive THIS cycle from the parent template. Use this after a
+  // template regenerate to refresh the existing cycle's scheduled
+  // visits + crew_days. apply_template_changes=true tells generate-
+  // cycle to overwrite the existing cycle instead of skipping it.
+  const regenerateCycle = useCallback(async () => {
+    if (!cycle?.template_id || !cycle?.start_date) return
+    setRegeneratingCycle(true)
+    setError(null)
+    try {
+      const token = await getToken()
+      const res = await fetch(
+        `/api/scheduler/templates/${cycle.template_id}/generate-cycle`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+          body: JSON.stringify({
+            start_date: cycle.start_date,
+            cycle_number: cycle.cycle_number,
+            apply_template_changes: true,
+          }),
+        }
+      )
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}))
+        throw new Error((j as any).error ?? `HTTP ${res.status}`)
+      }
+      await load()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setRegeneratingCycle(false)
+    }
+  }, [cycle?.template_id, cycle?.start_date, cycle?.cycle_number, getToken, load])
 
   // Regenerate the parent template in-place. The cycle reads its
   // unplaced_visits from the template, so when engine code changes
@@ -583,17 +618,28 @@ export default function CycleDetailPage() {
                   <span className="font-tabular text-fg">
                     {templateOptimizedAt ? templateOptimizedAt.slice(0, 16).replace('T', ' ') : 'unknown'}
                   </span>
-                  . If recent engine fixes shipped after that, regenerate
-                  to refresh the dropped-property list and reasons.
+                  . If you recently regenerated the template, this cycle
+                  is still showing the OLD result — click "Regenerate
+                  cycle" to re-derive it from the latest template.
                 </p>
                 {cycle.template_id && (
-                  <Button
-                    size="sm"
-                    onClick={regenerateTemplate}
-                    loading={regeneratingTemplate}
-                  >
-                    Regenerate template
-                  </Button>
+                  <div className="flex gap-2 flex-wrap">
+                    <Button
+                      size="sm"
+                      onClick={regenerateCycle}
+                      loading={regeneratingCycle}
+                    >
+                      Regenerate cycle
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      onClick={regenerateTemplate}
+                      loading={regeneratingTemplate}
+                    >
+                      Regenerate template
+                    </Button>
+                  </div>
                 )}
               </div>
             </div>


### PR DESCRIPTION
## Summary
The 9 missing properties were being dropped **inside cycle generation**, not template build. That's why regenerating the template didn't fix it and the user saw "template has 0 unplaced, cycle has 9."

## Root cause
Phase 4.4 pacing spreads trips across the cycle so all crews end within ±10 days of each other. \`addWorkdays\` then maps each trip workday to a Mon-Fri calendar date. For trips landing near the cycle horizon, the last few workdays map **past \`cycle_end_date\`** — and cycle gen silently \`continue\`s past those days without recording them anywhere.

\`\`\`ts
const scheduledDate = addWorkdays(startDate, dayOffset)
if (scheduledDate > endDate) continue  // ← SILENT DROP
\`\`\`

## Fix
**Engine** (\`generate-cycle-instance.ts\`):
- Capture overflow stops into an array instead of silent continue
- Insert each as \`scheduled_visits\` with \`status='unplaced'\` and reason: \`"Trip X extended past cycle end (target workday mapped to YYYY-MM-DD)…"\`

**UI** (\`CycleDetail\`):
- Banner expander now merges template-level unplaced (missing-coords path) with cycle-level unplaced (overflow path) into one list
- Each row links to \`/properties/[id]\`
- Reason breakdown pivots both sources

**Plus from earlier in this branch**: Regenerate-template + Regenerate-cycle buttons on the coverage banner so operators don't have to navigate.

## Why 38 idle days + 9 dropped isn't a contradiction
Phase 4.4 pacing intentionally spaces trips so all crews end together. Idle gaps between trips aren't unused capacity available to absorb other crews' workload — each trip is bound to one crew and one cluster. The 9 overflow visits are workdays needed **past** the cycle window, not workdays inside it that could have absorbed them.

If the operator wants to recover those 9, options are:
- Extend the cycle's \`cycle_length_days\` 
- Add a crew so each crew has shorter trips
- Tighten the pacing target (less spread → more compact)

## Test plan
- [ ] Regenerate Cycle 2 → expander now lists the 9 properties with overflow reasons
- [ ] Each address links to \`/properties/[id]\`
- [ ] Cycles with no overflow → no banner / unchanged
- [ ] tsc clean (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)