### PR TITLE
Capacity-aware geographic crew assignment

### DIFF
--- a/api/_lib/scheduler/build-routing-template.ts
+++ b/api/_lib/scheduler/build-routing-template.ts
@@ -378,22 +378,88 @@ export function buildRoutingTemplate(input: BuildTemplateInput): TemplateBuildRe
     }
   }
 
-  // ── 4. Crew assignment (load balanced, descending sort) ───────────
+  // ── 4. Crew assignment (Phase 4.5 — capacity-aware geographic) ────
+  // Each cluster goes to the geographically closest crew that has
+  // remaining workday capacity. When the closest crew is full, the
+  // cluster spills to the next-closest, naturally absorbing overflow
+  // before the schedule is built (rather than letting one crew's
+  // overflow drop visits while another sits idle).
+  //
+  // Capacity per crew = cycleDays workdays. The cluster's projected
+  // workday cost = days_on_site_per_trip × trips_per_cycle.
+  //
+  // Distance metric = haversine from the cluster's centroid to the
+  // crew's "primary branch" (the branch with the most work hours
+  // among the clusters already assigned to that crew). Crews with no
+  // primary branch yet (no clusters assigned) get distance 0 — the
+  // first cluster to land on them sets their primary.
   const crews = Array.from({ length: input.crew_count }, (_, i) => ({
     index: i,
     label: `Crew ${i + 1}`,
     cluster_ids: [] as string[],
     total_work_hours: 0,
     total_drive_hours: 0,
+    workdays_assigned: 0,
   }))
-  const sorted = [...clusters].sort((a, b) => b.total_work_hours - a.total_work_hours)
-  for (const cluster of sorted) {
-    const target = crews.reduce((min, c) =>
-      c.total_work_hours + c.total_drive_hours < min.total_work_hours + min.total_drive_hours ? c : min
-    )
+
+  const dominantBranchOf = (crew: typeof crews[number]): number | null => {
+    if (crew.cluster_ids.length === 0) return null
+    const work = new Map<number, number>()
+    for (const cid of crew.cluster_ids) {
+      const cl = clusters.find((c) => c.cluster_id === cid)
+      if (!cl) continue
+      work.set(cl.base_branch_index, (work.get(cl.base_branch_index) ?? 0) + cl.total_work_hours)
+    }
+    let bestIdx: number | null = null
+    let bestVal = -1
+    for (const [idx, val] of work) {
+      if (val > bestVal) {
+        bestVal = val
+        bestIdx = idx
+      }
+    }
+    return bestIdx
+  }
+
+  // Sort clusters biggest-first so the heaviest clusters get the most
+  // freedom of placement (they're more likely to define a crew's
+  // primary branch).
+  const sortedClusters = [...clusters].sort((a, b) => b.total_work_hours - a.total_work_hours)
+
+  let rebalanceWarning: string | null = null
+  for (const cluster of sortedClusters) {
+    const clusterWorkdays = cluster.days_on_site_per_trip * cluster.trips_per_cycle
+
+    const scored = crews.map((c) => {
+      const branchIdx = dominantBranchOf(c)
+      const branch = branchIdx != null ? input.branches[branchIdx] : null
+      const dist = branch
+        ? haversineMiles(
+            { lat: cluster.centroid_lat, lng: cluster.centroid_lng },
+            { lat: branch.lat, lng: branch.lng }
+          )
+        : 0
+      const wouldFit = c.workdays_assigned + clusterWorkdays <= cycleDays
+      return { crew: c, dist, wouldFit }
+    })
+
+    const fitting = scored.filter((s) => s.wouldFit)
+    const candidates = fitting.length > 0 ? fitting : scored
+    candidates.sort((a, b) => {
+      if (a.dist !== b.dist) return a.dist - b.dist
+      return a.crew.workdays_assigned - b.crew.workdays_assigned
+    })
+    const target = candidates[0].crew
+
+    if (fitting.length === 0 && rebalanceWarning == null) {
+      rebalanceWarning =
+        'All crews exceed cycle capacity for at least one cluster — overflow will surface as unplaced. Consider adding a crew or extending the cycle.'
+    }
+
     target.cluster_ids.push(cluster.cluster_id)
     target.total_work_hours += cluster.total_work_hours
     target.total_drive_hours += cluster.estimated_drive_hours
+    target.workdays_assigned += clusterWorkdays
   }
 
   // Branch-prefixed crew labels: pick each crew's dominant branch
@@ -813,6 +879,13 @@ export function buildRoutingTemplate(input: BuildTemplateInput): TemplateBuildRe
   }
 
   const warnings: TemplateBuildResult['warnings'] = []
+  if (rebalanceWarning) {
+    warnings.push({
+      type: 'crew_load_imbalance',
+      message: rebalanceWarning,
+      suggested_action: 'add a crew or extend cycle_length_days',
+    })
+  }
   if (crewEndSpread > TARGET_SPREAD) {
     const slowest = pacingPerCrew.reduce((a, b) => (a.cycle_end_workday < b.cycle_end_workday ? b : a))
     const fastest = pacingPerCrew.reduce((a, b) => (a.cycle_end_workday > b.cycle_end_workday ? b : a))


### PR DESCRIPTION
## Summary
The cluster→crew assignment was a pure greedy load-balance with no awareness of \`cycle_length_days\` as a workday capacity. So when a crew got loaded past the cycle horizon, the engine packed trips that wouldn't fit; the tail visits got silently dropped in cycle gen because their workdays mapped past \`cycle_end_date\`. Meanwhile other crews finished early with idle days they could have absorbed. PR #189 surfaced the dropped visits as unplaced rows but didn't fix the actual cause.

## Fix
Replace the greedy assignment with capacity-aware geographic placement:

For each cluster (sorted biggest first):
1. Score each crew by:
   - **Distance** from cluster centroid to crew's primary branch
   - **Workdays already assigned**
2. **Filter** to crews where the cluster fits in remaining capacity (\`workdays_assigned + clusterWorkdays ≤ cycleDays\`)
3. Pick the **closest** of those (tiebreak: least loaded)
4. If none fit, fall back to closest crew anyway and emit a \`crew_load_imbalance\` warning

This implements the operator's mental model: a crew stops accepting new clusters once full; clusters then spill to the next-closest crew with capacity. "Frisco's 9 overflow buildings" go to whichever non-Frisco branch is closest to those properties — automatically, before scheduling.

## Why post-build rebalancing wouldn't be enough
The fix has to happen **before** trip-build because:
- Trip routing computes stop sequences, drive distances, and durations against the assigned crew's branch
- If a cluster is moved post-build, the precomputed routing is stale
- Pacing post-process spreads trips per crew; it can't rebalance across crews without re-running routing

Pre-assignment makes the trip-build run with the right crew→cluster mapping from the start.

## Test plan
- [ ] Regenerate Cycle 2 with crew_count=3 → fewer (or zero) "overflow past cycle end" unplaced visits because clusters now distribute by capacity
- [ ] Crew workdays are roughly balanced (no crew way over cycleDays while another sits at half)
- [ ] When a cluster genuinely can't fit anywhere → \`crew_load_imbalance\` warning surfaces with "add a crew or extend cycle_length_days"
- [ ] tsc clean (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)