### PR TITLE
Crew Strategy: optimal staging recommendation + Apply button

### DIFF
--- a/api/analyses/account/[accountId]/clients/[clientId]/crew-strategy.ts
+++ b/api/analyses/account/[accountId]/clients/[clientId]/crew-strategy.ts
@@ -104,6 +104,55 @@ export interface CrewStrategyInputs {
 const DEFAULT_WORKING_DAYS_PER_YEAR = 250
 const ROVING_ESTIMATED_ANNUAL_MILES_PER_CREW = 30000
 
+// Distribute totalCrews across branches proportional to each branch's
+// building-day workload, using the largest-remainder method so the sum
+// matches exactly. Branches with non-zero workload are guaranteed at
+// least 1 crew (pulled from the largest holder if needed). Used by
+// Crew Strategy to recommend optimal staging — one home branch per
+// crew, every crew accounted for, no implicit "roving" residual.
+function computeOptimalStaging(
+  buildingDaysPerBranch: number[],
+  totalCrews: number,
+  branchNames: string[]
+): Array<{ branch_name: string; crew_count: number }> {
+  const out = (counts: number[]) =>
+    branchNames.map((n, i) => ({ branch_name: n, crew_count: counts[i] ?? 0 }))
+  if (totalCrews <= 0 || branchNames.length === 0) return out([])
+  const totalDays = buildingDaysPerBranch.reduce((a, b) => a + b, 0)
+  if (totalDays <= 0) {
+    // No workload signal — even split, ones first.
+    const counts = new Array(branchNames.length).fill(0)
+    for (let i = 0; i < totalCrews; i++) counts[i % branchNames.length]++
+    return out(counts)
+  }
+  const real = buildingDaysPerBranch.map((bd) => (bd / totalDays) * totalCrews)
+  const counts = real.map((r) => Math.floor(r))
+  const remainders = real.map((r, i) => ({ idx: i, frac: r - counts[i] }))
+  let allocated = counts.reduce((a, b) => a + b, 0)
+  remainders.sort((a, b) => b.frac - a.frac)
+  let i = 0
+  while (allocated < totalCrews && i < remainders.length) {
+    counts[remainders[i].idx]++
+    allocated++
+    i++
+  }
+  // Floor: any branch with workload > 0 gets at least 1 crew, pulled
+  // from the largest contributor if the proportional split rounded to 0.
+  for (let b = 0; b < counts.length; b++) {
+    if (counts[b] === 0 && buildingDaysPerBranch[b] > 0) {
+      let largest = 0
+      for (let j = 1; j < counts.length; j++) {
+        if (counts[j] > counts[largest]) largest = j
+      }
+      if (counts[largest] > 1 && largest !== b) {
+        counts[largest]--
+        counts[b]++
+      }
+    }
+  }
+  return out(counts)
+}
+
 function computeFteHoursPerYear(inputs: { hours_per_day: number }, workingDaysPerYear?: number | null): number {
   const days = Number.isFinite(workingDaysPerYear) && (workingDaysPerYear ?? 0) > 0
     ? Number(workingDaysPerYear)
@@ -983,6 +1032,17 @@ export function computeCrewStrategy(
       })),
       roving_crews: rovingCrews,
       dedicated_total: crewsPerBranch.reduce((a, b) => a + b, 0),
+      // Phase 4.7 — every crew has a home branch (engine treats them
+      // all as roving for cluster assignment). Distribute the total
+      // recommended crew count proportional to each branch's natural
+      // workload (building-days), using the largest-remainder method
+      // so sums match exactly. UI shows this as "Optimal staging" with
+      // an "Apply" button that writes to crew_count_per_branch_override.
+      optimal_staging: computeOptimalStaging(
+        branchBuildingDaysList,
+        optionB_crews,
+        branches.map((b) => b.name)
+      ),
       utilization_pct: optionB_util_pct,
       annual_labor_cost: Math.round(optionB_labor),
       annual_vehicle_cost: Math.round(optionB_vehicle),

--- a/src/components/analysis/CrewStrategyChart.tsx
+++ b/src/components/analysis/CrewStrategyChart.tsx
@@ -64,6 +64,13 @@ interface CrewOption {
   }>
   roving_crews?: number
   dedicated_total?: number
+  // Phase 4.7 — every crew has a home branch (engine treats them all
+  // as roving). Optimal staging distributes the total recommended
+  // crews proportionally to each branch's natural workload.
+  optimal_staging?: Array<{
+    branch_name: string
+    crew_count: number
+  }>
   surge_weeks?: number
   utilization_pct: number
   annual_labor_cost: number
@@ -795,20 +802,78 @@ export default function CrewStrategyChart({
                 numbers.
               </p>
             </div>
-            {overrideEnabled && overrideTotal > 0 && (
-              <Button
-                size="sm"
-                variant="secondary"
-                onClick={() => {
-                  setCrewOverride({})
-                  setOverrideEnabled(false)
-                  void saveOverride({}, false)
-                }}
-              >
-                Use Option {activeOption} instead
-              </Button>
-            )}
+            <div className="flex items-center gap-2 flex-wrap">
+              {Array.isArray(data.options.B.optimal_staging) &&
+                data.options.B.optimal_staging.some((s) => s.crew_count > 0) && (
+                  <Button
+                    size="sm"
+                    onClick={() => {
+                      const staging = data.options.B.optimal_staging ?? []
+                      const next: Record<string, number> = {}
+                      for (const s of staging) {
+                        if (s.crew_count > 0) next[s.branch_name] = s.crew_count
+                      }
+                      setCrewOverride(next)
+                      setOverrideEnabled(true)
+                      void saveOverride(next, true)
+                    }}
+                    title="Distribute the recommended total crews across branches proportional to each branch's natural workload (every crew gets a home)."
+                  >
+                    Apply optimal staging
+                  </Button>
+                )}
+              {overrideEnabled && overrideTotal > 0 && (
+                <Button
+                  size="sm"
+                  variant="secondary"
+                  onClick={() => {
+                    setCrewOverride({})
+                    setOverrideEnabled(false)
+                    void saveOverride({}, false)
+                  }}
+                >
+                  Use Option {activeOption} instead
+                </Button>
+              )}
+            </div>
           </div>
+
+          {Array.isArray(data.options.B.optimal_staging) &&
+            data.options.B.optimal_staging.some((s) => s.crew_count > 0) && (
+              <div className="mt-3 rounded-md border border-accent/30 bg-accent-subtle/40 px-3 py-2">
+                <p className="text-[10px] font-semibold uppercase tracking-wider text-fg-subtle">
+                  Optimal staging recommendation
+                </p>
+                <p className="mt-1 text-sm text-fg">
+                  Distribute{' '}
+                  <span className="font-tabular font-semibold">
+                    {data.options.B.optimal_staging.reduce(
+                      (s, x) => s + x.crew_count,
+                      0
+                    )}{' '}
+                    crews
+                  </span>{' '}
+                  proportional to each branch's natural workload — every crew
+                  gets a home, none float without a base. The engine will route
+                  each crew wherever the schedule says.
+                </p>
+                <ul className="mt-2 flex flex-wrap gap-2 text-xs text-fg-muted">
+                  {data.options.B.optimal_staging
+                    .filter((s) => s.crew_count > 0)
+                    .map((s) => (
+                      <li
+                        key={s.branch_name}
+                        className="rounded border border-border bg-surface px-2 py-0.5"
+                      >
+                        <span className="font-tabular font-semibold text-fg">
+                          {s.crew_count}
+                        </span>{' '}
+                        × {s.branch_name}
+                      </li>
+                    ))}
+                </ul>
+              </div>
+            )}
 
           <div className="mt-4 space-y-3">
             <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2">


### PR DESCRIPTION
## Summary
Closes the loop with PR #219 (engine treats every crew as roving). Now Crew Strategy actively tells the operator the optimal staging — \"this is the number of crews you need AND this is where to stage them.\"

## What changed

### Backend (\`crew-strategy\` module)
New \`options.B.optimal_staging: Array<{ branch_name; crew_count }>\` field.

Algorithm: distribute the total recommended crew count proportional to each branch's natural workload (building-days), using the largest-remainder method so the sum matches exactly. Branches with non-zero workload are guaranteed at least 1 crew (pulled from the largest holder if proportional rounding gave it 0).

### Frontend (\`CrewStrategyChart\`)
- New \"Optimal staging recommendation\" callout above the per-branch override grid, listing the proposed counts as chips.
- \"Apply optimal staging\" button writes the recommendation to \`crew_count_per_branch_override\` via the existing PATCH endpoint.

## End-to-end flow
1. Build a combined client (PR #213)
2. Sync from members + run Smart Analysis (PR #214 + #216)
3. Crew Strategy recommends total crews + **optimal staging**
4. Click \"Apply optimal staging\" — writes to constraints
5. Build a routing template — engine reads \`home_branch_indices\` (PR #219), stages every crew at a real branch, lets them work anywhere to minimize total drive

## Test plan
- [ ] On the combined client (Utah + Arizona + Nevada), open Crew Strategy
- [ ] Recommendation card shows e.g. \"3 × Tempe, 5 × Lindon, 2 × Las Vegas\" summing to the recommended total
- [ ] Click \"Apply optimal staging\" — manual override grid populates with those values
- [ ] Build a routing template → all crews get home_branch_indices honoring the staging
- [ ] Existing single-client templates unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)