### PR TITLE
Spread remote targets evenly across crew + fix banner de-dupe

### DIFF
--- a/api/_lib/scheduler/build-routing-template.ts
+++ b/api/_lib/scheduler/build-routing-template.ts
@@ -937,6 +937,38 @@ export function buildRoutingTemplate(input: BuildTemplateInput): TemplateBuildRe
   const trips: any[] = []
   const unplaced: any[] = []
 
+  // Phase 4.5i — pre-compute targetStart per (cluster, visit_idx) so
+  // remote trips on a crew spread evenly across cycleWorkdays instead
+  // of every cluster's visit-0 colliding at workday 33 and bunching
+  // sequentially. Round-robin across remote clusters per crew, then
+  // assign evenly-spaced targets across the cycle.
+  type RemoteJobKey = string // `${cluster_id}:${visit_idx}`
+  const remoteTargetByJob = new Map<RemoteJobKey, number>()
+  for (const crew of crews) {
+    const remoteClusters = crew.cluster_ids
+      .map((id) => clusters.find((c) => c.cluster_id === id))
+      .filter((c): c is ClusterSpec => !!c && c.cluster_type === 'remote')
+    if (remoteClusters.length === 0) continue
+    const maxVisits = Math.max(...remoteClusters.map((c) => c.trips_per_cycle))
+    const jobs: Array<{ cluster_id: string; visit_idx: number }> = []
+    // Round-robin: visit-0 across all clusters, then visit-1, etc.
+    // Preserves each cluster's even cadence (visits remain spaced) AND
+    // prevents two jobs from sharing a target workday.
+    for (let v = 0; v < maxVisits; v++) {
+      for (const cl of remoteClusters) {
+        if (v < cl.trips_per_cycle) {
+          jobs.push({ cluster_id: cl.cluster_id, visit_idx: v })
+        }
+      }
+    }
+    const totalJobs = jobs.length
+    if (totalJobs === 0) continue
+    jobs.forEach((j, i) => {
+      const target = Math.floor((cycleWorkdays * (i + 0.5)) / totalJobs)
+      remoteTargetByJob.set(`${j.cluster_id}:${j.visit_idx}`, target)
+    })
+  }
+
   for (const crew of crews) {
     let nextAvailableDay = 0
     for (const clusterId of crew.cluster_ids) {
@@ -948,17 +980,14 @@ export function buildRoutingTemplate(input: BuildTemplateInput): TemplateBuildRe
         // into the 10-hour window) so we'd otherwise leave properties
         // unplaced just because the estimate was conservative.
         const tripDurationEstimate = cluster.days_on_site_per_trip
-        // Remote trips spread across the cycle (target the midpoint of
-        // each visit segment); local trips pack sequentially from day 0
-        // since they're continuous work, not discrete visits.
+        // Remote trips spread across the cycle via the per-crew round-
+        // robin target map; local trips pack sequentially.
         let tripStart: number
         if (cluster.cluster_type === 'remote') {
-          // Target the midpoint of each visit's segment of the cycle.
-          // Use cycleWorkdays here — tripStart is a workday count.
-          const targetStart = Math.floor(
-            (cycleWorkdays * (visitIdx + 0.5)) / cluster.trips_per_cycle
-          )
-          tripStart = Math.max(targetStart, nextAvailableDay)
+          const target =
+            remoteTargetByJob.get(`${cluster.cluster_id}:${visitIdx}`) ??
+            Math.floor((cycleWorkdays * (visitIdx + 0.5)) / cluster.trips_per_cycle)
+          tripStart = Math.max(target, nextAvailableDay)
         } else {
           tripStart = nextAvailableDay
         }

--- a/src/pages/accounts/scheduler/CycleDetail.tsx
+++ b/src/pages/accounts/scheduler/CycleDetail.tsx
@@ -534,7 +534,12 @@ export default function CycleDetailPage() {
           // template+cycle). De-dupe by service_location_id since the
           // same property may appear in BOTH sources after cycle gen
           // inserts unplaced rows from template.unplaced_visits.
-          type DroppedRow = { property_id?: string; address: string; reason: string }
+          type DroppedRow = {
+            property_id?: string
+            address: string
+            reason: string
+            sl_id?: string
+          }
           const cycleUnplacedRows: DroppedRow[] = unplacedVisits.map((v) => ({
             property_id: (v as any).property_id ?? undefined,
             address:
@@ -543,6 +548,7 @@ export default function CycleDetailPage() {
               v.service_location_id ??
               '—',
             reason: v.unplaced_reason ?? 'unknown',
+            sl_id: v.service_location_id,
           }))
           // template.unplaced_visits was computed at TEMPLATE build time.
           // Cycle gen's gap-fill may have placed those visits onto idle
@@ -562,12 +568,13 @@ export default function CycleDetailPage() {
               address: u.address ?? u.service_location_id ?? '—',
               reason: u.detail ?? u.reason ?? 'unknown',
               sl_id: u.service_location_id,
-            } as any))
-          // De-dupe by service_location_id between the two lists.
+            }))
+          // De-dupe by service_location_id (preferred) → property_id →
+          // address. Both lists now set sl_id so this works consistently.
           const seenIds = new Set<string>()
           const allDropped: DroppedRow[] = []
           for (const r of [...cycleUnplacedRows, ...templateUnplacedRows]) {
-            const k = (r as any).sl_id ?? r.property_id ?? r.address
+            const k = r.sl_id ?? r.property_id ?? r.address
             if (seenIds.has(k)) continue
             seenIds.add(k)
             allDropped.push(r)


### PR DESCRIPTION
## Two fixes for the "2 properties keep failing + duplicate entries" report

### 1. Engine: remote targetStart bunching
Each remote cluster computed \`targetStart\` in isolation:
\`\`\`
targetStart = cycleWorkdays × (visit_idx + 0.5) / trips_per_cycle
\`\`\`

So every cluster's visit-0 targeted the same workday (e.g. 33). With \`max(target, nextAvailableDay)\`, cluster B's visit-0 bunched right after A's; cluster C's right after that. All of cluster B's and C's visits piled toward the **end** of the cycle.

Net effect: by the time locals run, \`cycleWorkdays - tripStart ≈ 33\`. Frisco's local cluster needs more, last 2-3 properties drop. Vernon TX & Wichita Falls TX in your case.

**Phase 4.5i**: pre-compute \`targetStart\` per \`(cluster, visit_idx)\` via round-robin across all of crew's remote clusters:
- Visit-0 across all clusters first, then visit-1, then visit-2…
- Each job gets an evenly-spaced target across \`cycleWorkdays\`
- Each cluster's visits stay evenly spaced for cadence (every ~3 months for \`trips_per_cycle=4\`)
- No two jobs share a target → \`nextAvailableDay\` grows evenly
- Locals get more workdays at the end

### 2. Banner de-dupe
Cycle-side rows had \`property_id\` but not \`sl_id\`; template-side rows had \`sl_id\`. The de-dupe key was \`sl_id ?? property_id ?? address\`, so the same property landed in the list twice (once keyed by property_id, once by sl_id). Both lists now set \`sl_id\` consistently — de-dupe works.

## Test plan
- [ ] Regenerate Cycle 2's template → "2415 High School Drive" appears once, not twice
- [ ] Frisco's local cluster's \`maxDaysForTrip\` is much larger than 33 (closer to ~50-80) because remotes spread evenly
- [ ] Vernon TX / Wichita Falls TX should fit (or if still don't, the gap is much smaller)
- [ ] Each remote cluster's individual cadence preserved (Broken Arrow's 4 trips still ~3 months apart)
- [ ] tsc clean (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)