### PR TITLE
Cycle utilization analyzer (Utilization tab)

### DIFF
--- a/api/scheduler/cycles/[cycleId]/idle-analysis.ts
+++ b/api/scheduler/cycles/[cycleId]/idle-analysis.ts
@@ -1,0 +1,236 @@
+// GET /api/scheduler/cycles/[cycleId]/idle-analysis
+//
+// Per-cycle idle-day analyzer. Identifies workdays where each crew has
+// no scheduled work, groups consecutive idle days into streaks, and
+// rolls up by home_branch_index so the operator can see at a glance
+// which branches have unused capacity and whether it shows up as
+// blocks (consider absorbing an overnight trip from elsewhere) or as
+// scattered single days (small unpaired buildings).
+//
+// Reuses computeCrewUtilization() from the scheduler lib for the
+// per-day classification — this endpoint adds streak detection +
+// per-branch rollup on top.
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { createAdminClient } from '../../../_lib/supabase.js'
+import { authenticateRequest } from '../../../_lib/auth.js'
+import { computeCrewUtilization } from '../../../_lib/scheduler/crew-utilization.js'
+
+interface IdleStreak {
+  start_date: string
+  end_date: string
+  length: number
+}
+
+interface CrewSummary {
+  crew_index: number
+  crew_label: string
+  home_branch_index: number | null
+  home_branch_name: string | null
+  workdays_total: number
+  idle_days: number
+  busy_days: number
+  utilization_pct: number
+  streaks: IdleStreak[]
+  longest_streak: number
+  pattern: 'blocks' | 'scattered' | 'mixed' | 'none'
+}
+
+interface BranchSummary {
+  branch_index: number | null
+  branch_name: string
+  crew_count: number
+  workdays_total: number
+  idle_days_total: number
+  busy_days_total: number
+  utilization_pct: number
+  streak_count: number
+  longest_streak: number
+  pattern: 'blocks' | 'scattered' | 'mixed' | 'none'
+  crew_indices: number[]
+}
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method === 'OPTIONS') return res.status(200).end()
+  if (req.method !== 'GET') return res.status(405).json({ error: 'Method not allowed' })
+  try { await authenticateRequest(req) } catch (err: any) {
+    return res.status(err.statusCode ?? 401).json({ error: err.message ?? 'Unauthorized' })
+  }
+  const cycleId = req.query.cycleId as string
+  const db = createAdminClient()
+
+  // Pull cycle + template (for branches + crew_assignments).
+  const { data: cycle, error: cycleErr } = await db
+    .from('cycle_instances')
+    .select('id, template_id, start_date, end_date')
+    .eq('id', cycleId)
+    .maybeSingle()
+  if (cycleErr) return res.status(500).json({ error: cycleErr.message })
+  if (!cycle) return res.status(404).json({ error: 'Cycle not found' })
+
+  const { data: tpl } = await db
+    .from('routing_templates')
+    .select('crew_count, crew_assignments, branches')
+    .eq('id', (cycle as any).template_id)
+    .maybeSingle()
+  const crewCount = (tpl as any)?.crew_count ?? 1
+  const branches = ((tpl as any)?.branches ?? []) as Array<{ name: string; lat: number; lng: number }>
+  const crewAssignments = ((tpl as any)?.crew_assignments ?? []) as Array<{
+    index?: number
+    label?: string
+    home_branch_index?: number
+  }>
+
+  // crew_index → home_branch_index (template snapshot, taken at build time).
+  const homeByCrewIdx = new Map<number, number>()
+  for (const ca of crewAssignments) {
+    const idx = ca.index
+    if (typeof idx === 'number' && typeof ca.home_branch_index === 'number') {
+      homeByCrewIdx.set(idx, ca.home_branch_index)
+    }
+  }
+
+  // Per-day utilization (reuses scheduler's authoritative classifier).
+  const days = await computeCrewUtilization(db, cycleId, { include_weekends: false })
+  // We only care about workdays here (between_trips, travel, rest, idle,
+  // overnight_continuation, fully_utilized are all workday categories).
+  const workdays = days.filter((d) => d.is_workday)
+
+  // Group by crew index for streak analysis.
+  const byCrew = new Map<number, typeof workdays>()
+  for (const d of workdays) {
+    const arr = byCrew.get(d.crew_index) ?? []
+    arr.push(d)
+    byCrew.set(d.crew_index, arr)
+  }
+
+  // For each crew, sort by date and walk it computing streaks of idle.
+  // We treat 'between_trips' and 'idle' as "available capacity" — both
+  // are workdays where the crew has no committed work. travel/rest/
+  // overnight_continuation are NOT idle (the crew is occupied).
+  const crewSummaries: CrewSummary[] = []
+  for (let crewIdx = 0; crewIdx < crewCount; crewIdx++) {
+    const arr = (byCrew.get(crewIdx) ?? []).slice().sort((a, b) =>
+      a.scheduled_date.localeCompare(b.scheduled_date)
+    )
+    const homeIdx = homeByCrewIdx.get(crewIdx) ?? null
+    const homeName = homeIdx != null ? (branches[homeIdx]?.name ?? null) : null
+
+    const streaks: IdleStreak[] = []
+    let cur: { start: string; end: string; length: number } | null = null
+    let busy = 0
+    for (const d of arr) {
+      const isIdleish =
+        d.state.kind === 'idle' ||
+        d.state.kind === 'between_trips'
+      if (isIdleish) {
+        if (cur) {
+          cur.end = d.scheduled_date
+          cur.length += 1
+        } else {
+          cur = { start: d.scheduled_date, end: d.scheduled_date, length: 1 }
+        }
+      } else {
+        busy += 1
+        if (cur) {
+          streaks.push({ start_date: cur.start, end_date: cur.end, length: cur.length })
+          cur = null
+        }
+      }
+    }
+    if (cur) streaks.push({ start_date: cur.start, end_date: cur.end, length: cur.length })
+
+    const idle = streaks.reduce((s, x) => s + x.length, 0)
+    const total = arr.length
+    const longest = streaks.reduce((m, s) => Math.max(m, s.length), 0)
+    const avgStreak = streaks.length > 0 ? idle / streaks.length : 0
+    let pattern: CrewSummary['pattern'] = 'none'
+    if (idle > 0) {
+      if (avgStreak >= 3) pattern = 'blocks'
+      else if (avgStreak < 1.5) pattern = 'scattered'
+      else pattern = 'mixed'
+    }
+
+    crewSummaries.push({
+      crew_index: crewIdx,
+      crew_label: arr[0]?.crew_label ?? `Crew ${crewIdx + 1}`,
+      home_branch_index: homeIdx,
+      home_branch_name: homeName,
+      workdays_total: total,
+      idle_days: idle,
+      busy_days: busy,
+      utilization_pct: total > 0 ? Math.round(((total - idle) / total) * 100) : 0,
+      streaks,
+      longest_streak: longest,
+      pattern,
+    })
+  }
+
+  // Branch rollup.
+  const byBranch = new Map<number | null, CrewSummary[]>()
+  for (const c of crewSummaries) {
+    const key = c.home_branch_index
+    const arr = byBranch.get(key) ?? []
+    arr.push(c)
+    byBranch.set(key, arr)
+  }
+  const branchSummaries: BranchSummary[] = []
+  for (const [branchIdx, crews] of byBranch.entries()) {
+    const idleTotal = crews.reduce((s, c) => s + c.idle_days, 0)
+    const wkTotal = crews.reduce((s, c) => s + c.workdays_total, 0)
+    const busyTotal = wkTotal - idleTotal
+    const allStreaks = crews.flatMap((c) => c.streaks)
+    const longest = allStreaks.reduce((m, s) => Math.max(m, s.length), 0)
+    const avgStreak = allStreaks.length > 0 ? idleTotal / allStreaks.length : 0
+    let pattern: BranchSummary['pattern'] = 'none'
+    if (idleTotal > 0) {
+      if (avgStreak >= 3) pattern = 'blocks'
+      else if (avgStreak < 1.5) pattern = 'scattered'
+      else pattern = 'mixed'
+    }
+    branchSummaries.push({
+      branch_index: branchIdx,
+      branch_name:
+        branchIdx != null
+          ? (branches[branchIdx]?.name ?? `Branch ${branchIdx}`)
+          : 'Unassigned',
+      crew_count: crews.length,
+      workdays_total: wkTotal,
+      idle_days_total: idleTotal,
+      busy_days_total: busyTotal,
+      utilization_pct: wkTotal > 0 ? Math.round((busyTotal / wkTotal) * 100) : 0,
+      streak_count: allStreaks.length,
+      longest_streak: longest,
+      pattern,
+      crew_indices: crews.map((c) => c.crew_index),
+    })
+  }
+  // Branches with the most idle days first — that's where the operator's
+  // attention should land.
+  branchSummaries.sort((a, b) => b.idle_days_total - a.idle_days_total)
+
+  // Portfolio rollup.
+  const portfolio = {
+    crew_count: crewSummaries.length,
+    workdays_total: crewSummaries.reduce((s, c) => s + c.workdays_total, 0),
+    idle_days_total: crewSummaries.reduce((s, c) => s + c.idle_days, 0),
+    utilization_pct: 0,
+    longest_streak: crewSummaries.reduce((m, c) => Math.max(m, c.longest_streak), 0),
+  }
+  portfolio.utilization_pct =
+    portfolio.workdays_total > 0
+      ? Math.round(
+          ((portfolio.workdays_total - portfolio.idle_days_total) /
+            portfolio.workdays_total) *
+            100
+        )
+      : 0
+
+  return res.status(200).json({
+    cycle_id: cycleId,
+    cycle_start: (cycle as any).start_date,
+    cycle_end: (cycle as any).end_date,
+    portfolio,
+    by_branch: branchSummaries,
+    by_crew: crewSummaries,
+  })
+}

--- a/src/components/scheduler/UtilizationPanel.tsx
+++ b/src/components/scheduler/UtilizationPanel.tsx
@@ -1,0 +1,340 @@
+// Cycle utilization analyzer — surfaces idle days per home branch with
+// streak detection ("blocks" vs "scattered"). Two-column layout:
+//   left  = per-branch rollup table
+//   right = drill-down to crews homed at the selected branch, each
+//           with a date strip showing busy vs idle days.
+//
+// The endpoint /api/scheduler/cycles/[id]/idle-analysis does the math;
+// this component renders.
+import { useEffect, useMemo, useState } from 'react'
+import { useAuth } from '../../hooks/useAuth'
+import { Card, CardTitle } from '../ui/Card'
+import { Badge } from '../ui/Badge'
+import { cn } from '../../lib/cn'
+
+interface IdleStreak {
+  start_date: string
+  end_date: string
+  length: number
+}
+
+interface CrewSummary {
+  crew_index: number
+  crew_label: string
+  home_branch_index: number | null
+  home_branch_name: string | null
+  workdays_total: number
+  idle_days: number
+  busy_days: number
+  utilization_pct: number
+  streaks: IdleStreak[]
+  longest_streak: number
+  pattern: 'blocks' | 'scattered' | 'mixed' | 'none'
+}
+
+interface BranchSummary {
+  branch_index: number | null
+  branch_name: string
+  crew_count: number
+  workdays_total: number
+  idle_days_total: number
+  busy_days_total: number
+  utilization_pct: number
+  streak_count: number
+  longest_streak: number
+  pattern: 'blocks' | 'scattered' | 'mixed' | 'none'
+  crew_indices: number[]
+}
+
+interface IdleAnalysis {
+  cycle_id: string
+  cycle_start: string
+  cycle_end: string
+  portfolio: {
+    crew_count: number
+    workdays_total: number
+    idle_days_total: number
+    utilization_pct: number
+    longest_streak: number
+  }
+  by_branch: BranchSummary[]
+  by_crew: CrewSummary[]
+}
+
+const PATTERN_TIPS: Record<BranchSummary['pattern'], string> = {
+  blocks: 'Idle days cluster into multi-day blocks — could absorb a multi-day overnight trip from elsewhere.',
+  scattered: 'Idle days are mostly single days — typical for unpaired small properties; consider in-day pairing rules.',
+  mixed: 'Mix of single-day idles and small blocks.',
+  none: 'No idle days detected.',
+}
+
+const PATTERN_BADGE: Record<BranchSummary['pattern'], 'success' | 'warning' | 'accent' | 'outline'> = {
+  blocks: 'warning',
+  scattered: 'accent',
+  mixed: 'accent',
+  none: 'success',
+}
+
+export default function UtilizationPanel({ cycleId }: { cycleId: string }) {
+  const { getToken } = useAuth()
+  const [data, setData] = useState<IdleAnalysis | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [selectedBranchKey, setSelectedBranchKey] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    ;(async () => {
+      setLoading(true)
+      try {
+        const token = await getToken()
+        const res = await fetch(`/api/scheduler/cycles/${cycleId}/idle-analysis`, {
+          headers: { Authorization: `Bearer ${token}` },
+        })
+        if (!res.ok) throw new Error(`Load failed (${res.status})`)
+        const j = (await res.json()) as IdleAnalysis
+        if (!cancelled) {
+          setData(j)
+          if (j.by_branch.length > 0 && !selectedBranchKey) {
+            setSelectedBranchKey(branchKey(j.by_branch[0]))
+          }
+        }
+      } catch (err) {
+        if (!cancelled) setError(err instanceof Error ? err.message : String(err))
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    })()
+    return () => { cancelled = true }
+  }, [cycleId, getToken])
+
+  const days = useMemo(() => {
+    if (!data) return [] as string[]
+    const out: string[] = []
+    const start = new Date(data.cycle_start + 'T00:00:00Z')
+    const end = new Date(data.cycle_end + 'T00:00:00Z')
+    for (let d = new Date(start); d <= end; d.setUTCDate(d.getUTCDate() + 1)) {
+      const dow = d.getUTCDay()
+      if (dow === 0 || dow === 6) continue
+      out.push(d.toISOString().slice(0, 10))
+    }
+    return out
+  }, [data])
+
+  const selectedBranch = useMemo(() => {
+    if (!data || !selectedBranchKey) return null
+    return data.by_branch.find((b) => branchKey(b) === selectedBranchKey) ?? null
+  }, [data, selectedBranchKey])
+
+  const selectedCrews = useMemo(() => {
+    if (!data || !selectedBranch) return []
+    const ids = new Set(selectedBranch.crew_indices)
+    return data.by_crew.filter((c) => ids.has(c.crew_index))
+  }, [data, selectedBranch])
+
+  if (loading) return <p className="text-sm text-fg-muted">Computing utilization…</p>
+  if (error) return <p className="text-sm text-danger">{error}</p>
+  if (!data) return null
+
+  return (
+    <div className="space-y-4">
+      <Card>
+        <div className="flex items-baseline justify-between gap-4 flex-wrap">
+          <div>
+            <CardTitle>Cycle utilization</CardTitle>
+            <p className="text-xs text-fg-subtle mt-1">
+              {data.cycle_start} → {data.cycle_end} · {data.portfolio.crew_count} crews ·{' '}
+              {data.portfolio.workdays_total} workdays total
+            </p>
+          </div>
+          <div className="flex items-center gap-4 text-sm">
+            <Stat label="Utilization" value={`${data.portfolio.utilization_pct}%`} />
+            <Stat label="Idle days" value={data.portfolio.idle_days_total.toString()} />
+            <Stat label="Longest idle run" value={`${data.portfolio.longest_streak} day${data.portfolio.longest_streak === 1 ? '' : 's'}`} />
+          </div>
+        </div>
+      </Card>
+
+      <div className="grid grid-cols-1 lg:grid-cols-5 gap-4">
+        {/* Per-branch rollup */}
+        <Card padding="none" className="lg:col-span-2 overflow-hidden">
+          <div className="px-4 py-3 border-b border-border">
+            <CardTitle>By home branch</CardTitle>
+            <p className="text-xs text-fg-subtle mt-0.5">
+              Click a row to drill down. Branches with the most idle days are
+              listed first.
+            </p>
+          </div>
+          <div className="divide-y divide-border">
+            {data.by_branch.map((b) => {
+              const key = branchKey(b)
+              const isSel = key === selectedBranchKey
+              return (
+                <button
+                  type="button"
+                  key={key}
+                  onClick={() => setSelectedBranchKey(key)}
+                  className={cn(
+                    'w-full px-4 py-3 text-left transition-colors',
+                    isSel ? 'bg-accent-subtle/50' : 'hover:bg-surface-subtle/40'
+                  )}
+                >
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="font-medium text-fg truncate">{b.branch_name}</span>
+                    <Badge variant={PATTERN_BADGE[b.pattern]} className="text-[10px]">
+                      {b.pattern}
+                    </Badge>
+                  </div>
+                  <div className="mt-1 flex items-center gap-3 text-xs text-fg-muted">
+                    <span>
+                      <span className="font-tabular text-fg">{b.crew_count}</span> crews
+                    </span>
+                    <span>
+                      <span className="font-tabular text-fg">{b.idle_days_total}</span> idle
+                    </span>
+                    {b.longest_streak > 0 && (
+                      <span>
+                        longest{' '}
+                        <span className="font-tabular text-fg">{b.longest_streak}</span>d
+                      </span>
+                    )}
+                    <span className="ml-auto font-tabular text-fg">
+                      {b.utilization_pct}%
+                    </span>
+                  </div>
+                  <UtilizationBar
+                    busy={b.busy_days_total}
+                    idle={b.idle_days_total}
+                  />
+                </button>
+              )
+            })}
+          </div>
+        </Card>
+
+        {/* Per-crew drilldown */}
+        <Card padding="none" className="lg:col-span-3 overflow-hidden">
+          <div className="px-4 py-3 border-b border-border">
+            <CardTitle>
+              {selectedBranch ? selectedBranch.branch_name : 'Select a branch'}
+            </CardTitle>
+            {selectedBranch && (
+              <p className="text-xs text-fg-subtle mt-0.5">
+                {PATTERN_TIPS[selectedBranch.pattern]}
+              </p>
+            )}
+          </div>
+          {selectedBranch && selectedCrews.length > 0 ? (
+            <div className="divide-y divide-border">
+              {selectedCrews.map((c) => (
+                <CrewRow key={c.crew_index} crew={c} days={days} />
+              ))}
+            </div>
+          ) : (
+            <p className="px-4 py-6 text-sm text-fg-subtle">
+              No crews to display.
+            </p>
+          )}
+        </Card>
+      </div>
+    </div>
+  )
+}
+
+function CrewRow({ crew, days }: { crew: CrewSummary; days: string[] }) {
+  const idleSet = useMemo(() => {
+    const s = new Set<string>()
+    for (const streak of crew.streaks) {
+      // Walk from start to end inclusive.
+      const start = new Date(streak.start_date + 'T00:00:00Z')
+      const end = new Date(streak.end_date + 'T00:00:00Z')
+      for (let d = new Date(start); d <= end; d.setUTCDate(d.getUTCDate() + 1)) {
+        s.add(d.toISOString().slice(0, 10))
+      }
+    }
+    return s
+  }, [crew.streaks])
+
+  return (
+    <div className="px-4 py-3 space-y-2">
+      <div className="flex items-center justify-between gap-3 flex-wrap">
+        <div className="flex items-center gap-2 min-w-0">
+          <span className="text-sm font-medium text-fg truncate">
+            {crew.crew_label}
+          </span>
+          <Badge variant={crew.pattern === 'blocks' ? 'warning' : 'outline'} className="text-[10px]">
+            {crew.pattern}
+          </Badge>
+        </div>
+        <div className="flex items-center gap-3 text-xs text-fg-muted">
+          <span>
+            <span className="font-tabular text-fg">{crew.busy_days}</span> busy
+          </span>
+          <span>
+            <span className="font-tabular text-fg">{crew.idle_days}</span> idle
+          </span>
+          {crew.longest_streak > 0 && (
+            <span>
+              longest <span className="font-tabular text-fg">{crew.longest_streak}</span>d
+            </span>
+          )}
+          <span className="font-tabular text-fg">{crew.utilization_pct}%</span>
+        </div>
+      </div>
+      {/* Date strip: one cell per workday. Idle = gray, busy = accent. */}
+      <div
+        className="flex gap-px overflow-x-auto rounded border border-border p-0.5 bg-surface-subtle/30"
+        style={{ minHeight: 18 }}
+      >
+        {days.map((d) => {
+          const idle = idleSet.has(d)
+          return (
+            <div
+              key={d}
+              className={cn(
+                'h-3.5 flex-shrink-0 rounded-sm',
+                idle ? 'bg-fg-subtle/30' : 'bg-accent/70'
+              )}
+              style={{ width: 4 }}
+              title={`${d} · ${idle ? 'idle' : 'busy'}`}
+            />
+          )
+        })}
+      </div>
+      {crew.streaks.length > 0 && (
+        <p className="text-[11px] text-fg-subtle">
+          Idle streaks:{' '}
+          {crew.streaks
+            .map((s) => `${s.start_date}${s.length > 1 ? `→${s.end_date} (${s.length}d)` : ''}`)
+            .join(' · ')}
+        </p>
+      )}
+    </div>
+  )
+}
+
+function UtilizationBar({ busy, idle }: { busy: number; idle: number }) {
+  const total = busy + idle
+  if (total === 0) return null
+  const busyPct = (busy / total) * 100
+  return (
+    <div className="mt-2 h-1.5 w-full rounded-full bg-fg-subtle/20 overflow-hidden">
+      <div className="h-full bg-accent" style={{ width: `${busyPct}%` }} />
+    </div>
+  )
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex flex-col items-end leading-tight">
+      <span className="font-mono font-semibold text-base text-fg">{value}</span>
+      <span className="text-[10px] uppercase tracking-wide text-fg-subtle">
+        {label}
+      </span>
+    </div>
+  )
+}
+
+function branchKey(b: BranchSummary): string {
+  return b.branch_index == null ? `__none__` : `b${b.branch_index}`
+}

--- a/src/components/scheduler/ViewSwitcher.tsx
+++ b/src/components/scheduler/ViewSwitcher.tsx
@@ -1,16 +1,17 @@
 // Phase 4f-1 — view switcher tabs (Gantt / Calendar / List / Map).
 // Keyboard shortcuts: 1, 2, 3, 4.
 import { useEffect } from 'react'
-import { LayoutGrid, Calendar, List, Map as MapIcon } from 'lucide-react'
+import { LayoutGrid, Calendar, List, Map as MapIcon, Activity } from 'lucide-react'
 import { cn } from '../../lib/cn'
 
-export type CycleViewKind = 'gantt' | 'calendar' | 'list' | 'map'
+export type CycleViewKind = 'gantt' | 'calendar' | 'list' | 'map' | 'utilization'
 
 const VIEWS: Array<{ key: CycleViewKind; label: string; icon: any; shortcut: string }> = [
   { key: 'gantt', label: 'Gantt', icon: LayoutGrid, shortcut: '1' },
   { key: 'calendar', label: 'Calendar', icon: Calendar, shortcut: '2' },
   { key: 'list', label: 'List', icon: List, shortcut: '3' },
   { key: 'map', label: 'Map', icon: MapIcon, shortcut: '4' },
+  { key: 'utilization', label: 'Utilization', icon: Activity, shortcut: '5' },
 ]
 
 interface Props {

--- a/src/pages/accounts/scheduler/CycleDetail.tsx
+++ b/src/pages/accounts/scheduler/CycleDetail.tsx
@@ -21,6 +21,7 @@ import ViewSwitcher, { type CycleViewKind } from '../../../components/scheduler/
 import GanttView, { type UtilDay } from '../../../components/scheduler/GanttView'
 import CalendarView from '../../../components/scheduler/CalendarView'
 import CycleMapView from '../../../components/scheduler/CycleMapView'
+import UtilizationPanel from '../../../components/scheduler/UtilizationPanel'
 import HistoryDrawer from '../../../components/scheduler/HistoryDrawer'
 import CycleChatDrawer from '../../../components/scheduler/CycleChatDrawer'
 import RebalanceSuggestionsDialog from '../../../components/scheduler/RebalanceSuggestionsDialog'
@@ -868,6 +869,10 @@ export default function CycleDetailPage() {
               cycleEnd={cycle.end_date}
             />
           </div>
+        )}
+
+        {view === 'utilization' && cycleId && (
+          <UtilizationPanel cycleId={cycleId} />
         )}
 
         {/* List view: existing crew_days + visits tables */}


### PR DESCRIPTION
## Summary
New \"Utilization\" tab on Cycle Detail (kbd shortcut **5**) that analyzes idle days post-cycle-generation: where they live (which home branch), and whether they show up as **blocks** (absorbable by a multi-day overnight from elsewhere) or **scattered** (typical of unpaired small properties).

## Backend
\`GET /api/scheduler/cycles/[cycleId]/idle-analysis\`
- Reuses \`computeCrewUtilization()\` from the scheduler lib (so the per-day classification matches everywhere else in the app).
- Walks each crew's workday timeline, groups consecutive idle days (\`kind ∈ {idle, between_trips}\`) into streaks.
- Maps each crew → \`home_branch_index\` from template \`crew_assignments\`, rolls up per branch.
- Classifies pattern: \`blocks\` (avg streak ≥ 3), \`scattered\` (avg streak < 1.5), \`mixed\`, or \`none\`.

## Frontend (\`UtilizationPanel\`)
Two-column layout:
- **Left** — per-branch table sorted by idle-days desc. Each row: crew count, idle total, longest streak, utilization %, mini busy/idle bar. Click to drill down.
- **Right** — per-crew rows for the selected branch. Each crew gets a date strip (one cell per workday, grey = idle, accent = busy) and a list of streaks with start/end and length.

Pattern badges with hover tooltips explaining the operational implication (\"absorb a multi-day overnight from elsewhere\" vs. \"consider in-day pairing rules\").

## Out of scope
Auto-suggesting \"move trip X to crew Y on these idle days\". The existing \`rebalance-suggestions\` endpoint already does this for **unplaced** visits; extending to **placed** visits is the natural follow-up once we've used the analyzer for a few cycles.

## Test plan
- [ ] Open any generated cycle → switch to Utilization tab via keyboard \"5\" or click
- [ ] Top stat row shows portfolio crew count / utilization / longest idle run
- [ ] Per-branch table lists each home branch with its rollup; clicking selects
- [ ] Per-crew strip for selected branch shows busy/idle pattern
- [ ] Branches sorted by idle days desc

🤖 Generated with [Claude Code](https://claude.com/claude-code)