### PR TITLE
Combined clients PR1: schema + create flow + UI badges

### DIFF
--- a/api/v1/accounts/[id]/clients/index.ts
+++ b/api/v1/accounts/[id]/clients/index.ts
@@ -36,14 +36,44 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   }
 
   if (req.method === 'POST') {
-    if (account.account_type === 'self_managed') {
+    const body = (req.body ?? {}) as Record<string, unknown>
+    const isCombined = body.is_combined === true
+    const memberIds = Array.isArray(body.member_client_ids)
+      ? (body.member_client_ids as string[]).filter((s) => typeof s === 'string')
+      : []
+
+    // Combined clients are a virtual portfolio across N member clients.
+    // They can be hosted under any account type (the host account is just
+    // for nav/permission scope) — the self_managed restriction only
+    // applies to ordinary clients.
+    if (!isCombined && account.account_type === 'self_managed') {
       return res.status(400).json({ error: 'Self-managed accounts cannot add clients manually' })
     }
 
-    const {
-      name, display_name, status = 'active',
-      notes, contact_name, contact_email, contact_phone,
-    } = req.body ?? {}
+    if (isCombined) {
+      if (memberIds.length < 2) {
+        return res.status(400).json({ error: 'Combined clients require at least 2 member_client_ids' })
+      }
+      // Verify all member ids exist and are not themselves combined.
+      const { data: members, error: mErr } = await db
+        .from('clients')
+        .select('id, is_combined')
+        .in('id', memberIds)
+      if (mErr) return res.status(500).json({ error: mErr.message })
+      const found = new Set((members ?? []).map((m: any) => m.id as string))
+      const missing = memberIds.filter((id) => !found.has(id))
+      if (missing.length > 0) {
+        return res.status(400).json({ error: `Unknown member client ids: ${missing.join(', ')}` })
+      }
+      const nestedCombined = (members ?? []).filter((m: any) => m.is_combined)
+      if (nestedCombined.length > 0) {
+        return res.status(400).json({ error: 'Cannot nest combined clients (a member is itself combined)' })
+      }
+    }
+
+    const name = body.name as string | undefined
+    const displayName = body.display_name as string | undefined
+    const status = (body.status as string | undefined) ?? 'active'
 
     if (!name?.trim()) return res.status(400).json({ error: 'name is required' })
 
@@ -52,12 +82,14 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       .insert({
         account_id: accountId,
         name: name.trim(),
-        display_name: display_name?.trim() ?? null,
+        display_name: displayName?.trim() ?? null,
         status,
-        notes: notes ?? null,
-        primary_contact_name: contact_name ?? null,
-        primary_contact_email: contact_email ?? null,
-        primary_contact_phone: contact_phone ?? null,
+        notes: (body.notes as string | undefined) ?? null,
+        primary_contact_name: (body.contact_name as string | undefined) ?? null,
+        primary_contact_email: (body.contact_email as string | undefined) ?? null,
+        primary_contact_phone: (body.contact_phone as string | undefined) ?? null,
+        is_combined: isCombined,
+        member_client_ids: isCombined ? memberIds : null,
         created_by: ctx.userId ?? null,
       })
       .select('*')

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -42,6 +42,7 @@ import CombinedSchedulesPage from './pages/accounts/scheduler/CombinedSchedules'
 import TravelPlannerPage from './pages/accounts/TravelPlanner'
 import CustomFieldsAdminPage from './pages/accounts/CustomFieldsAdmin'
 import NewAccountClientPage from './pages/accounts/NewAccountClient'
+import NewCombinedClientPage from './pages/accounts/NewCombinedClient'
 import ClientsListPage from './pages/clients/ClientsList'
 import NewClientPage from './pages/clients/NewClient'
 import ClientDetailPage from './pages/clients/ClientDetail'
@@ -186,6 +187,7 @@ export default function App() {
             element={<AuthGuard><CustomFieldsAdminPage /></AuthGuard>}
           />
           <Route path="/accounts/:id/clients/new" element={<AuthGuard><NewAccountClientPage /></AuthGuard>} />
+          <Route path="/accounts/:id/clients/new-combined" element={<AuthGuard><NewCombinedClientPage /></AuthGuard>} />
 
           {/* Clients */}
           <Route path="/clients" element={<AuthGuard><ClientsListPage /></AuthGuard>} />

--- a/src/pages/accounts/AccountDetail.tsx
+++ b/src/pages/accounts/AccountDetail.tsx
@@ -289,6 +289,9 @@ export default function AccountDetailPage() {
               <Button size="sm" variant="ghost" asChild>
                 <Link to={`/accounts/${id}/combined-schedules`}>Combined schedules</Link>
               </Button>
+              <Button size="sm" variant="ghost" asChild>
+                <Link to={`/accounts/${id}/clients/new-combined`}>+ Combined client</Link>
+              </Button>
               {isPM && (
                 <Button size="sm" variant="secondary" asChild>
                   <Link to={`/accounts/${id}/clients/new`}>+ Add client</Link>
@@ -320,14 +323,18 @@ export default function AccountDetailPage() {
             </Card>
           ) : (
             <ul className="space-y-2">
-              {clientsForDisplay(overview, clients).map((c) => (
-                <ClientOverviewRow
-                  key={c.id}
-                  accountId={id!}
-                  client={c}
-                  pending={!overview}
-                />
-              ))}
+              {clientsForDisplay(overview, clients).map((c) => {
+                const isCombined = clients.find((cl) => cl.id === c.id)?.is_combined === true
+                return (
+                  <ClientOverviewRow
+                    key={c.id}
+                    accountId={id!}
+                    client={c}
+                    pending={!overview}
+                    isCombined={isCombined}
+                  />
+                )
+              })}
             </ul>
           )}
         </section>
@@ -619,11 +626,13 @@ function ClientOverviewRow({
   accountId,
   client,
   pending,
+  isCombined,
 }: {
   accountId: string
   client: OverviewClient | Pick<OverviewClient, 'id' | 'name' | 'display_name' | 'property_count'>
   /** When true, only the bare-bones fields are populated. Hide derived UI. */
   pending?: boolean
+  isCombined?: boolean
 }) {
   const full = !pending && 'synthesis_status' in client
   const lastRun =
@@ -654,6 +663,11 @@ function ClientOverviewRow({
               <span className="text-base font-semibold text-fg truncate">
                 {client.display_name ?? client.name}
               </span>
+              {isCombined && (
+                <span className="rounded border border-accent/40 bg-accent/10 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-accent">
+                  Combined
+                </span>
+              )}
               {full && synthesisBadge((client as OverviewClient).synthesis_status)}
             </div>
             <p className="mt-1 text-xs text-fg-muted">

--- a/src/pages/accounts/NewCombinedClient.tsx
+++ b/src/pages/accounts/NewCombinedClient.tsx
@@ -1,0 +1,262 @@
+import { useState, useEffect, useMemo, useCallback } from 'react'
+import { useParams, useNavigate, Link } from 'react-router-dom'
+import { useAuth } from '../../hooks/useAuth'
+import AppShell from '../../components/layout/AppShell'
+import Button from '../../components/ui/Button'
+import { Card, CardTitle } from '../../components/ui/Card'
+import { Input, Textarea, FormField } from '../../components/ui/Input'
+
+interface ClientRow {
+  id: string
+  name: string
+  display_name: string | null
+  status: string
+  account_id: string
+  is_combined?: boolean
+  account_name?: string
+}
+
+interface AccountRow {
+  id: string
+  name: string
+  display_name: string | null
+}
+
+export default function NewCombinedClientPage() {
+  const { id: accountId } = useParams<{ id: string }>()
+  const { getToken } = useAuth()
+  const navigate = useNavigate()
+
+  const [account, setAccount] = useState<{ id: string; name: string; display_name: string | null } | null>(null)
+  const [clients, setClients] = useState<ClientRow[]>([])
+  const [loading, setLoading] = useState(true)
+  const [name, setName] = useState('')
+  const [displayName, setDisplayName] = useState('')
+  const [notes, setNotes] = useState('')
+  const [selected, setSelected] = useState<Set<string>>(new Set())
+  const [filter, setFilter] = useState('')
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const load = useCallback(async () => {
+    if (!accountId) return
+    setLoading(true)
+    try {
+      const token = await getToken()
+      const headers = { Authorization: `Bearer ${token}` }
+      const [accRes, cliRes, allAccRes] = await Promise.all([
+        fetch(`/api/v1/accounts/${accountId}`, { headers }),
+        fetch(`/api/v1/clients`, { headers }),
+        fetch(`/api/v1/accounts`, { headers }),
+      ])
+      if (accRes.ok) setAccount(await accRes.json())
+      const accList: AccountRow[] = allAccRes.ok ? await allAccRes.json() : []
+      const accNameById = new Map(accList.map((a) => [a.id, a.display_name ?? a.name]))
+      if (cliRes.ok) {
+        const list = (await cliRes.json()) as ClientRow[]
+        setClients(
+          list
+            .filter((c) => c.status !== 'churned' && !c.is_combined)
+            .map((c) => ({ ...c, account_name: accNameById.get(c.account_id) ?? '—' }))
+        )
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setLoading(false)
+    }
+  }, [accountId, getToken])
+
+  useEffect(() => { load() }, [load])
+
+  const grouped = useMemo(() => {
+    const q = filter.trim().toLowerCase()
+    const matches = (c: ClientRow) =>
+      !q || `${c.display_name ?? c.name} ${c.account_name ?? ''}`.toLowerCase().includes(q)
+    const inAccount = clients.filter((c) => c.account_id === accountId && matches(c))
+    const others = clients.filter((c) => c.account_id !== accountId && matches(c))
+    const byAccount = new Map<string, ClientRow[]>()
+    for (const c of others) {
+      const arr = byAccount.get(c.account_name ?? '—') ?? []
+      arr.push(c)
+      byAccount.set(c.account_name ?? '—', arr)
+    }
+    return {
+      thisAccount: inAccount,
+      others: Array.from(byAccount.entries()).sort((a, b) => a[0].localeCompare(b[0])),
+    }
+  }, [clients, accountId, filter])
+
+  function toggle(id: string) {
+    const next = new Set(selected)
+    if (next.has(id)) next.delete(id)
+    else next.add(id)
+    setSelected(next)
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setError(null)
+    if (!name.trim()) return setError('Name is required')
+    if (selected.size < 2) return setError('Pick at least 2 member clients')
+    setSaving(true)
+    try {
+      const token = await getToken()
+      const res = await fetch(`/api/v1/accounts/${accountId}/clients`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        body: JSON.stringify({
+          name: name.trim(),
+          display_name: displayName.trim() || null,
+          notes: notes.trim() || null,
+          is_combined: true,
+          member_client_ids: Array.from(selected),
+        }),
+      })
+      const body = await res.json()
+      if (!res.ok) throw new Error(body.error ?? 'Failed to create combined client')
+      navigate(`/clients/${body.id}`)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <AppShell
+      breadcrumb={[
+        { label: 'Accounts', to: '/accounts' },
+        { label: account?.display_name ?? account?.name ?? '…', to: `/accounts/${accountId}` },
+        { label: 'New combined client' },
+      ]}
+    >
+      <div className="mx-auto max-w-3xl px-6 py-10 space-y-6">
+        <header className="space-y-1">
+          <h1 className="text-2xl font-semibold tracking-tight text-fg">New combined client</h1>
+          <p className="text-sm text-fg-muted max-w-2xl">
+            A combined client is a virtual portfolio that aggregates properties from multiple
+            existing clients. Smart Analysis, Branch Optimization, and the scheduler treat it
+            like any other client. Member clients keep their own data and stay fully usable on
+            their own.
+          </p>
+        </header>
+
+        <form onSubmit={handleSubmit} className="space-y-5">
+          {error && (
+            <div className="rounded-md border border-danger/30 bg-danger-subtle px-3 py-2 text-sm text-danger">
+              {error}
+            </div>
+          )}
+
+          <Card className="space-y-4">
+            <CardTitle>Details</CardTitle>
+            <FormField label="Name" htmlFor="cc-name">
+              <Input
+                id="cc-name"
+                autoFocus
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="e.g. IFS + JLL combined portfolio"
+              />
+            </FormField>
+            <FormField label="Display name (optional)">
+              <Input value={displayName} onChange={(e) => setDisplayName(e.target.value)} />
+            </FormField>
+            <FormField label="Notes (optional)">
+              <Textarea rows={2} value={notes} onChange={(e) => setNotes(e.target.value)} />
+            </FormField>
+          </Card>
+
+          <Card padding="none" className="overflow-hidden">
+            <div className="border-b border-border px-4 py-3 flex items-center justify-between">
+              <CardTitle>Member clients ({selected.size} selected)</CardTitle>
+              <span className="text-xs text-fg-subtle">Combined clients cannot be members.</span>
+            </div>
+            <div className="px-4 py-3 border-b border-border">
+              <Input
+                value={filter}
+                onChange={(e) => setFilter(e.target.value)}
+                placeholder="Filter clients or accounts…"
+              />
+            </div>
+
+            {loading ? (
+              <p className="px-4 py-6 text-sm text-fg-muted">Loading clients…</p>
+            ) : (
+              <div className="max-h-96 overflow-y-auto">
+                {grouped.thisAccount.length > 0 && (
+                  <ClientGroup
+                    label="This account"
+                    clients={grouped.thisAccount}
+                    selected={selected}
+                    onToggle={toggle}
+                  />
+                )}
+                {grouped.others.map(([accName, list]) => (
+                  <ClientGroup
+                    key={accName}
+                    label={accName}
+                    clients={list}
+                    selected={selected}
+                    onToggle={toggle}
+                  />
+                ))}
+                {grouped.thisAccount.length === 0 && grouped.others.length === 0 && (
+                  <p className="px-4 py-4 text-xs text-fg-subtle">
+                    No clients match that filter.
+                  </p>
+                )}
+              </div>
+            )}
+          </Card>
+
+          <div className="flex items-center justify-end gap-2">
+            <Button variant="ghost" asChild>
+              <Link to={`/accounts/${accountId}`}>Cancel</Link>
+            </Button>
+            <Button type="submit" loading={saving} disabled={selected.size < 2 || !name.trim()}>
+              Create combined client
+            </Button>
+          </div>
+        </form>
+      </div>
+    </AppShell>
+  )
+}
+
+function ClientGroup({
+  label,
+  clients,
+  selected,
+  onToggle,
+}: {
+  label: string
+  clients: ClientRow[]
+  selected: Set<string>
+  onToggle: (id: string) => void
+}) {
+  if (clients.length === 0) return null
+  return (
+    <div className="border-b border-border last:border-b-0">
+      <div className="bg-surface-muted px-4 py-1 text-[10px] uppercase tracking-wide text-fg-subtle">
+        {label}
+      </div>
+      <ul className="divide-y divide-border">
+        {clients.map((c) => (
+          <li key={c.id} className="flex items-center gap-2 px-4 py-1.5">
+            <input
+              type="checkbox"
+              checked={selected.has(c.id)}
+              onChange={() => onToggle(c.id)}
+              className="rounded border-border accent-accent"
+            />
+            <span className="flex-1 text-sm text-fg">
+              {c.display_name ?? c.name}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/src/pages/clients/ClientDetail.tsx
+++ b/src/pages/clients/ClientDetail.tsx
@@ -185,11 +185,16 @@ export default function ClientDetailPage() {
                   {(client.display_name ?? client.name).charAt(0).toUpperCase()}
                 </div>
                 <div>
-                  <div className="flex items-center gap-2">
+                  <div className="flex items-center gap-2 flex-wrap">
                     <h1 className="text-2xl font-bold text-gray-900">{client.display_name ?? client.name}</h1>
                     <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${STATUS_BADGE[client.status] ?? 'bg-gray-100 text-gray-500'}`}>
                       {client.status}
                     </span>
+                    {client.is_combined && (
+                      <span className="rounded-full border border-blue-300 bg-blue-50 px-2 py-0.5 text-[11px] font-medium text-blue-700">
+                        Combined · {client.member_client_ids?.length ?? 0} members
+                      </span>
+                    )}
                   </div>
                   {client.display_name && <p className="text-sm text-gray-400">{client.name}</p>}
                 </div>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -29,6 +29,8 @@ export interface Client {
   brand_color?: string | null
   logo_url?: string | null
   metadata?: Record<string, unknown>
+  is_combined?: boolean
+  member_client_ids?: string[] | null
   created_at: string
   updated_at: string
   created_by?: string | null

--- a/supabase/migrations/20260502145635_combined_clients_entity.sql
+++ b/supabase/migrations/20260502145635_combined_clients_entity.sql
@@ -1,0 +1,39 @@
+-- Combined client entity. A combined client is a clients row whose
+-- service_locations are aggregated from `member_client_ids` instead of
+-- being directly attached. It exists so Smart Analysis, Branch
+-- Optimization, scheduler, etc. can treat a multi-client portfolio as a
+-- single virtual client.
+--
+-- Members remain fully usable on their own — a combined client is purely
+-- a view across them. SLs and offerings are NOT copied; consumer code
+-- resolves a combined client into its members at read time.
+--
+-- The host account_id (where the combined client appears in nav) is the
+-- account of the user creating it. member_client_ids may include clients
+-- from any account.
+
+ALTER TABLE public.clients
+  ADD COLUMN IF NOT EXISTS is_combined boolean NOT NULL DEFAULT false;
+
+ALTER TABLE public.clients
+  ADD COLUMN IF NOT EXISTS member_client_ids jsonb;
+
+-- Partial index — most clients are not combined, so a partial index is
+-- both small and useful for "list combined clients" queries.
+CREATE INDEX IF NOT EXISTS clients_is_combined_idx
+  ON public.clients(is_combined)
+  WHERE is_combined = true;
+
+-- Constraint: combined clients must have a non-empty member_client_ids
+-- array; non-combined clients must have it null.
+ALTER TABLE public.clients
+  DROP CONSTRAINT IF EXISTS clients_combined_members_check;
+ALTER TABLE public.clients
+  ADD CONSTRAINT clients_combined_members_check CHECK (
+    (is_combined = false AND member_client_ids IS NULL)
+    OR
+    (is_combined = true
+      AND member_client_ids IS NOT NULL
+      AND jsonb_typeof(member_client_ids) = 'array'
+      AND jsonb_array_length(member_client_ids) >= 2)
+  );


### PR DESCRIPTION
## Summary
First of three PRs to make combined-client portfolios first-class. PR1 lands the schema, the create flow, and surface badges. **Smart Analysis on combined clients does not yet work** — that's PR2 (the resolver). Until PR2, opening a combined client shows 0 properties because consumer code still queries SLs by literal client_id.

## Schema
\`supabase/migrations/20260502145635_combined_clients_entity.sql\`
- \`clients.is_combined boolean default false\`
- \`clients.member_client_ids jsonb\`
- Partial index on \`is_combined = true\`
- Check constraint: combined ⇒ ≥ 2 member ids; non-combined ⇒ null
- **Already pushed to remote** via \`supabase db push\`.

## API
\`POST /api/v1/accounts/[id]/clients\` now accepts:
- \`is_combined: true\` (boolean)
- \`member_client_ids: string[]\` (≥ 2)

Validation:
- All member ids must exist
- No nesting (member cannot itself be combined)
- self_managed account restriction only applies to ordinary clients

## UI
- \`/accounts/:id/clients/new-combined\` — multi-select picker grouped by account (this account first, then external accounts), filter input.
- \"+ Combined client\" button on AccountDetail next to \"Add client\".
- \"Combined · N members\" badge on ClientDetail header.
- \"Combined\" pill on AccountDetail client-list rows.

## Test plan
- [ ] Click \"+ Combined client\" from any account → land on \`/accounts/.../clients/new-combined\`
- [ ] Picker lists this account's clients in one group, other accounts in separate groups, filter works
- [ ] Cannot proceed without ≥ 2 selections
- [ ] After create → redirect to \`/clients/:id\`, header shows \"Combined · N members\" pill
- [ ] AccountDetail client list shows the new client with \"Combined\" badge

## Up next (PR2)
Resolver helper — \`resolveClientIds(db, clientId)\` returns \`[clientId]\` for normal clients and the member array for combined. Wired through SL, offering, and Smart Analysis loaders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)