### PR TITLE
Prioritize overnight trips + fix cycleDays calendar/workday mismatch

### DIFF
--- a/api/_lib/scheduler/build-routing-template.ts
+++ b/api/_lib/scheduler/build-routing-template.ts
@@ -838,7 +838,36 @@ export function buildRoutingTemplate(input: BuildTemplateInput): TemplateBuildRe
     }
   }
 
+  // Phase 4.5f — workday cap. cycle_length_days is in CALENDAR days
+  // (e.g. 365 for an annual cycle), but trip-build sequences trips
+  // by workday count. addWorkdays in cycle-gen maps workday N → the
+  // Nth Mon-Fri date from cycle.start_date, which is ~N × 7/5
+  // calendar days in. Without this conversion, trip-build thinks it
+  // has 365 workdays of room when really it has ~261, and the last
+  // ~104 workdays' worth of visits land past cycle_end_date and get
+  // silently dropped.
+  const cycleWorkdays = Math.max(1, Math.floor((cycleDays * 5) / 7))
+
   // ── 5. Sequence trips on cycle calendar ───────────────────────────
+  // Phase 4.5f — schedule REMOTE clusters first per crew. Overnight
+  // trips are multi-day contiguous blocks; if local trips eat up the
+  // early cycle workdays, the overnights end up landing past
+  // cycle_end_date and getting dropped (gap-fill can't recover them
+  // because it only handles single-day visits). Locals are more
+  // flexible — gap-fill catches single-day overflow on idle days
+  // from any crew. So overnights take priority for the early slots.
+  for (const crew of crews) {
+    crew.cluster_ids.sort((a, b) => {
+      const ca = clusters.find((c) => c.cluster_id === a)
+      const cb = clusters.find((c) => c.cluster_id === b)
+      const ar = ca?.cluster_type === 'remote' ? 0 : 1
+      const br = cb?.cluster_type === 'remote' ? 0 : 1
+      if (ar !== br) return ar - br
+      // Tiebreak: bigger clusters first within the same type.
+      return (cb?.total_work_hours ?? 0) - (ca?.total_work_hours ?? 0)
+    })
+  }
+
   const trips: any[] = []
   const unplaced: any[] = []
 
@@ -858,15 +887,17 @@ export function buildRoutingTemplate(input: BuildTemplateInput): TemplateBuildRe
         // since they're continuous work, not discrete visits.
         let tripStart: number
         if (cluster.cluster_type === 'remote') {
+          // Target the midpoint of each visit's segment of the cycle.
+          // Use cycleWorkdays here — tripStart is a workday count.
           const targetStart = Math.floor(
-            (cycleDays * (visitIdx + 0.5)) / cluster.trips_per_cycle
+            (cycleWorkdays * (visitIdx + 0.5)) / cluster.trips_per_cycle
           )
           tripStart = Math.max(targetStart, nextAvailableDay)
         } else {
           tripStart = nextAvailableDay
         }
         // Hard cap: trip can't run past the cycle window.
-        const maxDaysForTrip = Math.max(1, cycleDays - tripStart)
+        const maxDaysForTrip = Math.max(1, cycleWorkdays - tripStart)
 
         // Build per-day routes via routeDay(). Visits eligible for THIS
         // visit_index of THIS cluster:
@@ -1144,7 +1175,7 @@ export function buildRoutingTemplate(input: BuildTemplateInput): TemplateBuildRe
     list.sort((a, b) => (a.relative_start_day ?? 0) - (b.relative_start_day ?? 0))
     const naturalEnd = naturalEndByCrew.get(crewIdx) ?? 0
     if (naturalEnd >= latestNaturalEnd) continue
-    const slack = Math.min(latestNaturalEnd - naturalEnd, Math.max(0, cycleDays - naturalEnd))
+    const slack = Math.min(latestNaturalEnd - naturalEnd, Math.max(0, cycleWorkdays - naturalEnd))
     if (slack <= 0) continue
     // Distribute slack across the gaps after each trip except the last.
     // For N trips → N-1 gap slots; if there's 1 trip, just delay it.

--- a/api/_lib/scheduler/build-routing-template.ts
+++ b/api/_lib/scheduler/build-routing-template.ts
@@ -1168,28 +1168,34 @@ export function buildRoutingTemplate(input: BuildTemplateInput): TemplateBuildRe
   }
   const latestNaturalEnd = Math.max(0, ...Array.from(naturalEndByCrew.values()))
   // Stretch every crew's trips so their LAST trip ends at latestNaturalEnd
-  // (or as close as the cycle horizon allows). Distribute the slack as
-  // idle gaps proportional to trip durations between consecutive trips.
+  // (or as close as the cycle horizon allows). Pacing operates on LOCAL
+  // trips only — remote trips are intentionally placed at evenly-spaced
+  // midpoints (e.g. 4 Broken Arrow trips spread across the cycle every
+  // ~13 weeks). If pacing rewrote them, those spread targets would be
+  // collapsed into even-gap bunching, defeating the cluster's
+  // visits_per_cycle cadence.
   for (const [crewIdx, list] of tripsByCrew) {
     if (list.length === 0) continue
-    list.sort((a, b) => (a.relative_start_day ?? 0) - (b.relative_start_day ?? 0))
+    const localOnly = list.filter((t) => t.trip_type !== 'overnight')
+    if (localOnly.length === 0) continue
+    localOnly.sort((a, b) => (a.relative_start_day ?? 0) - (b.relative_start_day ?? 0))
     const naturalEnd = naturalEndByCrew.get(crewIdx) ?? 0
     if (naturalEnd >= latestNaturalEnd) continue
     const slack = Math.min(latestNaturalEnd - naturalEnd, Math.max(0, cycleWorkdays - naturalEnd))
     if (slack <= 0) continue
-    // Distribute slack across the gaps after each trip except the last.
-    // For N trips → N-1 gap slots; if there's 1 trip, just delay it.
-    const slots = Math.max(1, list.length - 1)
+    // Distribute slack across the gaps after each LOCAL trip except the
+    // last. Remote trips keep their target-midpoint positions.
+    const slots = Math.max(1, localOnly.length - 1)
     const baseGap = Math.floor(slack / slots)
     const remainder = slack - baseGap * slots
-    let cursor = list[0].relative_start_day ?? 0
-    if (list.length === 1) {
-      list[0].relative_start_day = cursor + slack
+    let cursor = localOnly[0].relative_start_day ?? 0
+    if (localOnly.length === 1) {
+      localOnly[0].relative_start_day = cursor + slack
     } else {
-      for (let i = 0; i < list.length; i++) {
-        list[i].relative_start_day = cursor
-        cursor += list[i].duration_days ?? 0
-        if (i < list.length - 1) {
+      for (let i = 0; i < localOnly.length; i++) {
+        localOnly[i].relative_start_day = cursor
+        cursor += localOnly[i].duration_days ?? 0
+        if (i < localOnly.length - 1) {
           cursor += baseGap + (i < remainder ? 1 : 0)
         }
       }


### PR DESCRIPTION
## Two related fixes for the 56 overnight trips that ran past cycle_end_date

### 1. Overnight priority
Each crew's \`cluster_ids\` now sorts so \`cluster_type='remote'\` clusters come **first**. Overnights are multi-day contiguous blocks — if locals eat the early cycle workdays, overnights can't fit later. Gap-fill can't recover them because it's single-day only. Locals are flexible: gap-fill catches single-day overflow on idle days from any crew. So overnights get the early slots.

### 2. \`cycleDays\` calendar/workday mismatch
\`cycle_length_days\` from \`cycle-length.ts\` is in **calendar** days (e.g. 365 for annual). But trip-build sequences trips by **workday** count, and cycle-gen's \`addWorkdays\` maps workday N → \~N × 7/5 calendar days from start.

Without the ratio, trip-build thought it had 365 workdays of room when really it had \~261 (5/7 of 365). The last \~104 workdays' worth of visits landed past \`cycle_end_date\` and got dropped silently. That's exactly the "2027-01-01" dates the user saw — those were workday offsets above \~261 mapping past the calendar end.

Fix: \`cycleWorkdays = Math.floor(cycleDays × 5 / 7)\`. Used by:
- \`maxDaysForTrip\` cap in trip-build
- remote trip target-start midpoint calculation
- pacing post-process slack bound

## Test plan
- [ ] Regenerate Cycle 2's template → unplaced count drops dramatically (the overnight trips that previously ran past cycle_end now fit)
- [ ] Per-crew utilization in pacing_analysis stays below \`cycleWorkdays\` workdays
- [ ] No "2027-XX-XX target workday mapped to" reasons after this
- [ ] tsc clean (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)