### PR TITLE
Branch assignments view + per-property override

### DIFF
--- a/api/_lib/scheduler/build-routing-template.ts
+++ b/api/_lib/scheduler/build-routing-template.ts
@@ -79,6 +79,11 @@ export interface BuildTemplateInput {
     allow_hard_constraint_violation: boolean
   }
   cycle_start_year: number
+  // Phase 4.5d — operator-supplied branch overrides keyed by SL id.
+  // When present, the rebalance pass FORCES that property to the
+  // specified branch (no auto-rebalance for it). All other properties
+  // run through the normal capacity-circle algorithm.
+  branch_assignment_overrides?: Record<string, number>
 }
 
 interface VisitSpec {
@@ -189,6 +194,19 @@ export interface TemplateBuildResult {
     message: string
     affected_crews?: number[]
     suggested_action?: string
+  }>
+  // Phase 4.5d — per-property branch recommendations from the
+  // capacity-circle rebalance. UI renders this as the "Branch
+  // Assignments" view where operators can override a property's
+  // assigned branch (those overrides flow back as input next build).
+  branch_assignments: Array<{
+    service_location_id: string
+    property_id: string
+    address: string
+    nearest_branch_idx: number
+    assigned_branch_idx: number
+    transferred: boolean
+    overridden: boolean
   }>
 }
 
@@ -365,6 +383,7 @@ export function buildRoutingTemplate(input: BuildTemplateInput): TemplateBuildRe
   // for the long drive in its budget, naturally rejecting transfers
   // that would actually cost more than they save.
   const localBranchAssignment = new Map<string, number>()
+  const branchAssignmentsOutput: TemplateBuildResult['branch_assignments'] = []
   let propertiesTransferred = 0
   if (local.length > 0 && input.branches.length > 1) {
     type EnrichedVisit = {
@@ -457,12 +476,31 @@ export function buildRoutingTemplate(input: BuildTemplateInput): TemplateBuildRe
       capacityByBranch.set(b, Math.max(0, totalCap - remoteCommitted))
     }
 
+    // Apply operator overrides first — those properties are FORCED to
+    // their override branch and don't enter the wants-list competition.
+    // Their cost still counts against their target branch's capacity
+    // so the engine doesn't double-book.
+    const overrides = input.branch_assignment_overrides ?? {}
+    const overriddenIds = new Set<string>()
+    const usedFromOverrides = new Map<number, number>()
+    for (const e of enriched) {
+      const override = overrides[e.v.service_location_id]
+      if (typeof override === 'number' && override >= 0 && override < input.branches.length) {
+        localBranchAssignment.set(e.v.service_location_id, override)
+        overriddenIds.add(e.v.service_location_id)
+        usedFromOverrides.set(override, (usedFromOverrides.get(override) ?? 0) + costOn(e, override))
+      }
+    }
+
     // Step 1: each branch picks its closest-fit properties until its
-    // capacity (after subtracting remote commitments) is full.
+    // capacity (after subtracting remote commitments AND override-
+    // claimed hours) is full. Overridden properties are skipped here.
     const wantsByBranch = new Map<number, Set<string>>()
     for (let b = 0; b < input.branches.length; b++) {
-      const cap = capacityByBranch.get(b) ?? 0
-      const sorted = [...enriched].sort((a, c) => costOn(a, b) - costOn(c, b))
+      const cap = (capacityByBranch.get(b) ?? 0) - (usedFromOverrides.get(b) ?? 0)
+      const sorted = [...enriched]
+        .filter((e) => !overriddenIds.has(e.v.service_location_id))
+        .sort((a, c) => costOn(a, b) - costOn(c, b))
       const wants = new Set<string>()
       let used = 0
       for (const e of sorted) {
@@ -521,6 +559,21 @@ export function buildRoutingTemplate(input: BuildTemplateInput): TemplateBuildRe
       // Anything still unassigned is genuine overflow — falls through
       // to the engine's existing unplaced-visits path. Gap-fill (#196)
       // takes a final crack on idle workdays.
+    }
+
+    // Emit per-property branch_assignments so the UI can show the
+    // recommendation and let operators override.
+    for (const e of enriched) {
+      const assigned = localBranchAssignment.get(e.v.service_location_id) ?? -1
+      branchAssignmentsOutput.push({
+        service_location_id: e.v.service_location_id,
+        property_id: e.v.property_id,
+        address: e.v.address,
+        nearest_branch_idx: e.nearest_idx,
+        assigned_branch_idx: assigned,
+        transferred: assigned !== e.nearest_idx && assigned >= 0,
+        overridden: overriddenIds.has(e.v.service_location_id),
+      })
     }
   }
 
@@ -1185,6 +1238,7 @@ export function buildRoutingTemplate(input: BuildTemplateInput): TemplateBuildRe
     },
     pacing_analysis,
     warnings,
+    branch_assignments: branchAssignmentsOutput,
   }
 }
 

--- a/api/scheduler/templates/[templateId]/branch-overrides.ts
+++ b/api/scheduler/templates/[templateId]/branch-overrides.ts
@@ -1,0 +1,59 @@
+// PATCH /api/scheduler/templates/[templateId]/branch-overrides
+// Body: { service_location_id: string, branch_idx: number | null }
+//
+// Sets or clears a per-property branch override on a routing template.
+// Set branch_idx = null to clear an override (property goes back to the
+// engine's recommendation on next regenerate).
+//
+// The override is stored on routing_templates.branch_assignment_overrides
+// and read by the engine in build-routing-template's rebalance pass.
+// User MUST regenerate the template for overrides to affect the schedule.
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { createAdminClient } from '../../../_lib/supabase.js'
+import { authenticateRequest } from '../../../_lib/auth.js'
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'PATCH' && req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+  try {
+    await authenticateRequest(req)
+  } catch (err: any) {
+    return res.status(err.statusCode ?? 401).json({ error: err.message ?? 'Unauthorized' })
+  }
+  const templateId = req.query.templateId as string
+  const body = (req.body ?? {}) as { service_location_id?: string; branch_idx?: number | null }
+  if (!body.service_location_id) {
+    return res.status(400).json({ error: 'service_location_id required' })
+  }
+  const db = createAdminClient()
+
+  const { data: tpl, error: tplErr } = await db
+    .from('routing_templates')
+    .select('branch_assignment_overrides, branches')
+    .eq('id', templateId)
+    .maybeSingle()
+  if (tplErr || !tpl) return res.status(404).json({ error: 'Template not found' })
+
+  const overrides = ((tpl as any).branch_assignment_overrides ?? {}) as Record<string, number>
+  const branches = ((tpl as any).branches ?? []) as any[]
+
+  if (body.branch_idx === null || body.branch_idx === undefined) {
+    delete overrides[body.service_location_id]
+  } else {
+    if (!Number.isInteger(body.branch_idx) || body.branch_idx < 0 || body.branch_idx >= branches.length) {
+      return res
+        .status(400)
+        .json({ error: `branch_idx must be an integer in [0, ${branches.length - 1}]` })
+    }
+    overrides[body.service_location_id] = body.branch_idx
+  }
+
+  const { error: updErr } = await db
+    .from('routing_templates')
+    .update({ branch_assignment_overrides: overrides, updated_at: new Date().toISOString() })
+    .eq('id', templateId)
+  if (updErr) return res.status(500).json({ error: updErr.message })
+
+  return res.status(200).json({ ok: true, overrides })
+}

--- a/api/scheduler/templates/[templateId]/regenerate.ts
+++ b/api/scheduler/templates/[templateId]/regenerate.ts
@@ -286,6 +286,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         allow_hard_constraint_violation: body.preferences?.allow_hard_constraint_violation ?? false,
       },
       cycle_start_year: new Date().getUTCFullYear(),
+      branch_assignment_overrides:
+        (tpl.branch_assignment_overrides as Record<string, number> | null) ?? undefined,
     })
 
     if (propertiesMissingCoords.length > 0) {
@@ -363,6 +365,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         optimizer_notes: result.optimizer_notes,
         pacing_analysis: result.pacing_analysis,
         warnings: result.warnings,
+        branch_assignments: result.branch_assignments,
       })
       .eq('id', templateId)
     const { data: full } = await db.from('routing_templates').select('*').eq('id', templateId).single()

--- a/api/scheduler/templates/index.ts
+++ b/api/scheduler/templates/index.ts
@@ -423,6 +423,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           optimizer_notes: result.optimizer_notes,
           pacing_analysis: result.pacing_analysis,
           warnings: result.warnings,
+          branch_assignments: result.branch_assignments,
         })
         .eq('id', templateId)
 

--- a/src/components/scheduler/BranchAssignmentsPanel.tsx
+++ b/src/components/scheduler/BranchAssignmentsPanel.tsx
@@ -1,0 +1,235 @@
+// Phase 4.5d — Branch Assignments panel.
+// Renders the engine's per-property branch recommendation and lets
+// operators override per-property. Overrides persist to
+// routing_templates.branch_assignment_overrides; the operator must
+// regenerate the template for them to affect the schedule.
+import { useMemo, useState } from 'react'
+import { Card, CardTitle, CardDescription } from '../ui/Card'
+import { Input } from '../ui/Input'
+import { Badge } from '../ui/Badge'
+import {
+  Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
+} from '../ui/Table'
+import { useAuth } from '../../hooks/useAuth'
+
+interface Branch { name: string; lat: number; lng: number }
+
+interface Assignment {
+  service_location_id: string
+  property_id: string
+  address: string
+  nearest_branch_idx: number
+  assigned_branch_idx: number
+  transferred: boolean
+  overridden: boolean
+}
+
+interface Props {
+  templateId: string
+  branches: Branch[]
+  assignments: Assignment[]
+  overrides: Record<string, number>
+  onChanged: () => void
+}
+
+export default function BranchAssignmentsPanel({
+  templateId,
+  branches,
+  assignments,
+  overrides,
+  onChanged,
+}: Props) {
+  const { getToken } = useAuth()
+  const [filter, setFilter] = useState('')
+  const [branchFilter, setBranchFilter] = useState<string>('all')
+  const [showOnlyTransferred, setShowOnlyTransferred] = useState(false)
+  const [savingId, setSavingId] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  const counts = useMemo(() => {
+    const transferred = assignments.filter((a) => a.transferred && !a.overridden).length
+    const overridden = assignments.filter((a) => a.overridden).length
+    return { total: assignments.length, transferred, overridden }
+  }, [assignments])
+
+  const filtered = useMemo(() => {
+    const q = filter.trim().toLowerCase()
+    return assignments.filter((a) => {
+      if (showOnlyTransferred && !a.transferred && !a.overridden) return false
+      if (branchFilter !== 'all') {
+        const target = Number(branchFilter)
+        if (a.assigned_branch_idx !== target) return false
+      }
+      if (!q) return true
+      return a.address.toLowerCase().includes(q)
+    })
+  }, [assignments, filter, branchFilter, showOnlyTransferred])
+
+  const setOverride = async (
+    serviceLocationId: string,
+    branchIdx: number | null
+  ) => {
+    setSavingId(serviceLocationId)
+    setError(null)
+    try {
+      const token = await getToken()
+      const res = await fetch(
+        `/api/scheduler/templates/${templateId}/branch-overrides`,
+        {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+          body: JSON.stringify({ service_location_id: serviceLocationId, branch_idx: branchIdx }),
+        }
+      )
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}))
+        throw new Error((j as any).error ?? `HTTP ${res.status}`)
+      }
+      onChanged()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e))
+    } finally {
+      setSavingId(null)
+    }
+  }
+
+  const branchLabel = (idx: number) => branches[idx]?.name ?? `Branch ${idx}`
+
+  return (
+    <Card padding="none">
+      <div className="border-b border-border px-4 py-3 flex items-center justify-between gap-3 flex-wrap">
+        <div>
+          <CardTitle>Branch assignments</CardTitle>
+          <CardDescription>
+            Engine's recommendation per property from the capacity-circle rebalance.
+            Override to force a property to a specific branch — regenerate the template
+            for the override to affect the schedule.
+          </CardDescription>
+        </div>
+        <div className="flex items-center gap-3 text-xs text-fg-muted">
+          <span><span className="font-tabular text-fg">{counts.total}</span> properties</span>
+          <span>·</span>
+          <span><span className="font-tabular text-fg">{counts.transferred}</span> auto-transferred</span>
+          <span>·</span>
+          <span><span className="font-tabular text-fg">{counts.overridden}</span> overridden</span>
+        </div>
+      </div>
+
+      <div className="border-b border-border px-4 py-2 flex items-center gap-2 flex-wrap">
+        <Input
+          placeholder="Filter by address…"
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+          className="max-w-xs h-8 text-xs"
+        />
+        <select
+          value={branchFilter}
+          onChange={(e) => setBranchFilter(e.target.value)}
+          className="h-8 rounded-md border border-border bg-surface px-2 text-xs text-fg"
+        >
+          <option value="all">All branches</option>
+          {branches.map((b, i) => (
+            <option key={i} value={String(i)}>
+              {b.name}
+            </option>
+          ))}
+        </select>
+        <label className="flex items-center gap-1 text-xs text-fg-muted">
+          <input
+            type="checkbox"
+            checked={showOnlyTransferred}
+            onChange={(e) => setShowOnlyTransferred(e.target.checked)}
+            className="rounded border-border accent-accent"
+          />
+          Only auto-transferred or overridden
+        </label>
+      </div>
+
+      {error && (
+        <p className="px-4 py-2 text-xs text-danger border-b border-danger/30 bg-danger-subtle">
+          {error}
+        </p>
+      )}
+
+      {filtered.length === 0 ? (
+        <p className="px-4 py-6 text-sm text-fg-muted">No assignments match the current filter.</p>
+      ) : (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Property</TableHead>
+              <TableHead>Engine recommendation</TableHead>
+              <TableHead>Assigned branch</TableHead>
+              <TableHead className="w-32" />
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {filtered.slice(0, 500).map((a) => {
+              const overrideVal = overrides[a.service_location_id]
+              const recommendedIdx =
+                a.overridden
+                  ? // engine echoes the override into assigned_branch_idx so
+                    // we need a "what would engine pick" hint — use nearest
+                    a.nearest_branch_idx
+                  : a.assigned_branch_idx
+              return (
+                <TableRow key={a.service_location_id}>
+                  <TableCell className="text-sm">
+                    <p className="font-medium text-fg">{a.address}</p>
+                    <p className="text-[11px] text-fg-subtle">
+                      Nearest: {branchLabel(a.nearest_branch_idx)}
+                      {a.transferred && !a.overridden && (
+                        <span className="ml-1 text-warning">
+                          → engine moved to {branchLabel(a.assigned_branch_idx)}
+                        </span>
+                      )}
+                    </p>
+                  </TableCell>
+                  <TableCell>
+                    <Badge
+                      variant={a.transferred ? 'warning' : 'outline'}
+                      className="text-[10px]"
+                    >
+                      {branchLabel(recommendedIdx)}
+                    </Badge>
+                  </TableCell>
+                  <TableCell>
+                    <select
+                      value={overrideVal != null ? String(overrideVal) : 'auto'}
+                      disabled={savingId === a.service_location_id}
+                      onChange={(e) => {
+                        const v = e.target.value
+                        setOverride(
+                          a.service_location_id,
+                          v === 'auto' ? null : Number(v)
+                        )
+                      }}
+                      className="h-7 rounded-md border border-border bg-surface px-2 text-xs text-fg"
+                    >
+                      <option value="auto">Auto (engine)</option>
+                      {branches.map((b, i) => (
+                        <option key={i} value={String(i)}>
+                          {b.name}
+                        </option>
+                      ))}
+                    </select>
+                  </TableCell>
+                  <TableCell className="text-right">
+                    {a.overridden && (
+                      <Badge variant="accent" className="text-[10px]">overridden</Badge>
+                    )}
+                  </TableCell>
+                </TableRow>
+              )
+            })}
+          </TableBody>
+        </Table>
+      )}
+      {filtered.length > 500 && (
+        <p className="px-4 py-2 text-xs text-fg-muted bg-surface-subtle border-t border-border">
+          Showing first 500 of {filtered.length}. Filter to narrow the list.
+        </p>
+      )}
+    </Card>
+  )
+}

--- a/src/pages/accounts/scheduler/TemplateDetail.tsx
+++ b/src/pages/accounts/scheduler/TemplateDetail.tsx
@@ -17,6 +17,7 @@ import {
   Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
 } from '../../../components/ui/Table'
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '../../../components/ui/Tabs'
+import BranchAssignmentsPanel from '../../../components/scheduler/BranchAssignmentsPanel'
 
 interface Template {
   id: string
@@ -43,6 +44,9 @@ interface Template {
   crew_assignments: any[]
   trips: any[]
   unplaced_visits: any[]
+  branches?: Array<{ name: string; lat: number; lng: number }>
+  branch_assignments?: any[]
+  branch_assignment_overrides?: Record<string, number>
 }
 
 interface Cycle {
@@ -295,6 +299,20 @@ export default function TemplateDetailPage() {
             {template.optimizer_notes}
           </div>
         )}
+
+        {/* Branch assignments — engine recommendations + per-property overrides */}
+        {Array.isArray(template.branch_assignments) &&
+          template.branch_assignments.length > 0 &&
+          Array.isArray(template.branches) &&
+          template.branches.length > 0 && (
+            <BranchAssignmentsPanel
+              templateId={templateId!}
+              branches={template.branches}
+              assignments={template.branch_assignments as any}
+              overrides={template.branch_assignment_overrides ?? {}}
+              onChanged={() => load()}
+            />
+          )}
 
         {/* Cycle instances */}
         <Card padding="none">

--- a/supabase/migrations/20260501220022_branch_assignment_overrides.sql
+++ b/supabase/migrations/20260501220022_branch_assignment_overrides.sql
@@ -1,0 +1,11 @@
+-- Phase 4.5d — branch assignment recommendations + overrides on routing templates.
+-- branch_assignments (engine output): per-property recommendation from the
+-- capacity-circle rebalance pass. Shape:
+--   [{ service_location_id, property_id, address, recommended_branch_idx,
+--      assigned_branch_idx, nearest_branch_idx, transferred, reason? }, ...]
+-- branch_assignment_overrides (operator input): force a property to a
+-- specific branch index regardless of the engine's recommendation.
+--   { service_location_id: branch_idx, ... }
+ALTER TABLE public.routing_templates
+  ADD COLUMN IF NOT EXISTS branch_assignments jsonb,
+  ADD COLUMN IF NOT EXISTS branch_assignment_overrides jsonb NOT NULL DEFAULT '{}'::jsonb;


### PR DESCRIPTION
## Summary
The pre-cluster rebalance (#197) picks each property's branch via the capacity-circle algorithm. This PR exposes those decisions to the operator and lets them override per-property when their domain knowledge says different.

## Migration
- \`routing_templates.branch_assignments\` jsonb (engine output: per-property recommendations)
- \`routing_templates.branch_assignment_overrides\` jsonb (operator input, defaults to \`{}\`)

## Engine changes
- \`buildRoutingTemplate\` accepts \`branch_assignment_overrides\`. Overridden properties are FORCED to their override branch and skip the wants-list competition. Their cost still counts against the override branch's capacity so the engine doesn't double-book.
- \`TemplateBuildResult\` emits \`branch_assignments[]\` (per-property recommendation + \`transferred\` / \`overridden\` flags).
- Both create + regenerate persist \`branch_assignments\`; regenerate also threads overrides into the engine.

## API
\`PATCH /api/scheduler/templates/[id]/branch-overrides\`
- Body: \`{ service_location_id, branch_idx | null }\`
- Sets or clears one property's override. \`null\` reverts to engine recommendation.

## UI — \`BranchAssignmentsPanel\` on Template Detail
- Per-property table: address, engine recommendation, current assigned branch, override dropdown
- Filters: address contains, branch dropdown, "only auto-transferred or overridden"
- Each row's dropdown saves immediately on change; "overridden" badge appears once set
- Counts at top: total / auto-transferred / overridden

## Operator workflow
1. **Look** → see which properties got auto-transferred and where (capacity-circle output is now visible)
2. **Disagree** → pick a different branch from the dropdown (saves immediately)
3. **Regenerate template** → engine respects overrides, recomputes everything else

## Test plan
- [ ] Regenerate Cycle 2's template → BranchAssignmentsPanel renders with per-property recommendations
- [ ] Auto-transferred properties show "→ engine moved to <branch>" hint
- [ ] Pick a different branch from a row's dropdown → "overridden" badge appears
- [ ] Regenerate → that property lands on the override branch
- [ ] Set dropdown back to "Auto" → next regenerate uses engine recommendation
- [ ] tsc + build clean (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)