### PR TITLE
Combined clients PR3: routing templates auto-detect combined clients

### DIFF
--- a/api/scheduler/templates/index.ts
+++ b/api/scheduler/templates/index.ts
@@ -64,22 +64,37 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     const clientId = body.client_id as string
     let slIds = (body.service_location_ids as string[]) ?? []
     const crewCount = Number(body.crew_count ?? 1)
+    if (!accountId || !clientId) {
+      return res.status(400).json({ error: 'account_id and client_id required' })
+    }
     // Phase 4.6 — combined templates: when combined_client_ids is set,
     // the SL pool spans all listed clients. client_id stays set to the
     // "base" client (constraints + offerings come from there). The
     // template row persists combined_client_ids so downstream paths
     // (regenerate, cycle gen) can re-fetch the same multi-client pool.
-    const combinedClientIds = Array.isArray(body.combined_client_ids)
+    let combinedClientIds: string[] | null = Array.isArray(body.combined_client_ids)
       ? (body.combined_client_ids as string[]).filter((id) => typeof id === 'string')
       : null
+    // Combined-client first-class entity (PR3): if the URL clientId points
+    // at a clients row with is_combined=true, auto-fill combined_client_ids
+    // from member_client_ids so the user doesn't have to retype them in
+    // the template form. This lets the standard NewTemplate page work
+    // unchanged for combined clients.
+    if (!combinedClientIds || combinedClientIds.length < 2) {
+      const { data: cliRow } = await db
+        .from('clients')
+        .select('id, is_combined, member_client_ids')
+        .eq('id', clientId)
+        .maybeSingle()
+      const c = cliRow as { id: string; is_combined: boolean | null; member_client_ids: string[] | null } | null
+      if (c?.is_combined && Array.isArray(c.member_client_ids) && c.member_client_ids.length >= 2) {
+        combinedClientIds = c.member_client_ids
+      }
+    }
     const isCombined = combinedClientIds != null && combinedClientIds.length > 1
     // Combined-template clients other than the base — used for
     // service_location and service_offering scope below.
     const allClientIds: string[] = isCombined ? combinedClientIds! : [clientId]
-
-    if (!accountId || !clientId) {
-      return res.status(400).json({ error: 'account_id and client_id required' })
-    }
     // Auto-fill SL ids for combined templates when caller didn't supply
     // any: pull every SL across the listed clients.
     if (isCombined && slIds.length === 0) {
@@ -109,45 +124,54 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     let combinedBranchSources: Array<{ name: string; lat: number; lng: number; client_ids: string[] }> | null = null
 
     if (isCombined) {
-      // Base client supplies crew_size / hours_per_day / drive_speed_mph,
-      // but BRANCHES + CREWS span every participating client. Load each
-      // combined client's constraints and union their selected branches,
-      // deduping co-located ones (rounded lat/lng).
-      const { data: clientRows } = await db
-        .from('clients')
-        .select('id, account_id')
-        .in('id', allClientIds)
-      const accountByClientId = new Map<string, string>(
-        (clientRows ?? []).map((r: any) => [r.id as string, r.account_id as string])
-      )
-      const byKey = new Map<string, { name: string; lat: number; lng: number; client_ids: string[] }>()
-      const ordered: Array<{ name: string; lat: number; lng: number; client_ids: string[] }> = []
-      for (const cid of allClientIds) {
-        const aid = accountByClientId.get(cid)
-        if (!aid) continue
-        const c = await loadConstraints(db, aid, cid)
-        const s = requireSelectedBranches(c)
-        if (!s.ok) continue
-        for (const b of s.branches) {
-          const k = `${b.lat.toFixed(3)},${b.lng.toFixed(3)}`
-          const existing = byKey.get(k)
-          if (existing) {
-            if (!existing.client_ids.includes(cid)) existing.client_ids.push(cid)
-          } else {
-            const entry = { name: b.name, lat: b.lat, lng: b.lng, client_ids: [cid] }
-            byKey.set(k, entry)
-            ordered.push(entry)
+      // Branch resolution priority for combined templates:
+      //   1. Combined client's OWN selected_branches if present (from
+      //      Sync action or Branch Optimization run on the combined
+      //      client itself). This is the first-class path.
+      //   2. Fallback: union the member clients' selected_branches with
+      //      dedupe by rounded lat/lng. This is the legacy ad-hoc path
+      //      and preserves behavior for templates created via the
+      //      CombinedSchedules dialog.
+      const ownSel = requireSelectedBranches(constraints)
+      if (ownSel.ok) {
+        branches = ownSel.branches.map((b) => ({ name: b.name, lat: b.lat, lng: b.lng }))
+      } else {
+        const { data: clientRows } = await db
+          .from('clients')
+          .select('id, account_id')
+          .in('id', allClientIds)
+        const accountByClientId = new Map<string, string>(
+          (clientRows ?? []).map((r: any) => [r.id as string, r.account_id as string])
+        )
+        const byKey = new Map<string, { name: string; lat: number; lng: number; client_ids: string[] }>()
+        const ordered: Array<{ name: string; lat: number; lng: number; client_ids: string[] }> = []
+        for (const cid of allClientIds) {
+          const aid = accountByClientId.get(cid)
+          if (!aid) continue
+          const c = await loadConstraints(db, aid, cid)
+          const s = requireSelectedBranches(c)
+          if (!s.ok) continue
+          for (const b of s.branches) {
+            const k = `${b.lat.toFixed(3)},${b.lng.toFixed(3)}`
+            const existing = byKey.get(k)
+            if (existing) {
+              if (!existing.client_ids.includes(cid)) existing.client_ids.push(cid)
+            } else {
+              const entry = { name: b.name, lat: b.lat, lng: b.lng, client_ids: [cid] }
+              byKey.set(k, entry)
+              ordered.push(entry)
+            }
           }
         }
+        if (ordered.length === 0) {
+          return res.status(400).json({
+            error: 'No branches selected. Run Branch Optimization on the combined client (or sync from members), or run it on at least one member client.',
+            code: 'BRANCHES_NOT_SELECTED',
+          })
+        }
+        branches = ordered.map((m) => ({ name: m.name, lat: m.lat, lng: m.lng }))
+        combinedBranchSources = ordered
       }
-      if (ordered.length === 0) {
-        return res.status(400).json({
-          error: 'No branches selected across the combined clients. Run Branch Optimization for at least one client first.',
-          code: 'BRANCHES_NOT_SELECTED',
-        })
-      }
-      branches = ordered.map((m) => ({ name: m.name, lat: m.lat, lng: m.lng }))
-      combinedBranchSources = ordered
     } else {
       const sel = requireSelectedBranches(constraints)
       if (!sel.ok) {

--- a/src/pages/accounts/scheduler/NewTemplate.tsx
+++ b/src/pages/accounts/scheduler/NewTemplate.tsx
@@ -44,6 +44,7 @@ export default function NewTemplatePage() {
   const [filter, setFilter] = useState('')
   const [selected, setSelected] = useState<Set<string>>(new Set())
   const [crewCount, setCrewCount] = useState(2)
+  const [combinedInfo, setCombinedInfo] = useState<{ memberCount: number; displayName: string } | null>(null)
   const [crewCountUserEdited, setCrewCountUserEdited] = useState(false)
   const [recommendedCrew, setRecommendedCrew] = useState<{
     count: number // conservative — what to default to
@@ -61,7 +62,7 @@ export default function NewTemplatePage() {
     setLoading(true)
     try {
       const token = await getToken()
-      const [slRes, offRes, latestRes] = await Promise.all([
+      const [slRes, offRes, latestRes, cliRes] = await Promise.all([
         fetch(`/api/v1/service-locations?client_id=${clientId}`, {
           headers: { Authorization: `Bearer ${token}` },
         }),
@@ -71,7 +72,19 @@ export default function NewTemplatePage() {
         fetch(`/api/analyses/account/${accountId}/clients/${clientId}/latest`, {
           headers: { Authorization: `Bearer ${token}` },
         }),
+        fetch(`/api/v1/clients/${clientId}`, {
+          headers: { Authorization: `Bearer ${token}` },
+        }),
       ])
+      if (cliRes.ok) {
+        const c = await cliRes.json()
+        if (c.is_combined) {
+          setCombinedInfo({
+            memberCount: c.member_client_ids?.length ?? 0,
+            displayName: c.display_name ?? c.name,
+          })
+        }
+      }
       if (slRes.ok) setSLs(await slRes.json())
       if (offRes.ok) {
         const o = await offRes.json()
@@ -227,6 +240,16 @@ export default function NewTemplatePage() {
         <header className="space-y-1">
           <h1 className="text-2xl font-semibold tracking-tight text-fg">New routing template</h1>
         </header>
+
+        {combinedInfo && (
+          <div className="rounded-md border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-900">
+            <strong>Combined client.</strong> Properties listed below are unioned from{' '}
+            {combinedInfo.memberCount} member clients. The template will be created with all
+            members linked, and the engine will route across the whole portfolio. Branches and
+            crew config come from this combined client's own settings — make sure you've
+            synced from members or run Branch Optimization on it first.
+          </div>
+        )}
 
         {error && <p className="text-sm text-danger">{error}</p>}
 


### PR DESCRIPTION
## Summary
Last of the three combined-clients PRs. Closes the loop so the standard NewTemplate page works for combined clients with no extra UI — the engine auto-detects \`is_combined\` on the URL clientId and fills \`combined_client_ids\` from \`member_client_ids\`.

## Changes

\`api/scheduler/templates/index.ts\` POST:
- Looks up the URL \`clientId\` in \`clients\`. If \`is_combined=true\`, auto-fills \`combined_client_ids\` from \`member_client_ids\`. No body field required.
- Branch resolution priority for combined templates:
  1. Combined client's **own** \`selected_branches\` (from Sync action or Branch Optimization on the combined client itself) — first-class path.
  2. Fallback: union member clients' \`selected_branches\` deduped by rounded lat/lng — preserves the legacy ad-hoc CombinedSchedules dialog flow.

\`NewTemplate.tsx\`:
- Fetches \`/api/v1/clients/:id\` and shows a banner when combined: \"Properties listed below are unioned from N member clients...\" pointing the user to Sync / Branch Optimization first.

\`regenerate.ts\`: no change. It reads \`tpl.combined_client_ids\` which the create path now persists correctly.

## End-to-end flow
1. **PR1**: Create combined client from any account
2. **PR2**: Open it → Sync from members (banner button) → branches/crews materialize on combined client's constraints. Run Smart Analysis / Branch Optimization → sees full portfolio.
3. **PR3** (this): \"+ New template\" under combined client → engine routes across all member properties using combined client's branches.

## Test plan
- [ ] Create combined client (IFS Utah + IFS Arizona + JLL NV/AZ)
- [ ] Sync from members on combined client
- [ ] Run Branch Optimization on combined client (writes selected_branches to combined's own constraints)
- [ ] New template under combined client → banner shows, properties union members, generate succeeds
- [ ] Cycle places visits using all branches from combined client's selected_branches
- [ ] Existing single-client templates unchanged
- [ ] Existing ad-hoc combined templates (created via CombinedSchedules dialog) still regenerate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)