### PR TITLE
Rebalance suggestions dialog: auto-opens when cycle has overflow

### DIFF
--- a/api/scheduler/cycles/[cycleId]/rebalance-suggestions.ts
+++ b/api/scheduler/cycles/[cycleId]/rebalance-suggestions.ts
@@ -1,0 +1,239 @@
+// POST /api/scheduler/cycles/[cycleId]/rebalance-suggestions
+//
+// After cycle generation, if anything's unplaced, find candidate
+// "trips" (clusters' visits that overflowed) and the best recipient
+// crews to move them to. Returns ranked recommendations the operator
+// can apply with one click.
+//
+// Logic is deterministic — no LLM — so it's fast and predictable.
+// The recipient must have:
+//   - Idle workdays ≥ the unplaced count for that cluster
+//   - Branch within 2× cluster_radius_miles of the cluster centroid
+// Among feasible recipients, prefer (a) most idle days, (b) shortest
+// drive from their branch to cluster centroid.
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { createAdminClient } from '../../../_lib/supabase.js'
+import { authenticateRequest } from '../../../_lib/auth.js'
+import { haversineMiles } from '../../../_lib/analysis/haversine.js'
+
+export const config = { maxDuration: 30 }
+
+interface Suggestion {
+  id: string
+  title: string
+  summary: string
+  from_branch_idx: number
+  from_branch_name: string
+  to_branch_idx: number
+  to_branch_name: string
+  property_count: number
+  service_location_ids: string[]
+  property_ids: string[]
+  cluster_label: string
+  drive_delta_miles: number
+}
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'POST') return res.status(405).json({ error: 'Method not allowed' })
+  try {
+    await authenticateRequest(req)
+  } catch (err: any) {
+    return res.status(err.statusCode ?? 401).json({ error: err.message ?? 'Unauthorized' })
+  }
+  const cycleId = req.query.cycleId as string
+  if (!cycleId) return res.status(400).json({ error: 'cycleId required' })
+  const db = createAdminClient()
+
+  // ── Load cycle, template, visits, routes ──────────────────────────
+  const { data: cycle } = await db
+    .from('cycle_instances')
+    .select('*')
+    .eq('id', cycleId)
+    .maybeSingle()
+  if (!cycle) return res.status(404).json({ error: 'Cycle not found' })
+
+  let template: any = null
+  if (cycle.template_id) {
+    const { data } = await db
+      .from('routing_templates')
+      .select('*')
+      .eq('id', cycle.template_id)
+      .maybeSingle()
+    template = data
+  }
+  if (!template) return res.status(404).json({ error: 'Template not found' })
+
+  // Page through visits + crew_day_routes (same pattern as cycle GET).
+  const PAGE = 1000
+  const visits: any[] = []
+  for (let p = 0; p < 50; p++) {
+    const { data } = await db
+      .from('scheduled_visits')
+      .select('id, status, service_location_id, property_id, scheduled_date, unplaced_reason, hours_per_visit_total, service_locations(property:properties(id, latitude, longitude, address_line1))')
+      .eq('cycle_instance_id', cycleId)
+      .range(p * PAGE, (p + 1) * PAGE - 1)
+    const batch = data ?? []
+    visits.push(...batch)
+    if (batch.length < PAGE) break
+  }
+  const crewDays: any[] = []
+  for (let p = 0; p < 50; p++) {
+    const { data } = await db
+      .from('crew_day_routes')
+      .select('id, crew_index, scheduled_date, day_type, total_work_minutes, total_drive_minutes, total_day_minutes, route, trip_id, start_location')
+      .eq('cycle_instance_id', cycleId)
+      .range(p * PAGE, (p + 1) * PAGE - 1)
+    const batch = data ?? []
+    crewDays.push(...batch)
+    if (batch.length < PAGE) break
+  }
+
+  const unplaced = visits.filter((v) => v.status === 'unplaced')
+  if (unplaced.length === 0) {
+    return res.status(200).json({ suggestions: [] })
+  }
+
+  // ── Build crew context: per-crew branch coords + idle workday count ─
+  const branches = (template.branches ?? []) as Array<{ name: string; lat: number; lng: number }>
+  const cfg = (template.config ?? {}) as Record<string, any>
+  const clusterRadius = (cfg.cluster_radius_miles as number) ?? 30
+
+  // Crew → branch coords (from any of their crew_day_routes' start_location).
+  const crewBranchByIdx = new Map<number, { idx: number; name: string; lat: number; lng: number }>()
+  for (const cd of crewDays) {
+    if (crewBranchByIdx.has(cd.crew_index)) continue
+    const sl = cd.start_location ?? null
+    if (!sl || typeof sl.lat !== 'number' || typeof sl.lng !== 'number') continue
+    // Match the crew's branch coords to one of template.branches by lat/lng.
+    let matchedIdx = 0
+    let bestDist = Number.POSITIVE_INFINITY
+    for (let i = 0; i < branches.length; i++) {
+      const d = haversineMiles({ lat: sl.lat, lng: sl.lng }, branches[i])
+      if (d < bestDist) {
+        bestDist = d
+        matchedIdx = i
+      }
+    }
+    crewBranchByIdx.set(cd.crew_index, {
+      idx: matchedIdx,
+      name: sl.name ?? branches[matchedIdx]?.name ?? `Crew ${cd.crew_index + 1}`,
+      lat: sl.lat,
+      lng: sl.lng,
+    })
+  }
+  // Fall back: any crews without routes get their template-order branch.
+  const declaredCrewCount = (template.crew_count as number) ?? crewBranchByIdx.size
+  for (let i = 0; i < declaredCrewCount; i++) {
+    if (crewBranchByIdx.has(i)) continue
+    const b = branches[i % Math.max(1, branches.length)]
+    if (b) crewBranchByIdx.set(i, { idx: i % branches.length, name: b.name, lat: b.lat, lng: b.lng })
+  }
+
+  // Compute idle workdays per crew (cycle workdays - days with routes).
+  const cycleStart = new Date(`${cycle.start_date}T00:00:00Z`)
+  const cycleEnd = new Date(`${cycle.end_date}T00:00:00Z`)
+  const workdays: string[] = []
+  for (let d = new Date(cycleStart); d <= cycleEnd; d.setUTCDate(d.getUTCDate() + 1)) {
+    const dow = d.getUTCDay()
+    if (dow !== 0 && dow !== 6) workdays.push(d.toISOString().slice(0, 10))
+  }
+  const usedByCrew = new Map<number, Set<string>>()
+  for (const cd of crewDays) {
+    const set = usedByCrew.get(cd.crew_index) ?? new Set<string>()
+    set.add(cd.scheduled_date)
+    usedByCrew.set(cd.crew_index, set)
+  }
+  const idleByCrew = new Map<number, number>()
+  for (const idx of crewBranchByIdx.keys()) {
+    const used = usedByCrew.get(idx) ?? new Set()
+    idleByCrew.set(idx, workdays.filter((d) => !used.has(d)).length)
+  }
+
+  // ── Group unplaced by their cluster_label (parsed from reason) ────
+  // The unplaced reason format is: "Trip ran out of cycle days for cluster <Label> ..."
+  // or "Trip "<Label>" extended past cycle end ..."
+  const groups = new Map<string, { label: string; props: any[] }>()
+  for (const u of unplaced) {
+    const reason: string = u.unplaced_reason ?? ''
+    let label = 'Unknown'
+    const m1 = reason.match(/cluster\s+([^()]+?)(?:\s+\()/) // "cluster Frisco (local)"
+    const m2 = reason.match(/Trip\s+"([^"]+)"/) // 'Trip "Broken Arrow, OK"'
+    if (m1) label = m1[1].trim()
+    else if (m2) label = m2[1].trim()
+    const g = groups.get(label) ?? { label, props: [] }
+    g.props.push(u)
+    groups.set(label, g)
+  }
+
+  // For each group, compute centroid + nearest-branch (the "from" branch),
+  // then find candidate recipients with capacity + reasonable geography.
+  const overrides = (template.branch_assignment_overrides ?? {}) as Record<string, number>
+  const suggestions: Suggestion[] = []
+  let suggestionId = 1
+  for (const [label, group] of groups) {
+    const validProps = group.props.filter(
+      (u) =>
+        typeof u.service_locations?.property?.latitude === 'number' &&
+        typeof u.service_locations?.property?.longitude === 'number'
+    )
+    if (validProps.length === 0) continue
+
+    const centroidLat =
+      validProps.reduce((s, u) => s + u.service_locations.property.latitude, 0) / validProps.length
+    const centroidLng =
+      validProps.reduce((s, u) => s + u.service_locations.property.longitude, 0) / validProps.length
+
+    // From: the closest crew branch (where these properties currently sit).
+    let fromBranchIdx = 0
+    let fromDist = Number.POSITIVE_INFINITY
+    for (const [, b] of crewBranchByIdx) {
+      const d = haversineMiles({ lat: centroidLat, lng: centroidLng }, b)
+      if (d < fromDist) {
+        fromDist = d
+        fromBranchIdx = b.idx
+      }
+    }
+
+    // To: best recipient = enough idle days + closest non-from branch within 2×radius.
+    const candidates = Array.from(crewBranchByIdx.values())
+      .filter((b) => b.idx !== fromBranchIdx)
+      .map((b) => ({
+        b,
+        dist: haversineMiles({ lat: centroidLat, lng: centroidLng }, b),
+        idle: idleByCrew.get(b.idx) ?? 0,
+      }))
+      .filter((c) => c.idle >= validProps.length)
+      .filter((c) => c.dist <= clusterRadius * 2)
+      .sort((a, c) => a.dist - c.dist)
+
+    if (candidates.length === 0) continue
+    const best = candidates[0]
+
+    suggestions.push({
+      id: `sug-${suggestionId++}`,
+      title: `Move ${label} (${validProps.length} propert${validProps.length === 1 ? 'y' : 'ies'}) → ${best.b.name}`,
+      summary:
+        `${validProps.length} unplaced ${label} propert${validProps.length === 1 ? 'y' : 'ies'} ` +
+        `currently routed via ${branches[fromBranchIdx]?.name ?? 'origin'}. ` +
+        `${best.b.name} has ${best.idle} idle workdays and is ` +
+        `${Math.round(best.dist)}mi from the cluster (vs ${Math.round(fromDist)}mi from ` +
+        `${branches[fromBranchIdx]?.name ?? 'origin'} — adds ~${Math.max(0, Math.round((best.dist - fromDist) * 2 / 60))}h drive per trip).`,
+      from_branch_idx: fromBranchIdx,
+      from_branch_name: branches[fromBranchIdx]?.name ?? `Branch ${fromBranchIdx}`,
+      to_branch_idx: best.b.idx,
+      to_branch_name: best.b.name,
+      property_count: validProps.length,
+      service_location_ids: validProps.map((u) => u.service_location_id),
+      property_ids: validProps.map((u) => u.property_id),
+      cluster_label: label,
+      drive_delta_miles: Math.round(best.dist - fromDist),
+    })
+  }
+
+  // Skip suggestions whose targets the operator already overrode.
+  const filtered = suggestions.filter((s) =>
+    s.service_location_ids.some((sl) => overrides[sl] !== s.to_branch_idx)
+  )
+
+  return res.status(200).json({ suggestions: filtered })
+}

--- a/api/scheduler/templates/[templateId]/branch-overrides.ts
+++ b/api/scheduler/templates/[templateId]/branch-overrides.ts
@@ -22,9 +22,16 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     return res.status(err.statusCode ?? 401).json({ error: err.message ?? 'Unauthorized' })
   }
   const templateId = req.query.templateId as string
-  const body = (req.body ?? {}) as { service_location_id?: string; branch_idx?: number | null }
-  if (!body.service_location_id) {
-    return res.status(400).json({ error: 'service_location_id required' })
+  const body = (req.body ?? {}) as {
+    service_location_id?: string
+    branch_idx?: number | null
+    // Batch form: apply N overrides at once (used by the rebalance
+    // suggestions modal). Single-form is preserved for backwards compat.
+    batch?: Array<{ service_location_id: string; branch_idx: number | null }>
+  }
+  const isBatch = Array.isArray(body.batch) && body.batch.length > 0
+  if (!isBatch && !body.service_location_id) {
+    return res.status(400).json({ error: 'service_location_id or batch required' })
   }
   const db = createAdminClient()
 
@@ -38,15 +45,27 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   const overrides = ((tpl as any).branch_assignment_overrides ?? {}) as Record<string, number>
   const branches = ((tpl as any).branches ?? []) as any[]
 
-  if (body.branch_idx === null || body.branch_idx === undefined) {
-    delete overrides[body.service_location_id]
-  } else {
-    if (!Number.isInteger(body.branch_idx) || body.branch_idx < 0 || body.branch_idx >= branches.length) {
-      return res
-        .status(400)
-        .json({ error: `branch_idx must be an integer in [0, ${branches.length - 1}]` })
+  const applyOne = (sl: string, idx: number | null | undefined): string | null => {
+    if (idx === null || idx === undefined) {
+      delete overrides[sl]
+      return null
     }
-    overrides[body.service_location_id] = body.branch_idx
+    if (!Number.isInteger(idx) || idx < 0 || idx >= branches.length) {
+      return `branch_idx must be an integer in [0, ${branches.length - 1}] (got ${idx} for ${sl})`
+    }
+    overrides[sl] = idx
+    return null
+  }
+
+  if (isBatch) {
+    for (const item of body.batch!) {
+      if (!item.service_location_id) continue
+      const err = applyOne(item.service_location_id, item.branch_idx ?? null)
+      if (err) return res.status(400).json({ error: err })
+    }
+  } else {
+    const err = applyOne(body.service_location_id!, body.branch_idx)
+    if (err) return res.status(400).json({ error: err })
   }
 
   const { error: updErr } = await db

--- a/src/components/scheduler/RebalanceSuggestionsDialog.tsx
+++ b/src/components/scheduler/RebalanceSuggestionsDialog.tsx
@@ -1,0 +1,253 @@
+// Phase 4.5j — Rebalance suggestions dialog.
+// Shown after generate-cycle when there are unplaced visits. The
+// /rebalance-suggestions endpoint returns deterministic recommendations
+// like "Move Broken Arrow OK trip from Frisco → Sugar Land". The
+// operator clicks Apply, we batch-override the affected properties on
+// the template, and prompt to regenerate.
+import { useEffect, useState } from 'react'
+import { ArrowRight } from 'lucide-react'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '../ui/Dialog'
+import Button from '../ui/Button'
+import { Badge } from '../ui/Badge'
+import { useAuth } from '../../hooks/useAuth'
+
+interface Suggestion {
+  id: string
+  title: string
+  summary: string
+  from_branch_idx: number
+  from_branch_name: string
+  to_branch_idx: number
+  to_branch_name: string
+  property_count: number
+  service_location_ids: string[]
+  property_ids: string[]
+  cluster_label: string
+  drive_delta_miles: number
+}
+
+interface Props {
+  cycleId: string
+  templateId: string
+  open: boolean
+  onClose: () => void
+  // Called after the operator applies one or more recommendations and
+  // chooses to regenerate. Parent triggers the regenerate API and
+  // reloads cycle data.
+  onRegenerate: () => Promise<void>
+}
+
+export default function RebalanceSuggestionsDialog({
+  cycleId,
+  templateId,
+  open,
+  onClose,
+  onRegenerate,
+}: Props) {
+  const { getToken } = useAuth()
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [suggestions, setSuggestions] = useState<Suggestion[]>([])
+  const [applied, setApplied] = useState<Set<string>>(new Set())
+  const [applying, setApplying] = useState<string | null>(null)
+  const [regenerating, setRegenerating] = useState(false)
+
+  useEffect(() => {
+    if (!open) return
+    let cancelled = false
+    const load = async () => {
+      setLoading(true)
+      setError(null)
+      setApplied(new Set())
+      try {
+        const token = await getToken()
+        const res = await fetch(
+          `/api/scheduler/cycles/${cycleId}/rebalance-suggestions`,
+          {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+            body: JSON.stringify({}),
+          }
+        )
+        const json = await res.json().catch(() => ({}))
+        if (!res.ok) throw new Error((json as any).error ?? `HTTP ${res.status}`)
+        if (!cancelled) setSuggestions((json as any).suggestions ?? [])
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : String(e))
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+    load()
+    return () => {
+      cancelled = true
+    }
+  }, [open, cycleId, getToken])
+
+  const apply = async (s: Suggestion) => {
+    setApplying(s.id)
+    setError(null)
+    try {
+      const token = await getToken()
+      const res = await fetch(
+        `/api/scheduler/templates/${templateId}/branch-overrides`,
+        {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+          body: JSON.stringify({
+            batch: s.service_location_ids.map((sl) => ({
+              service_location_id: sl,
+              branch_idx: s.to_branch_idx,
+            })),
+          }),
+        }
+      )
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}))
+        throw new Error((j as any).error ?? `HTTP ${res.status}`)
+      }
+      setApplied((prev) => new Set([...prev, s.id]))
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e))
+    } finally {
+      setApplying(null)
+    }
+  }
+
+  const applyAll = async () => {
+    for (const s of suggestions) {
+      if (applied.has(s.id)) continue
+      await apply(s)
+    }
+  }
+
+  const regenerateAndClose = async () => {
+    setRegenerating(true)
+    try {
+      await onRegenerate()
+      onClose()
+    } finally {
+      setRegenerating(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Rebalance suggestions</DialogTitle>
+          <DialogDescription>
+            Some properties didn't fit. Here's how we'd move trips to other
+            branches that have idle capacity. Apply any you want; regenerate
+            the template to put them into effect.
+          </DialogDescription>
+        </DialogHeader>
+
+        {loading && (
+          <p className="text-sm text-fg-muted py-4">Computing suggestions…</p>
+        )}
+
+        {error && (
+          <p className="rounded-md border border-danger/30 bg-danger-subtle px-3 py-2 text-sm text-danger">
+            {error}
+          </p>
+        )}
+
+        {!loading && suggestions.length === 0 && !error && (
+          <div className="py-3 space-y-2">
+            <p className="text-sm text-fg">
+              No automatic recommendations available.
+            </p>
+            <p className="text-xs text-fg-muted">
+              Either every recipient is already at capacity, or the
+              overflow is geographically too far for any other branch
+              to absorb. Use the Branch Assignments map view to manually
+              reassign individual properties, or extend the cycle / add
+              a crew.
+            </p>
+          </div>
+        )}
+
+        {!loading && suggestions.length > 0 && (
+          <ul className="space-y-2 max-h-96 overflow-y-auto py-1">
+            {suggestions.map((s) => {
+              const isApplied = applied.has(s.id)
+              const isApplying = applying === s.id
+              return (
+                <li
+                  key={s.id}
+                  className={
+                    'rounded-md border p-3 space-y-2 ' +
+                    (isApplied
+                      ? 'border-success/40 bg-success-subtle/40'
+                      : 'border-border bg-surface')
+                  }
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0 flex-1">
+                      <p className="text-sm font-semibold text-fg flex items-center gap-2 flex-wrap">
+                        {s.cluster_label}{' '}
+                        <span className="inline-flex items-center gap-1 text-xs text-fg-muted">
+                          <Badge variant="outline" className="text-[10px]">
+                            {s.from_branch_name}
+                          </Badge>
+                          <ArrowRight className="h-3 w-3" />
+                          <Badge variant="accent" className="text-[10px]">
+                            {s.to_branch_name}
+                          </Badge>
+                        </span>
+                      </p>
+                      <p className="text-xs text-fg-muted mt-1">{s.summary}</p>
+                    </div>
+                    {isApplied ? (
+                      <Badge variant="success" className="text-[10px] flex-shrink-0">
+                        Applied
+                      </Badge>
+                    ) : (
+                      <Button
+                        size="sm"
+                        onClick={() => apply(s)}
+                        loading={isApplying}
+                      >
+                        Apply
+                      </Button>
+                    )}
+                  </div>
+                </li>
+              )
+            })}
+          </ul>
+        )}
+
+        <DialogFooter>
+          <div className="flex items-center gap-2 flex-wrap w-full">
+            {suggestions.length > 0 && applied.size === 0 && (
+              <Button variant="secondary" size="sm" onClick={applyAll}>
+                Apply all
+              </Button>
+            )}
+            {applied.size > 0 && (
+              <Button
+                size="sm"
+                onClick={regenerateAndClose}
+                loading={regenerating}
+              >
+                Regenerate template ({applied.size} applied)
+              </Button>
+            )}
+            <Button variant="ghost" size="sm" onClick={onClose} className="ml-auto">
+              {applied.size > 0 ? 'Close (regenerate later)' : 'Skip'}
+            </Button>
+          </div>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/pages/accounts/scheduler/CycleDetail.tsx
+++ b/src/pages/accounts/scheduler/CycleDetail.tsx
@@ -23,6 +23,7 @@ import CalendarView from '../../../components/scheduler/CalendarView'
 import CycleMapView from '../../../components/scheduler/CycleMapView'
 import HistoryDrawer from '../../../components/scheduler/HistoryDrawer'
 import CycleChatDrawer from '../../../components/scheduler/CycleChatDrawer'
+import RebalanceSuggestionsDialog from '../../../components/scheduler/RebalanceSuggestionsDialog'
 import StatusBar, { type SaveState } from '../../../components/scheduler/StatusBar'
 
 interface Cycle {
@@ -89,6 +90,11 @@ export default function CycleDetailPage() {
   const [templateOptimizedAt, setTemplateOptimizedAt] = useState<string | null>(null)
   const [regeneratingTemplate, setRegeneratingTemplate] = useState(false)
   const [regeneratingCycle, setRegeneratingCycle] = useState(false)
+  // Auto-open the rebalance suggestions dialog the first time a freshly
+  // loaded cycle reveals unplaced visits. Won't reopen if the operator
+  // dismisses it (rebalanceShown flag).
+  const [rebalanceOpen, setRebalanceOpen] = useState(false)
+  const [rebalanceShown, setRebalanceShown] = useState(false)
   const [templateUnplaced, setTemplateUnplaced] = useState<Array<{
     service_location_id?: string
     property_id?: string
@@ -156,6 +162,16 @@ export default function CycleDetailPage() {
   }, [cycleId, getToken])
 
   useEffect(() => { load() }, [load])
+
+  // Auto-open rebalance suggestions on first load when there's overflow.
+  useEffect(() => {
+    if (loading || rebalanceShown) return
+    const unplacedNow = visits.filter((v) => v.status === 'unplaced').length
+    if (unplacedNow > 0 && cycle?.template_id) {
+      setRebalanceOpen(true)
+      setRebalanceShown(true)
+    }
+  }, [loading, visits, cycle?.template_id, rebalanceShown])
 
   // Re-derive THIS cycle from the parent template. Use this after a
   // template regenerate to refresh the existing cycle's scheduled
@@ -502,6 +518,15 @@ export default function CycleDetailPage() {
               )}
             </div>
             <div className="flex items-center gap-2">
+              {unplacedVisits.length > 0 && cycle?.template_id && (
+                <Button
+                  size="sm"
+                  variant="secondary"
+                  onClick={() => setRebalanceOpen(true)}
+                >
+                  Suggest rebalance ({unplacedVisits.length})
+                </Button>
+              )}
               <CycleChatDrawer
                 cycleId={cycleId!}
                 cycleLabel={cycle.cycle_number ? `Cycle #${cycle.cycle_number}` : null}
@@ -1095,6 +1120,43 @@ export default function CycleDetailPage() {
       />
 
       <HistoryDrawer cycleId={cycleId!} onChange={load} />
+
+      {cycle?.template_id && (
+        <RebalanceSuggestionsDialog
+          cycleId={cycleId!}
+          templateId={cycle.template_id}
+          open={rebalanceOpen}
+          onClose={() => setRebalanceOpen(false)}
+          onRegenerate={async () => {
+            // Regenerate template (so override-based clusters reform),
+            // then regenerate THIS cycle in place. After both, reload
+            // cycle data on the page.
+            const token = await getToken()
+            await fetch(
+              `/api/scheduler/templates/${cycle.template_id}/regenerate`,
+              {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+                body: JSON.stringify({}),
+              }
+            )
+            await fetch(
+              `/api/scheduler/templates/${cycle.template_id}/generate-cycle`,
+              {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+                body: JSON.stringify({
+                  start_date: cycle.start_date,
+                  cycle_number: cycle.cycle_number,
+                  apply_template_changes: true,
+                }),
+              }
+            )
+            await load()
+            setRebalanceShown(false) // allow auto-reopen if more overflow remains
+          }}
+        />
+      )}
 
       <StatusBar
         cycleName={`Cycle ${cycle.cycle_number}`}


### PR DESCRIPTION
## What
After cycle generation, if any properties didn't fit, a dialog proactively suggests trip-level moves to recipient branches with idle capacity. One-click apply per suggestion, then regenerate — no manual map clicking required.

## Backend
**\`POST /api/scheduler/cycles/[cycleId]/rebalance-suggestions\`** — deterministic recommendation engine:
- Groups unplaced visits by their cluster_label (parsed from \`unplaced_reason\`)
- Computes cluster centroid from the unplaced properties' coords
- Identifies candidate recipient crews where:
  - \`idle_workdays >= property_count\`
  - Branch is within \`2 × cluster_radius_miles\` of the centroid
- Picks the closest recipient
- Returns \`{ from, to, property_count, drive_delta_miles, summary }\`

No LLM — fast and predictable.

**\`PATCH /api/scheduler/templates/[id]/branch-overrides\`** now accepts \`{ batch: [{ service_location_id, branch_idx }] }\` so a whole suggestion's overrides apply in one call.

## UI
**\`RebalanceSuggestionsDialog\`**:
- Each suggestion: cluster label, from→to branch badges, plain-English summary
- Apply per suggestion or Apply all
- "Regenerate template (N applied)" runs template regen + cycle regen-in-place + page reload, then closes
- "Skip" preserves overrides without regenerating

**CycleDetail**:
- Auto-opens the dialog on first load when there's overflow (won't reopen after dismiss)
- Manual "Suggest rebalance (N)" button next to Chat for re-trigger any time

## Operator workflow
1. Generate cycle
2. Dialog pops up: "Move Broken Arrow OK trip Frisco → Sugar Land — 8 properties, 5h extra drive"
3. Click Apply (or Apply all)
4. Click Regenerate template → engine rebuilds with overrides → cycle regenerates → page reloads
5. Banner now shows fewer (or zero) unplaced

## Test plan
- [ ] Generate cycle with overflow → dialog opens automatically
- [ ] Suggestions show real candidate recipient branches with capacity
- [ ] Apply one → button toggles to "Applied"
- [ ] Apply all → all toggle to "Applied"
- [ ] Regenerate → template + cycle rebuild, dialog closes, banner updates
- [ ] Dismiss without applying → "Suggest rebalance (N)" button on toolbar to reopen
- [ ] No overflow → dialog doesn't open
- [ ] tsc + build clean (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)