### PR TITLE
Chunk + page scheduler queries for combined templates with 5000+ SLs

### DIFF
--- a/api/_lib/scheduler/cohort-assigner.ts
+++ b/api/_lib/scheduler/cohort-assigner.ts
@@ -193,13 +193,23 @@ export async function loadEligibleProperties(
   parentOfferingIds: string[]
 ): Promise<EligibleProperty[]> {
   if (parentOfferingIds.length === 0) return []
-  const { data } = await db
-    .from('service_locations')
-    .select('id, account_id, client_id, property:properties(id, latitude, longitude, state)')
-    .in('service_offering_id', parentOfferingIds)
-    .eq('client_id', clientId)
+  // Page — clients with thousands of SLs would silently truncate at the
+  // PostgREST 1000-row cap.
+  const PAGE = 1000
+  const data: any[] = []
+  for (let p = 0; p < 50; p++) {
+    const { data: batch } = await db
+      .from('service_locations')
+      .select('id, account_id, client_id, property:properties(id, latitude, longitude, state)')
+      .in('service_offering_id', parentOfferingIds)
+      .eq('client_id', clientId)
+      .range(p * PAGE, p * PAGE + PAGE - 1)
+    const rows = batch ?? []
+    data.push(...rows)
+    if (rows.length < PAGE) break
+  }
   const out: EligibleProperty[] = []
-  for (const row of data ?? []) {
+  for (const row of data) {
     const sl = row as any
     const p = sl.property
     if (!p?.latitude || !p?.longitude) continue

--- a/api/_lib/scheduler/generate-cycle-instance.ts
+++ b/api/_lib/scheduler/generate-cycle-instance.ts
@@ -88,12 +88,19 @@ export async function generateCycleInstance(
   }
   const completedCohorts = new Set<string>()
   if (cohortAssignmentIds.size > 0) {
-    const { data: cohortRows } = await db
-      .from('addon_cohort_assignments')
-      .select('id, last_completed_date, next_due_year')
-      .in('id', Array.from(cohortAssignmentIds))
+    // Chunk for URL-length safety on combined templates.
+    const idArr = Array.from(cohortAssignmentIds)
+    const cohortRows: any[] = []
+    for (let i = 0; i < idArr.length; i += 250) {
+      const chunk = idArr.slice(i, i + 250)
+      const { data } = await db
+        .from('addon_cohort_assignments')
+        .select('id, last_completed_date, next_due_year')
+        .in('id', chunk)
+      cohortRows.push(...(data ?? []))
+    }
     const cycleYear = Number(startDate.slice(0, 4))
-    for (const row of cohortRows ?? []) {
+    for (const row of cohortRows) {
       const r = row as { id: string; last_completed_date: string | null; next_due_year: number }
       if (r.next_due_year > cycleYear) completedCohorts.add(r.id)
     }
@@ -266,12 +273,17 @@ export async function generateCycleInstance(
     .map((u) => u.service_location_id as string)
   let propIdBySlId = new Map<string, string>()
   if (slIdsNeedingPropId.length > 0) {
-    const { data: slRows } = await db
-      .from('service_locations')
-      .select('id, property_id')
-      .in('id', slIdsNeedingPropId)
+    const slRows: any[] = []
+    for (let i = 0; i < slIdsNeedingPropId.length; i += 250) {
+      const chunk = slIdsNeedingPropId.slice(i, i + 250)
+      const { data } = await db
+        .from('service_locations')
+        .select('id, property_id')
+        .in('id', chunk)
+      slRows.push(...(data ?? []))
+    }
     propIdBySlId = new Map(
-      (slRows ?? []).map((r) => [(r as any).id as string, (r as any).property_id as string])
+      slRows.map((r) => [(r as any).id as string, (r as any).property_id as string])
     )
   }
   for (const u of unplacedRaw) {

--- a/api/_lib/scheduler/preflight-checks.ts
+++ b/api/_lib/scheduler/preflight-checks.ts
@@ -271,11 +271,18 @@ async function checkPropertiesRemovedSinceTemplate(
   ctx: CycleContext
 ): Promise<PreflightIssue[]> {
   if (!ctx.template.routed_service_location_ids?.length) return []
-  const { data: sls } = await db
-    .from('service_locations')
-    .select('id')
-    .in('id', ctx.template.routed_service_location_ids)
-  const stillExisting = new Set((sls ?? []).map((r: any) => r.id as string))
+  // Chunk for URL-length safety — combined templates can have 5000+ ids.
+  const allIds = ctx.template.routed_service_location_ids
+  const sls: any[] = []
+  for (let i = 0; i < allIds.length; i += 250) {
+    const chunk = allIds.slice(i, i + 250)
+    const { data } = await db
+      .from('service_locations')
+      .select('id')
+      .in('id', chunk)
+    sls.push(...(data ?? []))
+  }
+  const stillExisting = new Set(sls.map((r: any) => r.id as string))
   const removed = ctx.template.routed_service_location_ids.filter(
     (id) => !stillExisting.has(id)
   )

--- a/api/scheduler/templates/[templateId]/regenerate.ts
+++ b/api/scheduler/templates/[templateId]/regenerate.ts
@@ -136,12 +136,19 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   for (const addon of addonOfferings) {
     const a = addon as any
     const eligible = await loadEligibleProperties(db, accountId, clientId, (a.attaches_to_offering_ids ?? []) as string[])
-    const { data: existing } = await db
-      .from('addon_cohort_assignments')
-      .select('service_location_id')
-      .eq('service_offering_id', a.id)
-      .eq('client_id', clientId)
-    const assigned = new Set((existing ?? []).map((x: any) => x.service_location_id))
+    const existing: any[] = []
+    for (let p = 0; p < 50; p++) {
+      const { data: batch } = await db
+        .from('addon_cohort_assignments')
+        .select('service_location_id')
+        .eq('service_offering_id', a.id)
+        .eq('client_id', clientId)
+        .range(p * 1000, p * 1000 + 999)
+      const rows = batch ?? []
+      existing.push(...rows)
+      if (rows.length < 1000) break
+    }
+    const assigned = new Set(existing.map((x: any) => x.service_location_id))
     const unassigned = eligible.filter((e) => !assigned.has(e.service_location_id))
     if (unassigned.length > 0) {
       await applyCohortAssignments(db, {
@@ -156,14 +163,44 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       })
     }
   }
-  const { data: cohortRows } = await db
-    .from('addon_cohort_assignments')
-    .select('id, service_location_id, service_offering_id, cohort_index, next_due_year')
-    .in('service_location_id', routed.map((r) => r.sl.id))
-  const { data: constraintRows } = await db
-    .from('service_location_constraints')
-    .select('id, service_location_id, constraint_type, enforcement, config, notes')
-    .in('service_location_id', routed.map((r) => r.sl.id))
+  // Chunk + page — combined templates can have 5000+ routed SLs and an
+  // unchunked .in() either truncates at the 1000-row PostgREST cap or
+  // 414s on URL length.
+  const routedSlIds = routed.map((r) => r.sl.id)
+  const ID_CHUNK = 250
+  const RESULT_PAGE = 1000
+  const cohortRows: any[] = []
+  for (let i = 0; i < routedSlIds.length; i += ID_CHUNK) {
+    const idChunk = routedSlIds.slice(i, i + ID_CHUNK)
+    let pageOffset = 0
+    for (let p = 0; p < 50; p++) {
+      const { data } = await db
+        .from('addon_cohort_assignments')
+        .select('id, service_location_id, service_offering_id, cohort_index, next_due_year')
+        .in('service_location_id', idChunk)
+        .range(pageOffset, pageOffset + RESULT_PAGE - 1)
+      const batch = data ?? []
+      cohortRows.push(...batch)
+      if (batch.length < RESULT_PAGE) break
+      pageOffset += RESULT_PAGE
+    }
+  }
+  const constraintRows: any[] = []
+  for (let i = 0; i < routedSlIds.length; i += ID_CHUNK) {
+    const idChunk = routedSlIds.slice(i, i + ID_CHUNK)
+    let pageOffset = 0
+    for (let p = 0; p < 50; p++) {
+      const { data } = await db
+        .from('service_location_constraints')
+        .select('id, service_location_id, constraint_type, enforcement, config, notes')
+        .in('service_location_id', idChunk)
+        .range(pageOffset, pageOffset + RESULT_PAGE - 1)
+      const batch = data ?? []
+      constraintRows.push(...batch)
+      if (batch.length < RESULT_PAGE) break
+      pageOffset += RESULT_PAGE
+    }
+  }
   const constraintsBySl = new Map<string, StoredConstraint[]>()
   for (const c of constraintRows ?? []) {
     const arr = constraintsBySl.get((c as any).service_location_id) ?? []

--- a/api/scheduler/templates/index.ts
+++ b/api/scheduler/templates/index.ts
@@ -173,13 +173,21 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       const a = addon as any
       const parents = (a.attaches_to_offering_ids ?? []) as string[]
       const eligible = await loadEligibleProperties(db, accountId, clientId, parents)
-      // Are any eligible properties WITHOUT a cohort assignment?
-      const { data: existing } = await db
-        .from('addon_cohort_assignments')
-        .select('service_location_id')
-        .eq('service_offering_id', a.id)
-        .eq('client_id', clientId)
-      const assigned = new Set((existing ?? []).map((x: any) => x.service_location_id))
+      // Are any eligible properties WITHOUT a cohort assignment? Page —
+      // a client with 5000 SLs hits the 1000-row PostgREST cap otherwise.
+      const existing: any[] = []
+      for (let p = 0; p < 50; p++) {
+        const { data: batch } = await db
+          .from('addon_cohort_assignments')
+          .select('service_location_id')
+          .eq('service_offering_id', a.id)
+          .eq('client_id', clientId)
+          .range(p * 1000, p * 1000 + 999)
+        const rows = batch ?? []
+        existing.push(...rows)
+        if (rows.length < 1000) break
+      }
+      const assigned = new Set(existing.map((x: any) => x.service_location_id))
       const unassigned = eligible.filter((e) => !assigned.has(e.service_location_id))
       if (unassigned.length > 0) {
         await applyCohortAssignments(db, {
@@ -195,17 +203,45 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       }
     }
 
-    // Now load addon cohort assignments for the routed SLs.
-    const { data: cohortRows } = await db
-      .from('addon_cohort_assignments')
-      .select('id, service_location_id, service_offering_id, cohort_index, next_due_year')
-      .in('service_location_id', routed.map((r) => r.sl.id))
-
-    // Load constraints for the routed SLs.
-    const { data: constraintRows } = await db
-      .from('service_location_constraints')
-      .select('id, service_location_id, constraint_type, enforcement, config, notes')
-      .in('service_location_id', routed.map((r) => r.sl.id))
+    // Load addon cohort assignments + constraints for the routed SLs.
+    // Chunk SL ids by 250 to keep PostgREST URL under ~32KB and page each
+    // chunk to dodge the silent 1000-row cap; combined templates can hit
+    // 5000+ SLs and an unchunked .in() truncates or 414s.
+    const routedSlIds = routed.map((r) => r.sl.id)
+    const ID_CHUNK = 250
+    const RESULT_PAGE = 1000
+    const cohortRows: any[] = []
+    for (let i = 0; i < routedSlIds.length; i += ID_CHUNK) {
+      const idChunk = routedSlIds.slice(i, i + ID_CHUNK)
+      let pageOffset = 0
+      for (let p = 0; p < 50; p++) {
+        const { data } = await db
+          .from('addon_cohort_assignments')
+          .select('id, service_location_id, service_offering_id, cohort_index, next_due_year')
+          .in('service_location_id', idChunk)
+          .range(pageOffset, pageOffset + RESULT_PAGE - 1)
+        const batch = data ?? []
+        cohortRows.push(...batch)
+        if (batch.length < RESULT_PAGE) break
+        pageOffset += RESULT_PAGE
+      }
+    }
+    const constraintRows: any[] = []
+    for (let i = 0; i < routedSlIds.length; i += ID_CHUNK) {
+      const idChunk = routedSlIds.slice(i, i + ID_CHUNK)
+      let pageOffset = 0
+      for (let p = 0; p < 50; p++) {
+        const { data } = await db
+          .from('service_location_constraints')
+          .select('id, service_location_id, constraint_type, enforcement, config, notes')
+          .in('service_location_id', idChunk)
+          .range(pageOffset, pageOffset + RESULT_PAGE - 1)
+        const batch = data ?? []
+        constraintRows.push(...batch)
+        if (batch.length < RESULT_PAGE) break
+        pageOffset += RESULT_PAGE
+      }
+    }
     const constraintsBySl = new Map<string, StoredConstraint[]>()
     for (const c of constraintRows ?? []) {
       const arr = constraintsBySl.get((c as any).service_location_id) ?? []


### PR DESCRIPTION
## Summary
- Several scheduler queries were issuing unchunked \`.in('service_location_id', allIds)\` against PostgREST. Combined templates routinely have 5000+ SLs, which either silently truncates at the 1000-row page cap or 414s on URL length (~1200+ uuids).
- Switched all hot-path lookups to chunk ids by 250 + page each chunk (50 pages × 1000 = 50k row ceiling per chunk).

## Files touched
- \`api/scheduler/templates/index.ts\` — addon_cohort_assignments + service_location_constraints lookups, plus the per-addon existence check.
- \`api/scheduler/templates/[templateId]/regenerate.ts\` — same two patterns.
- \`api/_lib/scheduler/generate-cycle-instance.ts\` — cohort-completion lookup + sl→property_id lookup for unplaced rows.
- \`api/_lib/scheduler/preflight-checks.ts\` — routed_service_location_ids existence check.
- \`api/_lib/scheduler/cohort-assigner.ts\` (\`loadEligibleProperties\`) — paged the SLs-by-offering query.

## Test plan
- [ ] Build a combined template across IFS Utah + IFS Arizona + JLL NV/AZ + JLL Red River (target ~5k SLs). Verify the optimization completes without truncated SL count.
- [ ] Regenerate the same template — same expectation.
- [ ] Run a cycle on it — verify all routed visits + unplaced rows show up.
- [ ] Existing single-client templates (e.g. JLL Red River, ~500 SLs) still optimize unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)