### PR TITLE
Fix: loadAccountOfferings unions members for combined clients

### DIFF
--- a/api/_lib/analysis/service-offerings.ts
+++ b/api/_lib/analysis/service-offerings.ts
@@ -48,15 +48,60 @@ export function isWorkforceBOffering(name: string): boolean {
 
 // Pull every service_offering visible to (account, client) — the account's
 // account-level offerings plus the named client's own offerings.
+//
+// Combined-client awareness: if clientId points at an is_combined client,
+// expand to each member's (account_id, client_id) pair so the analysis
+// modules see the unioned offering set. Without this, member SLs whose
+// service_offering_id lives in their own account are mis-classified as
+// "other" and contribute zero to building-day / hours math — the symptom
+// being that combined-client per-branch utilization shows wildly low
+// building days for branches whose properties belong to non-host members.
 export async function loadAccountOfferings(
   db: SupabaseClient,
   accountId: string,
   clientId: string
 ): Promise<Map<string, OfferingRow>> {
+  // Resolve the client to detect combined.
+  const { data: cliRow } = await db
+    .from('clients')
+    .select('id, account_id, is_combined, member_client_ids')
+    .eq('id', clientId)
+    .maybeSingle()
+  const cli = cliRow as {
+    id: string
+    account_id: string
+    is_combined: boolean | null
+    member_client_ids: string[] | null
+  } | null
+
+  let orClause: string
+  if (cli?.is_combined && Array.isArray(cli.member_client_ids) && cli.member_client_ids.length > 0) {
+    // For each member, pull (member.account_id, member.id) so we get the
+    // member's account-level + client-level offerings. Also include the
+    // host account's account-level offerings so anything defined at that
+    // tier still flows through.
+    const { data: memberRows } = await db
+      .from('clients')
+      .select('id, account_id')
+      .in('id', cli.member_client_ids)
+    const members = (memberRows ?? []) as Array<{ id: string; account_id: string }>
+    const memberAccountIds = Array.from(new Set(members.map((m) => m.account_id)))
+    const memberClientIds = members.map((m) => m.id)
+    const parts: string[] = [
+      `account_id.eq.${accountId}`,
+      `client_id.eq.${clientId}`,
+    ]
+    if (memberAccountIds.length > 0) parts.push(`account_id.in.(${memberAccountIds.join(',')})`)
+    if (memberClientIds.length > 0) parts.push(`client_id.in.(${memberClientIds.join(',')})`)
+    orClause = parts.join(',')
+  } else {
+    orClause = `account_id.eq.${accountId},client_id.eq.${clientId}`
+  }
+
   const { data: offerings, error } = await db
     .from('service_offerings')
     .select('id, name, pricing_model, default_visits_per_year, default_hours_per_visit, default_crew_size')
-    .or(`account_id.eq.${accountId},client_id.eq.${clientId}`)
+    .or(orClause)
   if (error) throw new Error(`service_offerings lookup failed: ${error.message}`)
 
   const map = new Map<string, OfferingRow>()


### PR DESCRIPTION
## Bug
Per-branch utilization on a combined client showed wildly low building days for branches whose properties belong to non-host members. Reported case: combined client (Utah + Arizona + Nevada, hosted under JLL NV/AZ's account) showed:
- Tempe (Arizona properties): 451 buildings, **210 building days** ← wrong
- Lindon (Utah properties): 643 buildings, **46 building days** ← very wrong
- Las Vegas (Nevada/JLL): 143 buildings, **284 building days** ← correct

## Root cause
\`loadAccountOfferings\` filters offerings by \`account_id = host OR client_id = combined-id\`. A combined client owns no offerings, and member offerings live in the members' own accounts. Member SLs reference offering ids that don't end up in the returned map → \`classifyOffering\` falls back to \`'other'\` → the routed-visits loop skips them → zero (or near-zero) building-day contribution. Vegas was right because the host account *is* JLL NV/AZ's account.

## Fix
When the clientId resolves to \`is_combined\`, expand the \`.or()\` clause to also include each member's \`(account_id, client_id)\` so the unioned offering set comes back. Host account-level offerings still flow through unchanged.

One helper change, but it cascades through all 9 callers: \`crew-strategy\`, \`workforce-sizing\`, \`bid-pricing-structure\`, \`seasonality-capacity\`, \`overnight-breakdown\`, \`run-all-modules\`, \`scheduler/templates\` POST, \`regenerate\`, \`route-day\`.

## Test plan
- [ ] Re-run Smart Analysis on the combined client → Tempe and Lindon now show building days proportional to their property counts
- [ ] Run Crew Strategy → utilization % for each branch is sensible (not 4-21%)
- [ ] Existing per-client analyses unchanged (resolver only kicks in for is_combined=true)

## Open follow-up
The user also wants to specify a **home branch for roving crews** (currently \`crew_count_per_branch_override\` is a flat \`Record<branchName, number>\` with no concept of \"roving with home base\"). That's a separate feature — opening as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)