### PR TITLE
Branch Optimization: soft-adjust k floor instead of hard 400

### DIFF
--- a/api/analyses/account/[accountId]/clients/[clientId]/branch-optimization.ts
+++ b/api/analyses/account/[accountId]/clients/[clientId]/branch-optimization.ts
@@ -79,11 +79,27 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       (body as any).population_constraint ?? constraints.population_constraint,
   }
 
-  // Validate: k_range[0] cannot be smaller than the locked branch count.
-  if (inputs.existing_branches.length > 0 && inputs.k_range[0] < inputs.existing_branches.length) {
-    return res.status(400).json({
-      error: `k cannot be less than existing branch count (${inputs.existing_branches.length})`,
-    })
+  // Soft-adjust: k_range can't drop below the existing branch count
+  // (the optimizer can't suggest removing branches the operator has
+  // committed to). If the request asks for a k_min below existing,
+  // silently bump both bounds up so the optimizer still runs and
+  // surface a note in the summary text. Was previously a hard 400 —
+  // failing the analysis blocked the user from seeing the rest of
+  // the recommendation.
+  const existingN = inputs.existing_branches.length
+  let adjustmentNote: string | null = null
+  if (existingN > 0) {
+    const [origMin, origMax] = inputs.k_range
+    if (origMin < existingN) {
+      const newMax = Math.max(existingN, origMax)
+      inputs.k_range = [existingN, newMax]
+      adjustmentNote =
+        `Bumped k floor from ${origMin} to ${existingN} to honor your ${existingN} existing branch(es). ` +
+        `The optimizer can suggest adding branches but cannot drop any that are already committed.` +
+        (newMax !== origMax
+          ? ` Bumped ceiling from ${origMax} to ${newMax} to keep at least one scenario in scope.`
+          : '')
+    }
   }
 
   // Cache: if a completed run exists with the same inputs hash for this
@@ -133,9 +149,12 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     const allProperties = await loadAccountProperties(db, accountId, clientId)
     const properties = applyExclusions(allProperties, constraints.excluded_property_ids)
     const result = await computeBranchOptimization(properties, inputs)
+    const summaryWithNote = adjustmentNote
+      ? `${adjustmentNote} ${result.summary_text}`
+      : result.summary_text
     await completeAnalysisRecord(db, analysisId, {
-      outputs: result.outputs,
-      summary_text: result.summary_text,
+      outputs: { ...result.outputs, k_floor_adjusted: adjustmentNote },
+      summary_text: summaryWithNote,
       property_count: properties.length,
     })
     return res.status(200).json({ analysis_id: analysisId, status: 'completed' })


### PR DESCRIPTION
## Bug
Running Branch Optimization with \`k_range[0] < existing_branches.length\` (which is the default \`[1, 7]\` whenever you have ≥ 2 existing branches) fails with a 400 \"k cannot be less than existing branch count.\" Reported on a combined client with 4 existing branches across UT/NV/AZ/NM/TX/OK — Branch Optimization wouldn't run at all.

## Fix
Soft-adjust instead of failing:
- If \`k_range[0] < N\` (existing count), bump \`k_range[0]\` to N.
- If \`k_range[1] < N\`, bump that too so the range stays non-empty.
- Add a note to the analysis \`summary_text\` and a structured \`outputs.k_floor_adjusted\` field so the user knows why the suggested K range starts where it does.

The optimizer can suggest **adding** branches but cannot remove existing ones — that constraint is still honored. We just stop hiding it behind a 400.

## Test plan
- [ ] On a combined client with 4 existing branches, run Branch Optimization → succeeds
- [ ] Summary text leads with the adjustment note (\"Bumped k floor from 1 to 4 …\")
- [ ] Suggested K options start at 4, never below
- [ ] Existing single-client runs with no existing branches: behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)