### PR TITLE
Engine: every crew is roving with home-branch math

### DIFF
--- a/api/_lib/scheduler/build-routing-template.ts
+++ b/api/_lib/scheduler/build-routing-template.ts
@@ -84,6 +84,13 @@ export interface BuildTemplateInput {
   // specified branch (no auto-rebalance for it). All other properties
   // run through the normal capacity-circle algorithm.
   branch_assignment_overrides?: Record<string, number>
+  // Phase 4.7 — explicit per-crew home branch staging from operator
+  // constraints (crew_count_per_branch_override translated to an array
+  // of length=crew_count, each entry an index into branches[]). When
+  // present, supersedes the heuristic in the engine. If absent, the
+  // engine falls back to "first N crews → branch i in order, extras to
+  // busiest branch by cluster work hours."
+  home_branch_indices?: number[]
 }
 
 interface VisitSpec {
@@ -757,22 +764,17 @@ export function buildRoutingTemplate(input: BuildTemplateInput): TemplateBuildRe
     }
   }
 
-  // ── 4. Crew assignment (Phase 4.5 — capacity-aware geographic) ────
-  // Step 1: Pre-seed each crew with a home_branch_index so distance
-  // calculations are well-defined from the FIRST cluster onward. The
-  // earlier version returned distance 0 for empty crews, which made
-  // them silently win every tie even when they shouldn't.
+  // ── 4. Crew assignment (Phase 4.7 — every crew is roving) ─────────
+  // Every crew has a home_branch_index for travel-time math (drive from
+  // home → first job → ... → last job → home). Crews are NEVER capped
+  // to clusters near their home; the engine assigns each cluster to the
+  // best crew globally, weighing drive distance and load balance.
   //
-  // First N crews (where N = min(crew_count, branch_count)) get one
-  // unique branch each. Extra crews (when crew_count > branch_count)
-  // go to the branch with the most cluster work hours.
-  //
-  // Step 2: Each cluster goes first to a same-home-branch crew with
-  // capacity (cluster fits within the crew's remaining workday budget).
-  // If none, spills to the geographically closest crew with capacity.
-  // If everywhere is full, falls back to the closest crew anyway and
-  // emits a crew_load_imbalance warning so the operator knows the
-  // overflow is unavoidable with current crew_count + cycle_length.
+  // Home-branch source priority:
+  //   1. input.home_branch_indices[i] — explicit operator staging from
+  //      crew_count_per_branch_override. This is the first-class path.
+  //   2. Fallback heuristic: crew i → branch i (in input order); extras
+  //      cycle through the branches with the most cluster work hours.
   const workByBranchIdx = new Map<number, number>()
   for (const c of clusters) {
     workByBranchIdx.set(
@@ -784,14 +786,20 @@ export function buildRoutingTemplate(input: BuildTemplateInput): TemplateBuildRe
     .sort((a, b) => b[1] - a[1])
     .map(([idx]) => idx)
 
+  const explicitHomes = Array.isArray(input.home_branch_indices)
+    && input.home_branch_indices.length === input.crew_count
+    ? input.home_branch_indices
+    : null
+
   const crews = Array.from({ length: input.crew_count }, (_, i) => {
     let homeBranchIdx: number
-    if (i < input.branches.length) {
-      // Direct assignment: crew i → branch i, in branch input order.
+    if (explicitHomes && Number.isInteger(explicitHomes[i])
+        && explicitHomes[i] >= 0
+        && explicitHomes[i] < input.branches.length) {
+      homeBranchIdx = explicitHomes[i]
+    } else if (i < input.branches.length) {
       homeBranchIdx = i
     } else if (branchesByLoadDesc.length > 0) {
-      // Extra crews go to the busiest branches in load order, cycling
-      // if there are still more crews than busy branches.
       homeBranchIdx = branchesByLoadDesc[(i - input.branches.length) % branchesByLoadDesc.length]
     } else {
       homeBranchIdx = 0
@@ -807,12 +815,11 @@ export function buildRoutingTemplate(input: BuildTemplateInput): TemplateBuildRe
     }
   })
 
-  // Sort clusters biggest-first: heavy clusters drive the placement
+  // Sort clusters biggest-first: heavy clusters drive placement
   // decisions, smaller ones fill in gaps.
   const sortedClusters = [...clusters].sort((a, b) => b.total_work_hours - a.total_work_hours)
 
   let rebalanceWarning: string | null = null
-  let rebalanceSpillCount = 0
   for (const cluster of sortedClusters) {
     const clusterWorkdays = cluster.days_on_site_per_trip * cluster.trips_per_cycle
 
@@ -825,44 +832,29 @@ export function buildRoutingTemplate(input: BuildTemplateInput): TemplateBuildRe
       )
     }
 
-    // Try same-home-branch crews with capacity first.
-    const naturalFit = crews
-      .filter(
-        (c) =>
-          c.home_branch_index === cluster.base_branch_index &&
-          c.workdays_assigned + clusterWorkdays <= cycleDays
-      )
-      .sort((a, b) => a.workdays_assigned - b.workdays_assigned)
-
+    // Single-tier global assignment: pick the crew with capacity that
+    // minimizes drive distance from home → cluster, breaking ties by
+    // current workload so balance stays sane. No same-branch preference;
+    // a Lindon-home crew can take an Arizona cluster if it's the best
+    // global use of resources. Drive math still uses the crew's home,
+    // so travel time is correctly attributed.
+    const sortedAll = [...crews].sort((a, b) => {
+      const da = distFor(a.home_branch_index)
+      const db = distFor(b.home_branch_index)
+      if (da !== db) return da - db
+      return a.workdays_assigned - b.workdays_assigned
+    })
+    const fittingCrews = sortedAll.filter(
+      (c) => c.workdays_assigned + clusterWorkdays <= cycleDays
+    )
     let target: typeof crews[number]
-    if (naturalFit.length > 0) {
-      target = naturalFit[0]
+    if (fittingCrews.length > 0) {
+      target = fittingCrews[0]
     } else {
-      // Spill to the geographically closest crew with capacity.
-      const fittingCrews = crews
-        .filter((c) => c.workdays_assigned + clusterWorkdays <= cycleDays)
-        .sort((a, b) => {
-          const da = distFor(a.home_branch_index)
-          const db = distFor(b.home_branch_index)
-          if (da !== db) return da - db
-          return a.workdays_assigned - b.workdays_assigned
-        })
-      if (fittingCrews.length > 0) {
-        target = fittingCrews[0]
-        rebalanceSpillCount++
-      } else {
-        // No crew has capacity anywhere — nearest crew anyway, warn.
-        const sortedAll = [...crews].sort((a, b) => {
-          const da = distFor(a.home_branch_index)
-          const db = distFor(b.home_branch_index)
-          if (da !== db) return da - db
-          return a.workdays_assigned - b.workdays_assigned
-        })
-        target = sortedAll[0]
-        if (rebalanceWarning == null) {
-          rebalanceWarning =
-            'All crews exceed cycle capacity — overflow will surface as unplaced. Add a crew or extend cycle_length_days.'
-        }
+      target = sortedAll[0]
+      if (rebalanceWarning == null) {
+        rebalanceWarning =
+          'All crews exceed cycle capacity — overflow will surface as unplaced. Add a crew or extend cycle_length_days.'
       }
     }
 
@@ -1358,11 +1350,6 @@ export function buildRoutingTemplate(input: BuildTemplateInput): TemplateBuildRe
   if (propertiesTransferred > 0) {
     notes.push(
       `Pre-cluster rebalance reassigned ${propertiesTransferred} property(s) to a non-nearest branch (closer-by-cost branch was full; this branch was the next-best fit with capacity).`
-    )
-  }
-  if (rebalanceSpillCount > 0) {
-    notes.push(
-      `Capacity-aware rebalance spilled ${rebalanceSpillCount} cluster(s) from their natural home-branch crew to a next-closest crew with room.`
     )
   }
   if (rebalanceWarning) {

--- a/api/_lib/scheduler/derive-home-branches.ts
+++ b/api/_lib/scheduler/derive-home-branches.ts
@@ -1,0 +1,72 @@
+// Translate operator-supplied per-branch crew counts into a flat array
+// of home_branch_indices (length = crew_count). The engine uses this to
+// stage every crew at a home location for travel-time math while still
+// letting them work anywhere via the global cluster-assignment pass.
+//
+// Rules:
+//  - Per-branch counts are looked up by branch.name (case-insensitive
+//    exact match against the keys of crew_count_per_branch_override).
+//  - If sum(per_branch) < crew_count, the residual crews are staged at
+//    the busiest branch in input order. A small log-only warning would
+//    be ideal here, but the engine doesn't have a logger; the staging
+//    optimizer (PR2) will catch this case in the UI.
+//  - If sum(per_branch) > crew_count, the per-branch counts are scaled
+//    down proportionally and rounded to fit. Operator should normally
+//    enter sum = crew_count; this is a guard.
+//  - If override is null/empty, returns null and the engine falls back
+//    to its default heuristic (crew i → branch i, extras to busiest).
+
+export function deriveHomeBranchIndices(
+  override: Record<string, number> | null | undefined,
+  branches: Array<{ name: string }>,
+  crewCount: number
+): number[] | null {
+  if (!override || branches.length === 0 || crewCount <= 0) return null
+
+  const lowerNameToIdx = new Map<string, number>()
+  branches.forEach((b, i) => lowerNameToIdx.set(b.name.toLowerCase(), i))
+
+  // Normalize keys to indices, dropping any keys that don't map.
+  const counts: Array<{ idx: number; count: number }> = []
+  for (const [key, value] of Object.entries(override)) {
+    const idx = lowerNameToIdx.get(key.toLowerCase())
+    const n = Math.max(0, Math.floor(Number(value) || 0))
+    if (idx == null || n === 0) continue
+    counts.push({ idx, count: n })
+  }
+  if (counts.length === 0) return null
+
+  const totalAssigned = counts.reduce((s, c) => s + c.count, 0)
+  if (totalAssigned > crewCount) {
+    // Scale down proportionally — large rounding doesn't matter much
+    // since the operator should be entering sum = total.
+    const scale = crewCount / totalAssigned
+    let allocated = 0
+    for (const c of counts) {
+      c.count = Math.floor(c.count * scale)
+      allocated += c.count
+    }
+    // Top up any rounding shortfall on the largest entries.
+    counts.sort((a, b) => b.count - a.count)
+    let i = 0
+    while (allocated < crewCount && i < counts.length) {
+      counts[i].count++
+      allocated++
+      i++
+    }
+  }
+
+  // Build the flat array: for each entry, push idx repeated count times.
+  const result: number[] = []
+  for (const c of counts) {
+    for (let j = 0; j < c.count; j++) result.push(c.idx)
+  }
+
+  // Residual crews when sum(per_branch) < crew_count: stage at branch
+  // index 0 (operator UI in PR2 will require sum = total to remove this
+  // case). For now, branch 0 is a defensible default — it's typically
+  // the primary branch in operator input order.
+  while (result.length < crewCount) result.push(0)
+
+  return result
+}

--- a/api/scheduler/templates/[templateId]/regenerate.ts
+++ b/api/scheduler/templates/[templateId]/regenerate.ts
@@ -25,6 +25,7 @@ import {
   buildRoutingTemplate,
   type PropertyForBuild,
 } from '../../../_lib/scheduler/build-routing-template.js'
+import { deriveHomeBranchIndices } from '../../../_lib/scheduler/derive-home-branches.js'
 import {
   applyCohortAssignments,
   loadEligibleProperties,
@@ -333,6 +334,11 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       cycle_start_year: new Date().getUTCFullYear(),
       branch_assignment_overrides:
         (tpl.branch_assignment_overrides as Record<string, number> | null) ?? undefined,
+      home_branch_indices: deriveHomeBranchIndices(
+        constraints.crew_count_per_branch_override,
+        branches,
+        crewCount
+      ) ?? undefined,
     })
 
     if (propertiesMissingCoords.length > 0) {

--- a/api/scheduler/templates/index.ts
+++ b/api/scheduler/templates/index.ts
@@ -13,6 +13,7 @@ import {
   buildRoutingTemplate,
   type PropertyForBuild,
 } from '../../_lib/scheduler/build-routing-template.js'
+import { deriveHomeBranchIndices } from '../../_lib/scheduler/derive-home-branches.js'
 import {
   applyCohortAssignments,
   loadEligibleProperties,
@@ -495,6 +496,11 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           allow_hard_constraint_violation: ((body.preferences as any)?.allow_hard_constraint_violation as boolean | undefined) ?? false,
         },
         cycle_start_year: cycleStartYear,
+        home_branch_indices: deriveHomeBranchIndices(
+          constraints.crew_count_per_branch_override,
+          branches,
+          crewCount
+        ) ?? undefined,
       })
 
       // Splice in the missing-coords properties so the cycle UI surfaces


### PR DESCRIPTION
## Summary
First of two PRs that deliver the \"crews staged at a location but work wherever the schedule tells them\" model. This one rewires the engine; the next one (Crew Strategy enhancement) tells the operator the optimal staging.

## What changed in the engine
Previously, cluster assignment was two-tier:
1. Try same-home-branch crews with capacity (\"natural fit\")
2. If none, spill to nearest crew with capacity

A Lindon-home crew would never take an Arizona cluster unless every Tempe-home crew was already saturated. That's why combining JLL + IFS didn't surface any efficiency wins — the algorithm refused to move work across branches even when it would minimize total drive.

Now: **single global pass**. Each cluster goes to the crew whose home branch is closest, breaking ties on workload balance. Travel-time math still uses the crew's home for first / last legs (so \"home branch matters\" — you're right that without it we can't compute drive time).

## Operator staging plumbed through
The operator's per-branch crew counts (\`crew_count_per_branch_override\`, e.g. \`{Tempe: 2, Lindon: 4, \"Las Vegas\": 1}\`) didn't actually reach the engine before. Added:
- \`BuildTemplateInput.home_branch_indices?: number[]\` — flat array of length=crew_count.
- \`deriveHomeBranchIndices(override, branches, crewCount)\` — translates the operator's record into the flat array. Drops keys that don't match any branch by name. Scales down if sum > total. Stages residual crews at branch 0 when sum < total (the next PR removes this case by requiring sum = total in the UI).
- \`templates/index.ts\` POST and \`templates/[id]/regenerate\` both pass the derived array.

If absent / unusable, falls back to the old heuristic (crew i → branch i, extras to busiest by cluster work hours).

## Test plan
- [ ] Set the combined client's per-branch counts to {Tempe: 2, Lindon: 4, Vegas: 1, residual 3 → branch 0}; generate a template.
- [ ] Verify that all 10 crews appear with sensible home_branch labels.
- [ ] Verify that some Lindon-home crews end up working Arizona clusters when Tempe is busy (or vice-versa) — that's the rove-to-load-balance behavior.
- [ ] Existing single-client templates still optimize (resolver / fallback paths).
- [ ] No more \"Capacity-aware rebalance spilled N cluster(s)\" note in template output (the concept is gone).

## Up next (PR2)
Crew Strategy module computes optimal \`crews_per_branch\` from the property distribution and total crew count. UI gets an \"Apply staging\" button that writes to constraints, removing the residual-crew edge case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)