### PR TITLE
Honor branch overrides on overnight (remote) properties

### DIFF
--- a/api/_lib/scheduler/build-routing-template.ts
+++ b/api/_lib/scheduler/build-routing-template.ts
@@ -621,11 +621,12 @@ export function buildRoutingTemplate(input: BuildTemplateInput): TemplateBuildRe
     }
   }
 
-  // Include REMOTE properties in branch_assignments too so the UI count
-  // matches the total property count. Remotes always go to their
-  // nearest branch (no rebalance — the geography forces it). The UI
-  // disables override on these.
+  // Include REMOTE properties in branch_assignments. Each remote's
+  // assigned_branch_idx = override (if set) else its nearest branch.
+  // is_remote=true so the UI surfaces them differently, but overrides
+  // on remotes ARE honored by the engine (Phase 4.5h).
   if (remote.length > 0 && input.branches.length > 0) {
+    const overrides = input.branch_assignment_overrides ?? {}
     for (const v of remote) {
       let nearest = 0
       let bestDist = Number.POSITIVE_INFINITY
@@ -636,6 +637,12 @@ export function buildRoutingTemplate(input: BuildTemplateInput): TemplateBuildRe
           nearest = i
         }
       }
+      const overrideVal = overrides[v.service_location_id]
+      const hasOverride =
+        typeof overrideVal === 'number' &&
+        overrideVal >= 0 &&
+        overrideVal < input.branches.length
+      const assigned = hasOverride ? overrideVal : nearest
       branchAssignmentsOutput.push({
         service_location_id: v.service_location_id,
         property_id: v.property_id,
@@ -643,9 +650,9 @@ export function buildRoutingTemplate(input: BuildTemplateInput): TemplateBuildRe
         lat: v.lat,
         lng: v.lng,
         nearest_branch_idx: nearest,
-        assigned_branch_idx: nearest,
-        transferred: false,
-        overridden: false,
+        assigned_branch_idx: assigned,
+        transferred: assigned !== nearest,
+        overridden: hasOverride,
         is_remote: true,
       })
     }
@@ -678,22 +685,75 @@ export function buildRoutingTemplate(input: BuildTemplateInput): TemplateBuildRe
   }
 
   // Remote clusters: density cluster at radius. Each goes to its own
-  // nearest branch.
+  // nearest branch UNLESS the operator has set per-property overrides
+  // — properties with overrides are pulled out and grouped per-target-
+  // branch, density-clustered within each group, and the resulting
+  // clusters are forced to the override branch regardless of geography.
   if (remote.length > 0) {
-    const grouped = densityCluster(remote, input.config.cluster_radius_miles)
-    for (let gi = 0; gi < grouped.length; gi++) {
-      const group = grouped[gi]
-      const c = centroid(group.map((v) => ({ lat: v.lat, lng: v.lng })))
-      let bestBranchIdx = 0
-      let bestDist = Infinity
-      for (let i = 0; i < input.branches.length; i++) {
-        const d = haversineMiles(c, input.branches[i])
-        if (d < bestDist) {
-          bestDist = d
-          bestBranchIdx = i
+    const remoteOverrides = input.branch_assignment_overrides ?? {}
+    const overriddenRemote: VisitSpec[] = []
+    const naturalRemote: VisitSpec[] = []
+    for (const v of remote) {
+      const tgt = remoteOverrides[v.service_location_id]
+      if (
+        typeof tgt === 'number' &&
+        tgt >= 0 &&
+        tgt < input.branches.length
+      ) {
+        overriddenRemote.push(v)
+      } else {
+        naturalRemote.push(v)
+      }
+    }
+
+    // Natural path: density-cluster, assign each cluster to its centroid's nearest branch.
+    if (naturalRemote.length > 0) {
+      const grouped = densityCluster(naturalRemote, input.config.cluster_radius_miles)
+      for (let gi = 0; gi < grouped.length; gi++) {
+        const group = grouped[gi]
+        const c = centroid(group.map((v) => ({ lat: v.lat, lng: v.lng })))
+        let bestBranchIdx = 0
+        let bestDist = Infinity
+        for (let i = 0; i < input.branches.length; i++) {
+          const d = haversineMiles(c, input.branches[i])
+          if (d < bestDist) {
+            bestDist = d
+            bestBranchIdx = i
+          }
+        }
+        clusters.push(makeCluster(`remote-${gi}`, 'remote', bestBranchIdx, c, group, input))
+      }
+    }
+
+    // Override path: group properties by their override branch, then
+    // density-cluster within each group so geographically-close
+    // overrides on the same branch share a trip. The cluster's branch
+    // is the override branch (forced).
+    if (overriddenRemote.length > 0) {
+      const byBranch = new Map<number, VisitSpec[]>()
+      for (const v of overriddenRemote) {
+        const tgt = remoteOverrides[v.service_location_id] as number
+        const arr = byBranch.get(tgt) ?? []
+        arr.push(v)
+        byBranch.set(tgt, arr)
+      }
+      let overrideClusterIdx = 0
+      for (const [branchIdx, group] of byBranch) {
+        const subGroups = densityCluster(group, input.config.cluster_radius_miles)
+        for (const subGroup of subGroups) {
+          const c = centroid(subGroup.map((v) => ({ lat: v.lat, lng: v.lng })))
+          clusters.push(
+            makeCluster(
+              `remote-override-${branchIdx}-${overrideClusterIdx++}`,
+              'remote',
+              branchIdx,
+              c,
+              subGroup,
+              input
+            )
+          )
         }
       }
-      clusters.push(makeCluster(`remote-${gi}`, 'remote', bestBranchIdx, c, group, input))
     }
   }
 

--- a/src/components/scheduler/BranchAssignmentsMap.tsx
+++ b/src/components/scheduler/BranchAssignmentsMap.tsx
@@ -244,30 +244,26 @@ export default function BranchAssignmentsMap({
           : a.transferred
             ? '2px solid #fff'
             : '1.5px solid rgba(0,0,0,0.3)'
-        el.style.cursor = a.is_remote ? 'not-allowed' : 'pointer'
+        el.style.cursor = 'pointer'
         el.style.pointerEvents = 'auto'
-        el.title = `${a.address}${a.is_remote ? ' (remote — auto-routed)' : ' — click to reassign'}`
-        if (!a.is_remote) {
-          el.addEventListener('mouseenter', () => {
-            el.style.transform = 'scale(1.6)'
-            el.style.zIndex = '10'
+        el.title = `${a.address}${a.is_remote ? ' (overnight — click to reassign)' : ' — click to reassign'}`
+        el.addEventListener('mouseenter', () => {
+          el.style.transform = 'scale(1.6)'
+          el.style.zIndex = '10'
+        })
+        el.addEventListener('mouseleave', () => {
+          el.style.transform = 'scale(1)'
+          el.style.zIndex = ''
+        })
+        el.addEventListener('click', (e) => {
+          e.stopPropagation()
+          setSelected(a)
+          mapRef.current?.flyTo({
+            center: [a.lng, a.lat],
+            zoom: Math.max(mapRef.current.getZoom(), 9),
+            duration: 400,
           })
-          el.addEventListener('mouseleave', () => {
-            el.style.transform = 'scale(1)'
-            el.style.zIndex = ''
-          })
-          el.addEventListener('click', (e) => {
-            e.stopPropagation()
-            setSelected(a)
-            // Fly to the clicked dot so the visual connection between
-            // dot and override panel is clear.
-            mapRef.current?.flyTo({
-              center: [a.lng, a.lat],
-              zoom: Math.max(mapRef.current.getZoom(), 9),
-              duration: 400,
-            })
-          })
-        }
+        })
         markersRef.current.push(
           new mapboxgl.Marker({ element: el }).setLngLat([a.lng, a.lat]).addTo(map)
         )

--- a/src/components/scheduler/BranchAssignmentsPanel.tsx
+++ b/src/components/scheduler/BranchAssignmentsPanel.tsx
@@ -255,8 +255,7 @@ export default function BranchAssignmentsPanel({
                   <TableCell>
                     <select
                       value={overrideVal != null ? String(overrideVal) : 'auto'}
-                      disabled={savingId === a.service_location_id || a.is_remote}
-                      title={a.is_remote ? 'Remote properties auto-route to nearest branch' : undefined}
+                      disabled={savingId === a.service_location_id}
                       onChange={(e) => {
                         const v = e.target.value
                         setOverride(
@@ -264,10 +263,7 @@ export default function BranchAssignmentsPanel({
                           v === 'auto' ? null : Number(v)
                         )
                       }}
-                      className={
-                        'h-7 rounded-md border border-border bg-surface px-2 text-xs text-fg ' +
-                        (a.is_remote ? 'opacity-50' : '')
-                      }
+                      className="h-7 rounded-md border border-border bg-surface px-2 text-xs text-fg"
                     >
                       <option value="auto">Auto (engine)</option>
                       {branches.map((b, i) => (


### PR DESCRIPTION
## Why
Overnight (remote) properties are exactly the ones operators most need to reassign — a Frisco crew handling a Tulsa overnight might be better routed from Sugar Land — but the engine was forcing remotes to nearest-branch with no override path.

## Engine
Remote-cluster builder now splits the remote pool:

- **Natural** (no override): density-cluster as before; each cluster assigned to its centroid's nearest branch.
- **Overridden**: group properties by their override branch_idx, density-cluster within each group, force the cluster's \`base_branch_index\` to the override branch.

Side benefit: a single overridden remote forms its own cluster on the override branch, even if the rest of its natural cluster wasn't overridden. So you can pull a single property out of a multi-property overnight cluster without affecting the others.

\`branch_assignments\` output for remotes now reflects \`overridden\` + \`transferred\` properly (was hardcoded to nearest).

## UI
- **Map view**: remote dots are now clickable (cursor: pointer, hover scale, opens the override panel)
- **List view**: dropdown enabled for remotes (was disabled with an "auto-routes to nearest" tooltip)

## Workflow
1. Map view → click any overnight property dot in (say) Frisco's Oklahoma cluster
2. Top-right panel → pick the recipient branch (e.g. Albuquerque)
3. Save (immediate)
4. Regenerate template → engine forms a new remote-override cluster on the recipient branch
5. The recipient crew now handles that overnight trip

## Test plan
- [ ] Map: click any remote dot → override panel opens
- [ ] Pick a non-nearest branch → "overridden" badge appears
- [ ] Regenerate template → cluster shows up on the override branch's crew
- [ ] Multiple overrides on the same target branch but geographically near each other → share a single trip
- [ ] List view: remote rows now have a working dropdown
- [ ] tsc clean (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)