### PR TITLE
Branch Assignments: include remote properties (123 missing → 509 total)

### DIFF
--- a/api/_lib/scheduler/build-routing-template.ts
+++ b/api/_lib/scheduler/build-routing-template.ts
@@ -207,6 +207,7 @@ export interface TemplateBuildResult {
     assigned_branch_idx: number
     transferred: boolean
     overridden: boolean
+    is_remote: boolean
   }>
 }
 
@@ -573,6 +574,35 @@ export function buildRoutingTemplate(input: BuildTemplateInput): TemplateBuildRe
         assigned_branch_idx: assigned,
         transferred: assigned !== e.nearest_idx && assigned >= 0,
         overridden: overriddenIds.has(e.v.service_location_id),
+        is_remote: false,
+      })
+    }
+  }
+
+  // Include REMOTE properties in branch_assignments too so the UI count
+  // matches the total property count. Remotes always go to their
+  // nearest branch (no rebalance — the geography forces it). The UI
+  // disables override on these.
+  if (remote.length > 0 && input.branches.length > 0) {
+    for (const v of remote) {
+      let nearest = 0
+      let bestDist = Number.POSITIVE_INFINITY
+      for (let i = 0; i < input.branches.length; i++) {
+        const d = haversineMiles({ lat: v.lat, lng: v.lng }, input.branches[i])
+        if (d < bestDist) {
+          bestDist = d
+          nearest = i
+        }
+      }
+      branchAssignmentsOutput.push({
+        service_location_id: v.service_location_id,
+        property_id: v.property_id,
+        address: v.address,
+        nearest_branch_idx: nearest,
+        assigned_branch_idx: nearest,
+        transferred: false,
+        overridden: false,
+        is_remote: true,
       })
     }
   }

--- a/src/components/scheduler/BranchAssignmentsPanel.tsx
+++ b/src/components/scheduler/BranchAssignmentsPanel.tsx
@@ -22,6 +22,7 @@ interface Assignment {
   assigned_branch_idx: number
   transferred: boolean
   overridden: boolean
+  is_remote?: boolean
 }
 
 interface Props {
@@ -49,7 +50,8 @@ export default function BranchAssignmentsPanel({
   const counts = useMemo(() => {
     const transferred = assignments.filter((a) => a.transferred && !a.overridden).length
     const overridden = assignments.filter((a) => a.overridden).length
-    return { total: assignments.length, transferred, overridden }
+    const remote = assignments.filter((a) => a.is_remote).length
+    return { total: assignments.length, transferred, overridden, remote }
   }, [assignments])
 
   const filtered = useMemo(() => {
@@ -112,6 +114,12 @@ export default function BranchAssignmentsPanel({
           <span><span className="font-tabular text-fg">{counts.transferred}</span> auto-transferred</span>
           <span>·</span>
           <span><span className="font-tabular text-fg">{counts.overridden}</span> overridden</span>
+          {counts.remote > 0 && (
+            <>
+              <span>·</span>
+              <span><span className="font-tabular text-fg">{counts.remote}</span> remote</span>
+            </>
+          )}
         </div>
       </div>
 
@@ -183,6 +191,9 @@ export default function BranchAssignmentsPanel({
                           → engine moved to {branchLabel(a.assigned_branch_idx)}
                         </span>
                       )}
+                      {a.is_remote && (
+                        <span className="ml-1 text-fg-muted">· remote (overnight)</span>
+                      )}
                     </p>
                   </TableCell>
                   <TableCell>
@@ -196,7 +207,8 @@ export default function BranchAssignmentsPanel({
                   <TableCell>
                     <select
                       value={overrideVal != null ? String(overrideVal) : 'auto'}
-                      disabled={savingId === a.service_location_id}
+                      disabled={savingId === a.service_location_id || a.is_remote}
+                      title={a.is_remote ? 'Remote properties auto-route to nearest branch' : undefined}
                       onChange={(e) => {
                         const v = e.target.value
                         setOverride(
@@ -204,7 +216,10 @@ export default function BranchAssignmentsPanel({
                           v === 'auto' ? null : Number(v)
                         )
                       }}
-                      className="h-7 rounded-md border border-border bg-surface px-2 text-xs text-fg"
+                      className={
+                        'h-7 rounded-md border border-border bg-surface px-2 text-xs text-fg ' +
+                        (a.is_remote ? 'opacity-50' : '')
+                      }
                     >
                       <option value="auto">Auto (engine)</option>
                       {branches.map((b, i) => (


### PR DESCRIPTION
## Why
The panel showed 386 of 509 properties. The engine's \`branch_assignments\` output only included LOCAL properties; the 123 remote (overnight) ones were silently excluded. Every property was being scheduled — the count display was just incomplete.

## Fix
- Engine emits remote properties in \`branch_assignments\` too, with \`is_remote=true\`. They're routed to their nearest branch (the geography forces it; remotes can't be economically cross-assigned the way border-locals can).
- UI adds a "remote" count to the header strip
- Each remote row shows "· remote (overnight)" in the address subtext
- Override dropdown is disabled for remote rows with a tooltip explaining auto-routing

## Followup (if needed)
Letting operators override remote properties too would require the engine to honor those overrides in the remote-cluster assignment path. Skipping for now since remotes are by definition far from any branch and the choice is geographically forced.

## Test plan
- [ ] Regenerate Cycle 2's template → Branch Assignments shows 509 properties (whatever your client total is)
- [ ] Header shows local + remote counts separately
- [ ] Remote rows visibly disabled with tooltip
- [ ] Local rows still work for override
- [ ] tsc clean (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)