### PR TITLE
Combined clients PR2: resolver + sync action

### DIFF
--- a/api/_lib/analysis/account-data.ts
+++ b/api/_lib/analysis/account-data.ts
@@ -2,6 +2,7 @@
 // locations and persist analysis records to portfolio_analyses.
 import type { SupabaseClient } from '@supabase/supabase-js'
 import crypto from 'crypto'
+import { resolveClientIds } from '../clients/resolve-client-ids.js'
 
 export interface AccountProperty {
   id: string
@@ -43,32 +44,56 @@ export async function loadAccountProperties(
   // Step 1: confirm the client belongs to this account
   const { data: clientRow, error: clientErr } = await db
     .from('clients')
-    .select('id')
+    .select('id, is_combined, member_client_ids')
     .eq('id', clientId)
     .eq('account_id', accountId)
     .maybeSingle()
   if (clientErr) throw new Error(`clients lookup failed: ${clientErr.message}`)
   if (!clientRow) return []
-  const clientIds = [clientId]
+  // Combined clients own no SLs of their own — resolve to member ids so
+  // every analysis module gets the unioned property set automatically.
+  const clientIds: string[] = await resolveClientIds(db, clientId)
 
-  // Step 2: distinct property ids via service_locations
-  const { data: slRows, error: slErr } = await db
-    .from('service_locations')
-    .select('property_id')
-    .in('client_id', clientIds)
-    .not('property_id', 'is', null)
-  if (slErr) throw new Error(`service_locations lookup failed: ${slErr.message}`)
-  const propIds = [...new Set((slRows ?? []).map((r: any) => r.property_id).filter(Boolean))]
+  // Step 2: distinct property ids via service_locations. Page — combined
+  // clients union member SLs and could exceed the 1000-row PostgREST cap.
+  const PAGE = 1000
+  const slRows: any[] = []
+  for (let p = 0; p < 50; p++) {
+    const { data, error: slErr } = await db
+      .from('service_locations')
+      .select('property_id')
+      .in('client_id', clientIds)
+      .not('property_id', 'is', null)
+      .range(p * PAGE, p * PAGE + PAGE - 1)
+    if (slErr) throw new Error(`service_locations lookup failed: ${slErr.message}`)
+    const batch = data ?? []
+    slRows.push(...batch)
+    if (batch.length < PAGE) break
+  }
+  const propIds = [...new Set(slRows.map((r: any) => r.property_id).filter(Boolean))]
   if (!propIds.length) return []
 
-  // Step 3: properties + their service_locations (filtered to this account's clients)
-  const { data: props, error: propErr } = await db
-    .from('properties')
-    .select(
-      'id, address_line1, address_line2, city, state, postal_code, latitude, longitude, geocode_confidence, address_validation_verdict, branch_override, service_locations(id, property_id, client_id, display_name, serviceable_sqft, visits_per_year_override, service_offering_id, status, building_size_class_override, building_size_override_reason)'
-    )
-    .in('id', propIds)
-  if (propErr) throw new Error(`properties lookup failed: ${propErr.message}`)
+  // Step 3: properties + their service_locations (chunk + page; combined
+  // clients can pull thousands of properties).
+  const props: any[] = []
+  for (let i = 0; i < propIds.length; i += 250) {
+    const chunk = propIds.slice(i, i + 250)
+    let pageOffset = 0
+    for (let p = 0; p < 50; p++) {
+      const { data, error: propErr } = await db
+        .from('properties')
+        .select(
+          'id, address_line1, address_line2, city, state, postal_code, latitude, longitude, geocode_confidence, address_validation_verdict, branch_override, service_locations(id, property_id, client_id, display_name, serviceable_sqft, visits_per_year_override, service_offering_id, status, building_size_class_override, building_size_override_reason)'
+        )
+        .in('id', chunk)
+        .range(pageOffset, pageOffset + PAGE - 1)
+      if (propErr) throw new Error(`properties lookup failed: ${propErr.message}`)
+      const batch = data ?? []
+      props.push(...batch)
+      if (batch.length < PAGE) break
+      pageOffset += PAGE
+    }
+  }
 
   return (props ?? []).map((p: any) => ({
     id: p.id,

--- a/api/_lib/clients/resolve-client-ids.ts
+++ b/api/_lib/clients/resolve-client-ids.ts
@@ -1,0 +1,68 @@
+// Combined-client resolver. A "combined client" is a clients row with
+// is_combined=true and member_client_ids set — a virtual portfolio that
+// owns no service_locations of its own. Every read path that filters by
+// client_id should pass through this helper so a combined client resolves
+// to the union of its members.
+//
+// For a normal client the result is just [clientId], so callers can use
+// `.in('client_id', resolved)` unconditionally without branching.
+//
+// Cache: scoped to the request. We could memoize across requests but
+// `clients.is_combined` rarely changes and the table is small.
+
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+export async function resolveClientIds(
+  db: SupabaseClient,
+  clientId: string
+): Promise<string[]> {
+  const { data, error } = await db
+    .from('clients')
+    .select('id, is_combined, member_client_ids')
+    .eq('id', clientId)
+    .maybeSingle()
+  if (error) throw new Error(`resolveClientIds: ${error.message}`)
+  if (!data) return [clientId]
+  const row = data as {
+    id: string
+    is_combined: boolean | null
+    member_client_ids: string[] | null
+  }
+  if (row.is_combined && Array.isArray(row.member_client_ids) && row.member_client_ids.length > 0) {
+    return row.member_client_ids
+  }
+  return [clientId]
+}
+
+// Variant for an array of input client_ids — expands any combined ids
+// into their members and returns a deduped, normal-only id list.
+export async function resolveClientIdsList(
+  db: SupabaseClient,
+  clientIds: string[]
+): Promise<string[]> {
+  if (clientIds.length === 0) return []
+  const { data, error } = await db
+    .from('clients')
+    .select('id, is_combined, member_client_ids')
+    .in('id', clientIds)
+  if (error) throw new Error(`resolveClientIdsList: ${error.message}`)
+  const out = new Set<string>()
+  const seen = new Set<string>()
+  for (const r of (data ?? []) as Array<{
+    id: string
+    is_combined: boolean | null
+    member_client_ids: string[] | null
+  }>) {
+    seen.add(r.id)
+    if (r.is_combined && Array.isArray(r.member_client_ids)) {
+      for (const m of r.member_client_ids) out.add(m)
+    } else {
+      out.add(r.id)
+    }
+  }
+  // Pass through any ids that didn't come back from the lookup (treat as
+  // unresolved normal ids — caller may have passed a stale/unknown id and
+  // we'd rather hand it back than silently drop it).
+  for (const id of clientIds) if (!seen.has(id)) out.add(id)
+  return Array.from(out)
+}

--- a/api/accounts/[accountId]/overview.ts
+++ b/api/accounts/[accountId]/overview.ts
@@ -35,10 +35,10 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (accErr) return res.status(500).json({ error: accErr.message })
   if (!account) return res.status(404).json({ error: 'Account not found' })
 
-  // Clients on this account
+  // Clients on this account (includes combined clients hosted here).
   const { data: clientRows } = await db
     .from('clients')
-    .select('id, name, display_name, status')
+    .select('id, name, display_name, status, is_combined, member_client_ids')
     .eq('account_id', accountId)
     .order('name', { ascending: true })
   const clients = (clientRows ?? []) as Array<{
@@ -46,22 +46,42 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     name: string
     display_name: string | null
     status: string
+    is_combined: boolean | null
+    member_client_ids: string[] | null
   }>
   const clientIds = clients.map((c) => c.id)
+  // Combined clients own no SLs of their own — their property/SL counts
+  // come from member clients (which can live in other accounts). Pull
+  // SLs for every referenced member id too so the rollup is complete.
+  const memberIds = new Set<string>()
+  for (const c of clients) {
+    if (c.is_combined && Array.isArray(c.member_client_ids)) {
+      for (const m of c.member_client_ids) memberIds.add(m)
+    }
+  }
+  const allClientIdsForSlPull = Array.from(new Set([...clientIds, ...memberIds]))
 
-  // Service locations grouped by client (counts + property_id list per client)
+  // Service locations grouped by client (counts + property_id list per client).
+  // Pull for every referenced client id including cross-account members so
+  // combined-client rollups are complete.
   const slByClient = new Map<string, { propIds: Set<string>; slCount: number }>()
-  if (clientIds.length) {
-    const { data: slRows } = await db
-      .from('service_locations')
-      .select('id, property_id, client_id')
-      .in('client_id', clientIds)
-      .not('property_id', 'is', null)
-    for (const r of (slRows ?? []) as any[]) {
-      const cur = slByClient.get(r.client_id) ?? { propIds: new Set<string>(), slCount: 0 }
-      cur.slCount += 1
-      cur.propIds.add(r.property_id)
-      slByClient.set(r.client_id, cur)
+  if (allClientIdsForSlPull.length) {
+    const PAGE = 1000
+    for (let p = 0; p < 50; p++) {
+      const { data: slRows } = await db
+        .from('service_locations')
+        .select('id, property_id, client_id')
+        .in('client_id', allClientIdsForSlPull)
+        .not('property_id', 'is', null)
+        .range(p * PAGE, p * PAGE + PAGE - 1)
+      const batch = (slRows ?? []) as any[]
+      for (const r of batch) {
+        const cur = slByClient.get(r.client_id) ?? { propIds: new Set<string>(), slCount: 0 }
+        cur.slCount += 1
+        cur.propIds.add(r.property_id)
+        slByClient.set(r.client_id, cur)
+      }
+      if (batch.length < PAGE) break
     }
   }
 
@@ -129,10 +149,19 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     }
   }
 
-  // Build per-client payload
+  // Build per-client payload. For combined clients, fan out to members
+  // and sum their counts.
   const clientsOut = clients.map((c) => {
-    const sl = slByClient.get(c.id)
-    const props = sl?.propIds ?? new Set<string>()
+    const isCombined = c.is_combined === true && Array.isArray(c.member_client_ids)
+    const sourceIds = isCombined ? (c.member_client_ids as string[]) : [c.id]
+    const props = new Set<string>()
+    let slCount = 0
+    for (const sid of sourceIds) {
+      const sl = slByClient.get(sid)
+      if (!sl) continue
+      slCount += sl.slCount
+      for (const pid of sl.propIds) props.add(pid)
+    }
     const states = new Set<string>()
     for (const pid of props) {
       const s = stateById.get(pid)
@@ -149,8 +178,10 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       name: c.name,
       display_name: c.display_name,
       status: c.status,
+      is_combined: isCombined,
+      member_count: isCombined ? sourceIds.length : null,
       property_count: props.size,
-      service_location_count: sl?.slCount ?? 0,
+      service_location_count: slCount,
       states_count: states.size,
       last_analysis_at: ana.last_analysis_at,
       last_synthesis_at: ana.last_synthesis_at,
@@ -159,9 +190,14 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     }
   })
 
-  // Account-level rollups
-  const totalProperties = clientsOut.reduce((sum, c) => sum + c.property_count, 0)
-  const totalServiceLocations = clientsOut.reduce((sum, c) => sum + c.service_location_count, 0)
+  // Account-level rollups — exclude combined clients to avoid
+  // double-counting members that also live in this account.
+  const totalProperties = clientsOut
+    .filter((c) => !c.is_combined)
+    .reduce((sum, c) => sum + c.property_count, 0)
+  const totalServiceLocations = clientsOut
+    .filter((c) => !c.is_combined)
+    .reduce((sum, c) => sum + c.service_location_count, 0)
   const allStates = new Set<string>()
   for (const c of clientsOut) {
     // Recompute per client from stateById (cheap)

--- a/api/v1/clients/[id].ts
+++ b/api/v1/clients/[id].ts
@@ -1,6 +1,7 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
 import { createAdminClient } from '../../_lib/supabase.js'
 import { authenticateRequest } from '../../_lib/auth.js'
+import { resolveClientIds } from '../../_lib/clients/resolve-client-ids.js'
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method === 'OPTIONS') return res.status(200).end()
@@ -24,11 +25,14 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
     if (error || !client) return res.status(404).json({ error: 'Client not found' })
 
+    // For combined clients, stats come from the unioned member SLs.
+    const idsForStats = await resolveClientIds(db, id)
+
     // Stats: service location count, portfolio count, total sqft; also template config status
     const [slRes, portRes, sqftRes, uploadRes, templateRes, accountRes] = await Promise.all([
-      db.from('service_locations').select('id', { count: 'exact', head: true }).eq('client_id', id),
-      db.from('portfolios').select('portfolio_id', { count: 'exact', head: true }).eq('client_id', id),
-      db.from('service_locations').select('serviceable_sqft').eq('client_id', id).not('serviceable_sqft', 'is', null),
+      db.from('service_locations').select('id', { count: 'exact', head: true }).in('client_id', idsForStats),
+      db.from('portfolios').select('portfolio_id', { count: 'exact', head: true }).in('client_id', idsForStats),
+      db.from('service_locations').select('serviceable_sqft').in('client_id', idsForStats).not('serviceable_sqft', 'is', null),
       db.from('upload_batches').select('upload_batch_id, filename, created_at, status, row_count').eq('client_id', id).order('created_at', { ascending: false }).limit(20),
       db.from('client_templates').select('is_configured').eq('client_id', id).maybeSingle(),
       (client as any).account_id

--- a/api/v1/clients/[id]/sync-combined.ts
+++ b/api/v1/clients/[id]/sync-combined.ts
@@ -1,0 +1,129 @@
+// POST /api/v1/clients/[id]/sync-combined
+//
+// For combined clients only. Pulls aggregate state from each member
+// client into the combined client's own account_operational_constraints
+// so it behaves like a normal client for downstream tooling (Branch
+// Optimization, scheduler, etc.):
+//
+//  - selected_branches  — union across members, dedupe by rounded lat/lng
+//  - crew_count_per_branch_override — sum per-branch contributions
+//
+// Properties / SLs / offerings are NOT copied; reads use the resolver
+// helper to fan out to member ids on the fly.
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { createAdminClient } from '../../../_lib/supabase.js'
+import { authenticateRequest } from '../../../_lib/auth.js'
+import {
+  loadConstraints,
+  type SelectedBranch,
+} from '../../../_lib/analysis/operational-constraints.js'
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method === 'OPTIONS') return res.status(200).end()
+  if (req.method !== 'POST') return res.status(405).json({ error: 'Method not allowed' })
+
+  let ctx: Awaited<ReturnType<typeof authenticateRequest>>
+  try { ctx = await authenticateRequest(req) } catch (err: any) {
+    return res.status(err.statusCode ?? 401).json({ error: err.message ?? 'Unauthorized' })
+  }
+
+  const clientId = req.query.id as string
+  const db = createAdminClient()
+
+  // Look up the combined client + its members.
+  const { data: client, error: cliErr } = await db
+    .from('clients')
+    .select('id, account_id, is_combined, member_client_ids, metadata')
+    .eq('id', clientId)
+    .maybeSingle()
+  if (cliErr) return res.status(500).json({ error: cliErr.message })
+  if (!client) return res.status(404).json({ error: 'Client not found' })
+  const c = client as {
+    id: string
+    account_id: string
+    is_combined: boolean
+    member_client_ids: string[] | null
+    metadata: Record<string, unknown> | null
+  }
+  if (!c.is_combined || !Array.isArray(c.member_client_ids) || c.member_client_ids.length < 2) {
+    return res.status(400).json({ error: 'Client is not a combined client' })
+  }
+
+  // Each member may live under a different account.
+  const { data: memberRows, error: memErr } = await db
+    .from('clients')
+    .select('id, account_id, name, display_name')
+    .in('id', c.member_client_ids)
+  if (memErr) return res.status(500).json({ error: memErr.message })
+  const members = (memberRows ?? []) as Array<{
+    id: string; account_id: string; name: string; display_name: string | null
+  }>
+
+  // Aggregate branches + per-branch crew counts across members.
+  const byKey = new Map<string, { branch: SelectedBranch; sources: string[] }>()
+  const crewByBranchName: Record<string, number> = {}
+  const memberSummaries: Array<{ client_id: string; client_name: string; branches: number; crews: number }> = []
+  let totalCrewSum = 0
+
+  for (const m of members) {
+    const cons = await loadConstraints(db, m.account_id, m.id)
+    const sel = cons.selected_branches ?? []
+    let memberCrews = 0
+    for (const b of sel) {
+      const k = `${b.lat.toFixed(3)},${b.lng.toFixed(3)}`
+      const existing = byKey.get(k)
+      if (existing) {
+        if (!existing.sources.includes(m.id)) existing.sources.push(m.id)
+      } else {
+        byKey.set(k, { branch: { ...b }, sources: [m.id] })
+      }
+      const perBranch = cons.crew_count_per_branch_override?.[b.name] ?? 0
+      if (perBranch > 0) {
+        crewByBranchName[b.name] = (crewByBranchName[b.name] ?? 0) + perBranch
+        memberCrews += perBranch
+      }
+    }
+    totalCrewSum += memberCrews
+    memberSummaries.push({
+      client_id: m.id,
+      client_name: m.display_name ?? m.name,
+      branches: sel.length,
+      crews: memberCrews,
+    })
+  }
+
+  const mergedBranches: SelectedBranch[] = Array.from(byKey.values()).map((v) => v.branch)
+  const syncedAt = new Date().toISOString()
+
+  // Upsert into the combined client's constraints row.
+  const { error: upErr } = await db
+    .from('account_operational_constraints')
+    .upsert(
+      {
+        account_id: c.account_id,
+        client_id: c.id,
+        selected_branches: mergedBranches,
+        selected_k: mergedBranches.length,
+        selected_at: syncedAt,
+        crew_count_per_branch_override:
+          Object.keys(crewByBranchName).length > 0 ? crewByBranchName : null,
+        updated_at: syncedAt,
+        updated_by: ctx.userId ?? null,
+      },
+      { onConflict: 'account_id,client_id' }
+    )
+  if (upErr) return res.status(500).json({ error: `constraints upsert failed: ${upErr.message}` })
+
+  // Stamp the sync timestamp on clients.metadata.
+  const newMeta = { ...(c.metadata ?? {}), combined_last_synced_at: syncedAt }
+  await db.from('clients').update({ metadata: newMeta }).eq('id', c.id)
+
+  return res.status(200).json({
+    synced_at: syncedAt,
+    branches: mergedBranches.length,
+    branches_dedup: mergedBranches,
+    crew_total: totalCrewSum,
+    crew_by_branch: crewByBranchName,
+    members: memberSummaries,
+  })
+}

--- a/api/v1/service-locations/index.ts
+++ b/api/v1/service-locations/index.ts
@@ -2,6 +2,7 @@ import type { VercelRequest, VercelResponse } from '@vercel/node'
 import { createAdminClient } from '../../_lib/supabase.js'
 import { authenticateRequest } from '../../_lib/auth.js'
 import { fireWebhook } from '../../_lib/webhooks.js'
+import { resolveClientIdsList } from '../../_lib/clients/resolve-client-ids.js'
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method === 'OPTIONS') return res.status(200).end()
@@ -29,7 +30,13 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       .select('*, property:properties(state, city)')
       .order('property(state)', { ascending: true })
 
-    if (client_id) query = query.in('client_id', String(client_id).split(','))
+    if (client_id) {
+      // Combined clients own no SLs of their own — resolve to member ids
+      // so the listing returns the unioned SL set.
+      const requested = String(client_id).split(',').filter(Boolean)
+      const resolved = await resolveClientIdsList(db, requested)
+      query = query.in('client_id', resolved)
+    }
     if (status) query = query.in('status', String(status).split(','))
     if (property_id) query = query.eq('property_id', String(property_id))
 

--- a/api/v1/service-offerings/index.ts
+++ b/api/v1/service-offerings/index.ts
@@ -1,6 +1,7 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
 import { createAdminClient } from '../../_lib/supabase.js'
 import { authenticateRequest } from '../../_lib/auth.js'
+import { resolveClientIds } from '../../_lib/clients/resolve-client-ids.js'
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method === 'OPTIONS') return res.status(200).end()
@@ -17,16 +18,18 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method === 'GET') {
     const { account_id, client_id, include_archived, include_related } = req.query
 
-    // include_related=true: return global + account-level + client-level in one query
+    // include_related=true: return global + account-level + client-level in one query.
+    // For combined clients, expand client-level filter to every member id.
     if (include_related === 'true' && account_id) {
       const aid = String(account_id)
       const cid = client_id ? String(client_id) : null
+      const resolvedCids = cid ? await resolveClientIds(db, cid) : []
       let query = db
         .from('service_offerings')
         .select('*')
         .or(
-          cid
-            ? `and(account_id.is.null,client_id.is.null),and(account_id.eq.${aid},client_id.is.null),and(account_id.eq.${aid},client_id.eq.${cid})`
+          resolvedCids.length > 0
+            ? `and(account_id.is.null,client_id.is.null),and(account_id.eq.${aid},client_id.is.null),client_id.in.(${resolvedCids.join(',')})`
             : `and(account_id.is.null,client_id.is.null),and(account_id.eq.${aid},client_id.is.null)`
         )
         .order('name', { ascending: true })
@@ -38,7 +41,12 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
     let query = db.from('service_offerings').select('*').order('name', { ascending: true })
     if (account_id) query = query.eq('account_id', String(account_id))
-    if (client_id) query = query.eq('client_id', String(client_id))
+    if (client_id) {
+      // Combined clients own no offerings of their own — resolve to member
+      // ids so the listing returns the unioned offering set.
+      const resolved = await resolveClientIds(db, String(client_id))
+      query = query.in('client_id', resolved)
+    }
     if (include_archived !== 'true') query = query.eq('is_archived', false)
     const { data, error } = await query
     if (error) return res.status(500).json({ error: error.message })

--- a/src/pages/clients/ClientDetail.tsx
+++ b/src/pages/clients/ClientDetail.tsx
@@ -32,6 +32,35 @@ export default function ClientDetailPage() {
   const [archiving, setArchiving] = useState(false)
   const [confirmArchive, setConfirmArchive] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [syncing, setSyncing] = useState(false)
+  const [syncResult, setSyncResult] = useState<{
+    branches: number; crew_total: number; synced_at: string
+  } | null>(null)
+
+  async function handleSyncCombined() {
+    if (!client) return
+    setSyncing(true)
+    setError(null)
+    try {
+      const token = await getToken()
+      const res = await fetch(`/api/v1/clients/${client.id}/sync-combined`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      const body = await res.json()
+      if (!res.ok) throw new Error(body.error ?? `Sync failed (${res.status})`)
+      setSyncResult({
+        branches: body.branches,
+        crew_total: body.crew_total,
+        synced_at: body.synced_at,
+      })
+      await loadClient()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setSyncing(false)
+    }
+  }
 
   // Edit form state
   const [editName, setEditName] = useState('')
@@ -216,6 +245,47 @@ export default function ClientDetailPage() {
               </div>
             </div>
           </div>
+
+          {/* Combined-client sync banner */}
+          {client.is_combined && (
+            <div className="rounded-xl border border-blue-200 bg-blue-50 p-4">
+              <div className="flex items-start justify-between gap-4">
+                <div className="space-y-1">
+                  <h2 className="text-sm font-semibold text-blue-900">Combined client sync</h2>
+                  <p className="text-xs text-blue-800/80">
+                    Pulls each member's selected branches and crew counts into this combined
+                    client. Properties, service locations, and offerings stay virtual — they're
+                    resolved from members on every read, no copy needed.
+                  </p>
+                  {(() => {
+                    const last = (client.metadata as any)?.combined_last_synced_at as string | undefined
+                    if (last) {
+                      return (
+                        <p className="text-[11px] text-blue-700/70">
+                          Last synced: {new Date(last).toLocaleString()}
+                        </p>
+                      )
+                    }
+                    return (
+                      <p className="text-[11px] text-blue-700/70">
+                        Never synced — Smart Analysis still works (members are resolved at read
+                        time), but Branch Optimization needs a sync to see member branches.
+                      </p>
+                    )
+                  })()}
+                  {syncResult && (
+                    <p className="text-[11px] text-blue-900">
+                      Synced {syncResult.branches} branches, {syncResult.crew_total} crews total at{' '}
+                      {new Date(syncResult.synced_at).toLocaleTimeString()}.
+                    </p>
+                  )}
+                </div>
+                <Button size="sm" onClick={handleSyncCombined} loading={syncing}>
+                  Sync from members
+                </Button>
+              </div>
+            </div>
+          )}
 
           {/* Stats */}
           <div className="grid grid-cols-3 gap-4">


### PR DESCRIPTION
## Summary
PR2 of 3. Wires a resolver helper through every read path that filters by client_id, plus adds an explicit **Sync from members** action that pulls each member's branches and crew counts into the combined client's own constraints. After this PR, you can run Smart Analysis (Branch Optimization, Crew Strategy, etc.) on a combined client and it sees the union of member properties.

Properties / SLs / offerings stay virtual — never copied. Only branches + per-branch crew counts get materialized into the combined client, since those are what Branch Optimization writes to.

## Resolver
\`api/_lib/clients/resolve-client-ids.ts\`:
- \`resolveClientIds(db, id)\` → \`[id]\` for normal, member array for combined
- \`resolveClientIdsList(db, ids)\` → array variant

Wired into:
- \`api/_lib/analysis/account-data.ts\` (loadAccountProperties) — feeds **all 15 Smart Analysis modules**. Also paginated the SL + property fetches.
- \`api/v1/service-locations\` GET
- \`api/v1/service-offerings\` GET (both simple + include_related paths)
- \`api/v1/clients/[id]\` GET stats
- \`api/accounts/[accountId]/overview\` — combined-client rows now show aggregated counts; account totals skip combined rows to avoid double-counting members in the same account.

## Sync
\`POST /api/v1/clients/[id]/sync-combined\`:
- Fetches each member's \`account_operational_constraints\`
- Unions \`selected_branches\` dedup'd by rounded lat/lng
- Sums \`crew_count_per_branch_override\` per branch name
- Upserts onto the combined client's own constraints row
- Stamps \`combined_last_synced_at\` into \`clients.metadata\`

UI on \`ClientDetail\`:
- Banner appears for combined clients with last-synced timestamp + Sync button
- After sync, shows the result inline (\"Synced 12 branches, 18 crews total\")

## Test plan
- [ ] Open a combined client → property/SL counts now show member union (not 0)
- [ ] Click \"Sync from members\" → branches list shows up under Branch Optimization
- [ ] Run Smart Analysis on combined → Branch Optimization sees full portfolio, suggests optimal branches across it
- [ ] Run Crew Strategy → suggests crew count from total work hours across all members
- [ ] Existing single-client pages unchanged (resolver returns \`[id]\` for non-combined)
- [ ] AccountDetail rollups unchanged (combined clients excluded from totals)

## Up next (PR3)
Routing-template flow under combined clients — when you make a template under a combined client, auto-fill \`combined_client_ids\` from its members. The ad-hoc CombinedSchedules dialog can probably go away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)