### PR TITLE
Fix gap-fill float→int cast crash + show generate errors

### DIFF
--- a/api/_lib/scheduler/generate-cycle-instance.ts
+++ b/api/_lib/scheduler/generate-cycle-instance.ts
@@ -459,6 +459,11 @@ export async function generateCycleInstance(
       return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`
     }
 
+    // Round all minute fields — crew_day_routes integer columns reject
+    // floats (e.g. driveTimeMinutes returns a real-valued estimate).
+    const driveMinInt = Math.round(best.driveMin)
+    const totalDriveMin = Math.round(2 * best.driveMin)
+    const totalDayMin = Math.round(best.totalMin)
     crewDayRoutes.push({
       id: newRouteId,
       cycle_instance_id: cycleInstanceId,
@@ -479,16 +484,16 @@ export async function generateCycleInstance(
           address: prop.address ?? '',
           arrival_time: fmt(arrivalMin),
           departure_time: fmt(departureMin),
-          drive_minutes_from_previous: best.driveMin,
+          drive_minutes_from_previous: driveMinInt,
           drive_distance_miles_from_previous: Math.round(best.distMi * 10) / 10,
           work_minutes: propWorkMin,
           constraint_violations: [],
         },
       ],
-      total_drive_minutes: 2 * best.driveMin,
+      total_drive_minutes: totalDriveMin,
       total_work_minutes: propWorkMin,
       total_buffer_minutes: 0,
-      total_day_minutes: best.totalMin,
+      total_day_minutes: totalDayMin,
       total_drive_miles: Math.round(best.distMi * 2 * 10) / 10,
       trip_day_number: 1,
       trip_total_days: 1,

--- a/src/pages/accounts/scheduler/TemplateDetail.tsx
+++ b/src/pages/accounts/scheduler/TemplateDetail.tsx
@@ -554,6 +554,11 @@ export default function TemplateDetailPage() {
                 onChange={(e) => setGenStartDate(e.target.value)}
               />
             </FormField>
+            {error && (
+              <p className="rounded-md border border-danger/30 bg-danger-subtle px-3 py-2 text-xs text-danger">
+                {error}
+              </p>
+            )}
           </div>
           <DialogFooter>
             <Button variant="ghost" onClick={() => setGenerateOpen(false)}>Cancel</Button>


### PR DESCRIPTION
## Two bugs blocking Generate Cycle

### 1. Gap-fill sent floats to integer columns (the actual crash)
The error was \`Invalid input syntax for type integer: "574.1744852478544"\`. Gap-fill (#196) computed \`total_drive_minutes\` / \`total_day_minutes\` from \`driveTimeMinutes()\` which returns a real-valued estimate, then pushed straight into \`crew_day_routes\` integer columns. Postgres rejected and the whole batch insert rolled back, killing the cycle.

Fix: round every minute-valued field before insert (\`total_drive_minutes\`, \`total_day_minutes\`, \`drive_minutes_from_previous\` on the route stop).

### 2. Generate dialog hid all errors
\`setError\` populated the page-level state but the generate dialog itself didn't render it. The user saw the spinner stop and the dialog stay open with no message — looked like a silent failure with no way to debug.

Fix: render the error inline in the dialog with danger styling.

## Test plan
- [ ] Generate cycle on a template with overflow → completes successfully (no float-cast error)
- [ ] Force a failure (e.g. invalid start_date) → the error message displays in the dialog
- [ ] tsc clean (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)