### PR TITLE
Combined schedules: union branches across all participating clients

### DIFF
--- a/api/scheduler/templates/index.ts
+++ b/api/scheduler/templates/index.ts
@@ -105,14 +105,59 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     }
 
     const constraints = await loadConstraints(db, accountId, clientId)
-    const sel = requireSelectedBranches(constraints)
-    if (!sel.ok) {
-      return res.status(400).json({
-        error: 'No branches selected. Run Branch Optimization first.',
-        code: 'BRANCHES_NOT_SELECTED',
-      })
+    let branches: Array<{ name: string; lat: number; lng: number }>
+    let combinedBranchSources: Array<{ name: string; lat: number; lng: number; client_ids: string[] }> | null = null
+
+    if (isCombined) {
+      // Base client supplies crew_size / hours_per_day / drive_speed_mph,
+      // but BRANCHES + CREWS span every participating client. Load each
+      // combined client's constraints and union their selected branches,
+      // deduping co-located ones (rounded lat/lng).
+      const { data: clientRows } = await db
+        .from('clients')
+        .select('id, account_id')
+        .in('id', allClientIds)
+      const accountByClientId = new Map<string, string>(
+        (clientRows ?? []).map((r: any) => [r.id as string, r.account_id as string])
+      )
+      const byKey = new Map<string, { name: string; lat: number; lng: number; client_ids: string[] }>()
+      const ordered: Array<{ name: string; lat: number; lng: number; client_ids: string[] }> = []
+      for (const cid of allClientIds) {
+        const aid = accountByClientId.get(cid)
+        if (!aid) continue
+        const c = await loadConstraints(db, aid, cid)
+        const s = requireSelectedBranches(c)
+        if (!s.ok) continue
+        for (const b of s.branches) {
+          const k = `${b.lat.toFixed(3)},${b.lng.toFixed(3)}`
+          const existing = byKey.get(k)
+          if (existing) {
+            if (!existing.client_ids.includes(cid)) existing.client_ids.push(cid)
+          } else {
+            const entry = { name: b.name, lat: b.lat, lng: b.lng, client_ids: [cid] }
+            byKey.set(k, entry)
+            ordered.push(entry)
+          }
+        }
+      }
+      if (ordered.length === 0) {
+        return res.status(400).json({
+          error: 'No branches selected across the combined clients. Run Branch Optimization for at least one client first.',
+          code: 'BRANCHES_NOT_SELECTED',
+        })
+      }
+      branches = ordered.map((m) => ({ name: m.name, lat: m.lat, lng: m.lng }))
+      combinedBranchSources = ordered
+    } else {
+      const sel = requireSelectedBranches(constraints)
+      if (!sel.ok) {
+        return res.status(400).json({
+          error: 'No branches selected. Run Branch Optimization first.',
+          code: 'BRANCHES_NOT_SELECTED',
+        })
+      }
+      branches = sel.branches.map((b) => ({ name: b.name, lat: b.lat, lng: b.lng }))
     }
-    const branches = sel.branches.map((b) => ({ name: b.name, lat: b.lat, lng: b.lng }))
 
     // Fetch SLs + properties + offerings. Chunk by 250 ids (URL length
     // safety) AND page each chunk because PostgREST silently caps page
@@ -372,6 +417,10 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           crew_size: constraints.crew_size,
           hours_per_day: constraints.hours_per_day,
           drive_speed_mph: constraints.drive_speed_mph,
+          // For combined templates, record which clients contributed each
+          // branch so the UI can show provenance (e.g. "Phoenix branch ←
+          // IFS Arizona"). Only set on combined templates.
+          ...(combinedBranchSources ? { combined_branch_sources: combinedBranchSources } : {}),
           ...((body.config as any) ?? {}),
         },
         planning_mode: planningMode,

--- a/src/pages/accounts/scheduler/CombinedSchedules.tsx
+++ b/src/pages/accounts/scheduler/CombinedSchedules.tsx
@@ -344,9 +344,11 @@ function CreateCombinedDialog({
         <DialogHeader>
           <DialogTitle>New combined schedule</DialogTitle>
           <DialogDescription>
-            Pick the clients to synthesize into one schedule. The engine will route across
-            all of them and place visits on a single set of crews. Select a base client —
-            its operational constraints (crew size, hours/day, drive speed) drive the engine.
+            Pick the clients to synthesize into one schedule. The engine unions every
+            selected client's branches and routes properties to whichever branch is
+            closest, so crews from each branch share the load. Set crew count to the
+            total crews across all branches combined (the engine spreads them by
+            capacity). Base client supplies crew size, hours/day, and drive speed.
           </DialogDescription>
         </DialogHeader>
 

--- a/src/pages/accounts/scheduler/TemplateDetail.tsx
+++ b/src/pages/accounts/scheduler/TemplateDetail.tsx
@@ -47,6 +47,16 @@ interface Template {
   branches?: Array<{ name: string; lat: number; lng: number }>
   branch_assignments?: any[]
   branch_assignment_overrides?: Record<string, number>
+  combined_client_ids?: string[] | null
+  config?: {
+    combined_branch_sources?: Array<{
+      name: string
+      lat: number
+      lng: number
+      client_ids: string[]
+    }>
+    [key: string]: unknown
+  }
 }
 
 interface Cycle {
@@ -251,6 +261,19 @@ export default function TemplateDetailPage() {
               {template.total_visits_per_cycle ?? 0} visits/cycle ·{' '}
               ${(template.total_estimated_cost_per_year ?? 0).toLocaleString()} estimated annual cost
             </p>
+            {Array.isArray(template.combined_client_ids) && template.combined_client_ids.length > 1 && (
+              <p className="text-xs text-fg-subtle">
+                Combined schedule across {template.combined_client_ids.length} clients ·{' '}
+                {(template.branches?.length ?? 0)} branches unioned
+                {template.config?.combined_branch_sources && (
+                  <>
+                    {' '}({template.config.combined_branch_sources
+                      .map((b) => b.name)
+                      .join(', ')})
+                  </>
+                )}
+              </p>
+            )}
             {template.description && <p className="text-sm text-fg-subtle">{template.description}</p>}
           </div>
           <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary
- Combined templates were only using the **base** client's branches, so properties from other clients all funneled through (e.g.) the base's SLC branch via the capacity-circle algorithm.
- Now we union \`selected_branches\` from every client in \`combined_client_ids\`, dedupe co-located ones (lat/lng rounded to 3 decimals), and pass the merged list to the engine. The engine's existing capacity-circle assignment already handles N branches — properties go to the closest branch, crews are distributed by load.

## What changed
- \`templates POST\`: when \`isCombined\`, fetch each combined client's \`account_id\`, load constraints per (account, client), and union branches.
- Template's \`config.combined_branch_sources\` records which clients contributed each branch (so we can show \"Phoenix branch ← IFS Arizona, JLL NV/AZ\").
- TemplateDetail shows \"Combined schedule across N clients · M branches unioned\" line listing each branch by name.
- Combined-schedules dialog copy updated: tells the user crews/branches aggregate and to set total crew count for all branches combined.

## Caveats
- Branch snapshot is taken at create time. If a participating client re-runs Branch Optimization later, the combined template won't auto-refresh — user has to recreate. Acceptable for v1; can add a \"refresh branches\" action later.
- Crew count is still a single user input (you tell us how many total crews to spread across all branches). The engine's home_branch_index assignment then distributes crews by branch load.

## Test plan
- [ ] Create combined: IFS Utah (SLC) + IFS Arizona (Phoenix) + JLL NV/AZ (Vegas)
- [ ] Verify TemplateDetail header shows \"3 clients · 3 branches unioned (SLC, Phoenix, Vegas)\"
- [ ] Verify cycle places SLC properties on SLC-home crews, Phoenix on Phoenix-home, etc.
- [ ] Create a single-client (non-combined) template — branches still come from that client only
- [ ] Co-located branches across two clients dedupe to one entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)