### PR TITLE
Combined schedules v1: synthesize routing across multiple clients

### DIFF
--- a/api/scheduler/templates/[templateId]/regenerate.ts
+++ b/api/scheduler/templates/[templateId]/regenerate.ts
@@ -65,6 +65,14 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   const accountId = tpl.account_id as string
   const clientId = tpl.client_id as string
   const slIds = (tpl.routed_service_location_ids ?? []) as string[]
+  // Combined templates persist combined_client_ids so regenerate can
+  // re-fetch offerings across all source clients.
+  const combinedClientIds = Array.isArray(tpl.combined_client_ids)
+    ? (tpl.combined_client_ids as string[])
+    : null
+  const allClientIds = combinedClientIds && combinedClientIds.length > 1
+    ? combinedClientIds
+    : [clientId]
   const crewCount = body.crew_count ?? tpl.crew_count ?? 1
   const customCycleDays = body.custom_cycle_length_days !== undefined
     ? body.custom_cycle_length_days ?? undefined
@@ -105,8 +113,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   }
   const { data: offeringRows } = await db
     .from('service_offerings')
-    .select('id, name, is_routed, offering_role, visit_interval_years, attaches_to_offering_ids, uses_cohort_rotation')
-    .eq('client_id', clientId)
+    .select('id, name, is_routed, offering_role, visit_interval_years, attaches_to_offering_ids, uses_cohort_rotation, client_id')
+    .in('client_id', allClientIds)
   const offerings = new Map<string, any>()
   for (const o of offeringRows ?? []) offerings.set((o as any).id, o)
 

--- a/api/scheduler/templates/index.ts
+++ b/api/scheduler/templates/index.ts
@@ -32,15 +32,25 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method === 'GET') {
     const accountId = req.query.account_id as string | undefined
     const clientId = req.query.client_id as string | undefined
-    if (!accountId || !clientId) {
-      return res.status(400).json({ error: 'account_id and client_id required' })
+    // ?combined=true → list COMBINED templates for the account
+    // (combined_client_ids is set). client_id is then optional.
+    const wantCombined = String(req.query.combined ?? '').toLowerCase() === 'true'
+    if (!accountId) {
+      return res.status(400).json({ error: 'account_id required' })
+    }
+    if (!wantCombined && !clientId) {
+      return res.status(400).json({ error: 'client_id required (or pass combined=true for account-level combined templates)' })
     }
     let q = db
       .from('routing_templates')
-      .select('id, name, description, status, crew_count, cycle_length_days, cycle_length_label, total_visits_per_cycle, total_estimated_cost_per_year, optimization_score, hard_constraint_violations, soft_constraint_violations, created_at, optimized_at')
+      .select('id, name, description, status, client_id, crew_count, cycle_length_days, cycle_length_label, total_visits_per_cycle, total_estimated_cost_per_year, optimization_score, hard_constraint_violations, soft_constraint_violations, combined_client_ids, created_at, optimized_at')
       .eq('account_id', accountId)
-      .eq('client_id', clientId)
       .order('created_at', { ascending: false })
+    if (wantCombined) {
+      q = q.not('combined_client_ids', 'is', null)
+    } else {
+      q = q.eq('client_id', clientId!).is('combined_client_ids', null)
+    }
     const status = req.query.status as string | undefined
     if (status) q = q.in('status', String(status).split(','))
     const { data, error } = await q.limit(100)
@@ -52,11 +62,43 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     const body = (req.body ?? {}) as Record<string, unknown>
     const accountId = body.account_id as string
     const clientId = body.client_id as string
-    const slIds = (body.service_location_ids as string[]) ?? []
+    let slIds = (body.service_location_ids as string[]) ?? []
     const crewCount = Number(body.crew_count ?? 1)
+    // Phase 4.6 — combined templates: when combined_client_ids is set,
+    // the SL pool spans all listed clients. client_id stays set to the
+    // "base" client (constraints + offerings come from there). The
+    // template row persists combined_client_ids so downstream paths
+    // (regenerate, cycle gen) can re-fetch the same multi-client pool.
+    const combinedClientIds = Array.isArray(body.combined_client_ids)
+      ? (body.combined_client_ids as string[]).filter((id) => typeof id === 'string')
+      : null
+    const isCombined = combinedClientIds != null && combinedClientIds.length > 1
+    // Combined-template clients other than the base — used for
+    // service_location and service_offering scope below.
+    const allClientIds: string[] = isCombined ? combinedClientIds! : [clientId]
 
     if (!accountId || !clientId) {
       return res.status(400).json({ error: 'account_id and client_id required' })
+    }
+    // Auto-fill SL ids for combined templates when caller didn't supply
+    // any: pull every SL across the listed clients.
+    if (isCombined && slIds.length === 0) {
+      const fetched: string[] = []
+      for (const cid of allClientIds) {
+        let pageOffset = 0
+        for (let p = 0; p < 50; p++) {
+          const { data } = await db
+            .from('service_locations')
+            .select('id')
+            .eq('client_id', cid)
+            .range(pageOffset, pageOffset + 999)
+          const batch = data ?? []
+          for (const r of batch) fetched.push((r as any).id)
+          if (batch.length < 1000) break
+          pageOffset += 1000
+        }
+      }
+      slIds = fetched
     }
     if (slIds.length === 0) {
       return res.status(400).json({ error: 'service_location_ids must be non-empty' })
@@ -96,8 +138,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     }
     const { data: offeringRows } = await db
       .from('service_offerings')
-      .select('id, name, is_routed, offering_role, visit_interval_years, attaches_to_offering_ids, uses_cohort_rotation')
-      .eq('client_id', clientId)
+      .select('id, name, is_routed, offering_role, visit_interval_years, attaches_to_offering_ids, uses_cohort_rotation, client_id')
+      .in('client_id', allClientIds)
     const offerings = new Map<string, any>()
     for (const o of offeringRows ?? []) offerings.set((o as any).id, o)
 
@@ -289,6 +331,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         routed_service_location_ids: propertiesForBuild.map((p) => p.service_location_id),
         crew_count: crewCount,
         branches,
+        combined_client_ids: isCombined ? combinedClientIds : null,
         config: {
           crew_size: constraints.crew_size,
           hours_per_day: constraints.hours_per_day,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,6 +38,7 @@ import NewTemplatePage from './pages/accounts/scheduler/NewTemplate'
 import TemplateDetailPage from './pages/accounts/scheduler/TemplateDetail'
 import CycleComparePage from './pages/accounts/scheduler/CycleCompare'
 import CycleDetailPage from './pages/accounts/scheduler/CycleDetail'
+import CombinedSchedulesPage from './pages/accounts/scheduler/CombinedSchedules'
 import TravelPlannerPage from './pages/accounts/TravelPlanner'
 import CustomFieldsAdminPage from './pages/accounts/CustomFieldsAdmin'
 import NewAccountClientPage from './pages/accounts/NewAccountClient'
@@ -171,6 +172,10 @@ export default function App() {
           <Route
             path="/accounts/:accountId/clients/:clientId/scheduler/compare"
             element={<AuthGuard><CycleComparePage /></AuthGuard>}
+          />
+          <Route
+            path="/accounts/:accountId/combined-schedules"
+            element={<AuthGuard><CombinedSchedulesPage /></AuthGuard>}
           />
           <Route
             path="/accounts/:accountId/clients/:clientId/travel"

--- a/src/pages/accounts/AccountDetail.tsx
+++ b/src/pages/accounts/AccountDetail.tsx
@@ -285,11 +285,16 @@ export default function AccountDetailPage() {
             <h2 className="text-xl font-semibold tracking-tight text-fg">
               Clients
             </h2>
-            {isPM && (
-              <Button size="sm" variant="secondary" asChild>
-                <Link to={`/accounts/${id}/clients/new`}>+ Add client</Link>
+            <div className="flex items-center gap-2">
+              <Button size="sm" variant="ghost" asChild>
+                <Link to={`/accounts/${id}/combined-schedules`}>Combined schedules</Link>
               </Button>
-            )}
+              {isPM && (
+                <Button size="sm" variant="secondary" asChild>
+                  <Link to={`/accounts/${id}/clients/new`}>+ Add client</Link>
+                </Button>
+              )}
+            </div>
           </div>
 
           {clientsForDisplay(overview, clients).length === 0 ? (

--- a/src/pages/accounts/scheduler/CombinedSchedules.tsx
+++ b/src/pages/accounts/scheduler/CombinedSchedules.tsx
@@ -1,0 +1,360 @@
+// Phase 4.6 — Combined Schedules: account-level page that lists all
+// combined routing templates and lets the operator create new ones
+// by picking N clients to synthesize into a single schedule.
+import { useState, useEffect, useCallback } from 'react'
+import { useParams, useNavigate, Link } from 'react-router-dom'
+import { Plus, Layers } from 'lucide-react'
+import { useAuth } from '../../../hooks/useAuth'
+import AppShell from '../../../components/layout/AppShell'
+import Button from '../../../components/ui/Button'
+import { Badge } from '../../../components/ui/Badge'
+import { Card } from '../../../components/ui/Card'
+import { EmptyState } from '../../../components/ui/EmptyState'
+import {
+  Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
+} from '../../../components/ui/Table'
+import {
+  Dialog, DialogContent, DialogDescription, DialogFooter,
+  DialogHeader, DialogTitle,
+} from '../../../components/ui/Dialog'
+import { Input, FormField } from '../../../components/ui/Input'
+
+interface TemplateRow {
+  id: string
+  name: string
+  status: string
+  client_id: string
+  crew_count: number
+  cycle_length_days: number
+  cycle_length_label: string
+  total_visits_per_cycle: number | null
+  optimization_score: number | null
+  combined_client_ids: string[] | null
+  created_at: string
+}
+
+interface ClientRow {
+  id: string
+  name: string
+  display_name: string | null
+  status: string
+}
+
+export default function CombinedSchedulesPage() {
+  const { accountId } = useParams<{ accountId: string }>()
+  const { getToken } = useAuth()
+  const navigate = useNavigate()
+  const [rows, setRows] = useState<TemplateRow[]>([])
+  const [clients, setClients] = useState<ClientRow[]>([])
+  const [account, setAccount] = useState<{ name: string; display_name: string | null } | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [createOpen, setCreateOpen] = useState(false)
+
+  const load = useCallback(async () => {
+    if (!accountId) return
+    setLoading(true)
+    try {
+      const token = await getToken()
+      const headers = { Authorization: `Bearer ${token}` }
+      const [tplRes, accRes, cliRes] = await Promise.all([
+        fetch(`/api/scheduler/templates?account_id=${accountId}&combined=true`, { headers }),
+        fetch(`/api/accounts/${accountId}`, { headers }),
+        fetch(`/api/v1/clients?account_id=${accountId}`, { headers }),
+      ])
+      if (!tplRes.ok) throw new Error(`Load failed (${tplRes.status})`)
+      const data = await tplRes.json()
+      setRows(data.templates ?? [])
+      if (accRes.ok) {
+        const j = await accRes.json()
+        setAccount(j.account ?? j)
+      }
+      if (cliRes.ok) {
+        const cli = await cliRes.json()
+        const list = (cli.clients ?? cli) as ClientRow[]
+        setClients(list.filter((c) => c.status !== 'churned'))
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setLoading(false)
+    }
+  }, [accountId, getToken])
+
+  useEffect(() => { load() }, [load])
+
+  return (
+    <AppShell
+      breadcrumb={[
+        { label: 'Accounts', to: '/accounts' },
+        { label: account?.display_name ?? account?.name ?? '…', to: `/accounts/${accountId}` },
+        { label: 'Combined schedules' },
+      ]}
+    >
+      <div className="mx-auto max-w-6xl px-6 py-10 space-y-6">
+        <header className="flex items-start justify-between gap-4">
+          <div className="space-y-1">
+            <h1 className="text-2xl font-semibold tracking-tight text-fg flex items-center gap-2">
+              <Layers className="h-6 w-6 text-accent" />
+              Combined schedules
+            </h1>
+            <p className="text-sm text-fg-muted max-w-2xl">
+              Synthesize a single schedule across multiple clients in this account. Useful when
+              clients share crews and you want to optimize routing across the whole portfolio
+              instead of one client at a time.
+            </p>
+          </div>
+          <Button onClick={() => setCreateOpen(true)} disabled={clients.length < 2}>
+            <Plus className="h-4 w-4" />
+            New combined schedule
+          </Button>
+        </header>
+
+        {error && <p className="text-sm text-danger">{error}</p>}
+
+        {loading ? (
+          <p className="text-sm text-fg-muted">Loading…</p>
+        ) : rows.length === 0 ? (
+          <EmptyState
+            title="No combined schedules yet"
+            description={
+              clients.length < 2
+                ? 'You need at least 2 active clients to combine. Add clients first.'
+                : 'Click "New combined schedule" to synthesize a route across multiple clients.'
+            }
+          />
+        ) : (
+          <Card padding="none">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Name</TableHead>
+                  <TableHead>Clients</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead className="text-right">Crews</TableHead>
+                  <TableHead className="text-right">Visits/cycle</TableHead>
+                  <TableHead className="text-right">Score</TableHead>
+                  <TableHead />
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {rows.map((t) => (
+                  <TableRow key={t.id}>
+                    <TableCell>
+                      <Link
+                        to={`/accounts/${accountId}/clients/${t.client_id}/scheduler/templates/${t.id}`}
+                        className="font-medium text-accent hover:underline"
+                      >
+                        {t.name}
+                      </Link>
+                      <p className="text-[11px] text-fg-subtle">{t.cycle_length_label}</p>
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex flex-wrap gap-1">
+                        {(t.combined_client_ids ?? []).slice(0, 4).map((cid) => {
+                          const c = clients.find((x) => x.id === cid)
+                          return (
+                            <Badge key={cid} variant="outline" className="text-[10px]">
+                              {c?.display_name ?? c?.name ?? cid.slice(0, 8)}
+                            </Badge>
+                          )
+                        })}
+                        {(t.combined_client_ids ?? []).length > 4 && (
+                          <span className="text-[11px] text-fg-subtle self-center">
+                            +{(t.combined_client_ids ?? []).length - 4}
+                          </span>
+                        )}
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant={t.status === 'active' ? 'success' : 'outline'}>
+                        {t.status}
+                      </Badge>
+                    </TableCell>
+                    <TableCell numeric>{t.crew_count}</TableCell>
+                    <TableCell numeric>{t.total_visits_per_cycle ?? '—'}</TableCell>
+                    <TableCell numeric>
+                      {t.optimization_score != null ? `${t.optimization_score}/100` : '—'}
+                    </TableCell>
+                    <TableCell />
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </Card>
+        )}
+      </div>
+
+      {createOpen && (
+        <CreateCombinedDialog
+          accountId={accountId!}
+          clients={clients}
+          onClose={() => setCreateOpen(false)}
+          onCreated={(templateId, baseClientId) => {
+            setCreateOpen(false)
+            navigate(
+              `/accounts/${accountId}/clients/${baseClientId}/scheduler/templates/${templateId}`
+            )
+          }}
+        />
+      )}
+    </AppShell>
+  )
+}
+
+function CreateCombinedDialog({
+  accountId,
+  clients,
+  onClose,
+  onCreated,
+}: {
+  accountId: string
+  clients: ClientRow[]
+  onClose: () => void
+  onCreated: (templateId: string, baseClientId: string) => void
+}) {
+  const { getToken } = useAuth()
+  const [name, setName] = useState('')
+  const [selected, setSelected] = useState<Set<string>>(new Set())
+  const [baseClientId, setBaseClientId] = useState<string>('')
+  const [crewCount, setCrewCount] = useState('4')
+  const [creating, setCreating] = useState(false)
+  const [err, setErr] = useState<string | null>(null)
+
+  const toggle = (id: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      // Auto-set base to first selection if not set yet.
+      if (!baseClientId && next.size > 0) {
+        setBaseClientId(Array.from(next)[0])
+      }
+      return next
+    })
+  }
+
+  const create = async () => {
+    setErr(null)
+    if (selected.size < 2) {
+      setErr('Pick at least 2 clients to combine')
+      return
+    }
+    if (!baseClientId || !selected.has(baseClientId)) {
+      setErr('Pick a base client (constraints come from this client)')
+      return
+    }
+    if (!name.trim()) {
+      setErr('Name is required')
+      return
+    }
+    const n = Math.max(1, Math.floor(Number(crewCount) || 1))
+    setCreating(true)
+    try {
+      const token = await getToken()
+      const res = await fetch('/api/scheduler/templates', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({
+          account_id: accountId,
+          client_id: baseClientId,
+          combined_client_ids: Array.from(selected),
+          name: name.trim(),
+          crew_count: n,
+        }),
+      })
+      const j = await res.json()
+      if (!res.ok) throw new Error((j as any).error ?? `HTTP ${res.status}`)
+      const tplId = j.template?.id ?? j.id
+      onCreated(tplId, baseClientId)
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e))
+    } finally {
+      setCreating(false)
+    }
+  }
+
+  return (
+    <Dialog open onOpenChange={(o) => !o && onClose()}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>New combined schedule</DialogTitle>
+          <DialogDescription>
+            Pick the clients to synthesize into one schedule. The engine will route across
+            all of them and place visits on a single set of crews. Select a base client —
+            its operational constraints (crew size, hours/day, drive speed) drive the engine.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3">
+          <FormField label="Name">
+            <Input
+              autoFocus
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="e.g. IFS + JLL combined Q1"
+            />
+          </FormField>
+
+          <FormField label={`Clients to combine (${selected.size} selected)`}>
+            <ul className="max-h-56 overflow-y-auto rounded-md border border-border divide-y divide-border">
+              {clients.map((c) => {
+                const isBase = c.id === baseClientId
+                return (
+                  <li key={c.id} className="flex items-center gap-2 px-2 py-1.5">
+                    <input
+                      type="checkbox"
+                      checked={selected.has(c.id)}
+                      onChange={() => toggle(c.id)}
+                      className="rounded border-border accent-accent"
+                    />
+                    <span className="flex-1 text-sm text-fg">
+                      {c.display_name ?? c.name}
+                    </span>
+                    {selected.has(c.id) && (
+                      <button
+                        type="button"
+                        onClick={() => setBaseClientId(c.id)}
+                        className={
+                          'rounded border px-2 py-0.5 text-[10px] ' +
+                          (isBase
+                            ? 'border-accent bg-accent/10 text-accent'
+                            : 'border-border text-fg-muted hover:bg-surface-muted')
+                        }
+                      >
+                        {isBase ? 'Base ✓' : 'Set as base'}
+                      </button>
+                    )}
+                  </li>
+                )
+              })}
+            </ul>
+          </FormField>
+
+          <FormField label="Crew count">
+            <Input
+              type="number"
+              min={1}
+              value={crewCount}
+              onChange={(e) => setCrewCount(e.target.value)}
+            />
+          </FormField>
+        </div>
+
+        {err && (
+          <p className="text-xs text-danger border border-danger/30 bg-danger-subtle rounded-md px-2 py-1">
+            {err}
+          </p>
+        )}
+
+        <DialogFooter>
+          <Button variant="ghost" onClick={onClose} disabled={creating}>Cancel</Button>
+          <Button onClick={create} loading={creating}>Create + optimize</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/supabase/migrations/20260502134041_combined_schedules.sql
+++ b/supabase/migrations/20260502134041_combined_schedules.sql
@@ -1,0 +1,17 @@
+-- Phase 4.6 — combined schedules: a routing template can synthesize
+-- multiple clients into a single cycle.
+--
+-- combined_client_ids: NULL = single-client template (existing behavior).
+-- Non-null array = the SL pool is the UNION across all listed clients.
+-- The template's own client_id field stays set to combined_client_ids[0]
+-- (the "base" client whose operational constraints govern; FK satisfied).
+--
+-- Branch picks for combined templates are stored on the template's
+-- existing branches jsonb column; UI builds the union pool from the
+-- selected clients' selected_branches and lets the operator trim.
+ALTER TABLE public.routing_templates
+  ADD COLUMN IF NOT EXISTS combined_client_ids jsonb;
+
+CREATE INDEX IF NOT EXISTS routing_templates_combined_idx
+  ON public.routing_templates(account_id)
+  WHERE combined_client_ids IS NOT NULL;


### PR DESCRIPTION
## Summary
Operators can now create a single routing template that spans multiple clients in an account (IFS Utah + IFS Arizona + JLL Red River…), pulling all their service locations into one pool and routing them as a unified schedule. Useful when clients share crews and you want to optimize routing across the whole portfolio instead of one client at a time.

## Migration
\`routing_templates.combined_client_ids\` jsonb (NULL = single-client, array = combined). Partial index for fast account-level listing.

## Engine / API
- **\`POST /api/scheduler/templates\`** accepts optional \`combined_client_ids\`. When set:
  - SL pool gathered across all listed clients (auto-fills if caller doesn't supply IDs)
  - \`service_offerings\` query widens to \`.in('client_id', allClientIds)\`
  - \`client_id\` stays set to the "base" client (operational constraints come from there; FK satisfied)
  - \`combined_client_ids\` persisted on the row
- **\`GET /api/scheduler/templates?combined=true\`** lists account-level combined templates
- **\`regenerate.ts\`** re-fetches offerings across \`combined_client_ids\` when the template was originally combined

## UI
- New page **\`/accounts/:accountId/combined-schedules\`**
  - Lists combined templates with client badges
  - "New combined schedule" dialog: name, multi-select clients (≥2), base client picker, crew_count
- Detail page **reuses TemplateDetail** via the base client's URL — no new detail page in v1
- "Combined schedules" link added to the AccountDetail header next to "Add client"

## Operator workflow
1. Open an account → click "Combined schedules" in the header
2. "New combined schedule" → tick the clients to combine, pick base, set crew_count, name it
3. "Create + optimize" → engine runs across all selected clients' SLs
4. Land on existing TemplateDetail (under base client's URL) showing the combined result
5. From there: regenerate, generate cycle, branch assignments, all existing tools work

## Out of scope (deferred)
- Per-client cost splits (this is a scheduling app, not billing)
- Cross-client addon cohort validation (addons attach via base client only)
- Color-coding visits by source client (visit data carries client_id; UI enhancement is a follow-up)
- Smart constraint reconciliation across clients (we just use base client's settings)

## Test plan
- [ ] Account with 2+ active clients → "Combined schedules" page accessible from AccountDetail
- [ ] Create combined template with 2-3 clients → engine runs, lands on TemplateDetail
- [ ] Generated cycle includes visits from all selected clients
- [ ] Regenerate template re-fetches offerings across all source clients
- [ ] Single-client templates unchanged (backwards compat: combined_client_ids NULL)
- [ ] tsc + build clean (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)