### PR TITLE
Fix: routing templates list shows combined-client templates

### DIFF
--- a/api/scheduler/templates/index.ts
+++ b/api/scheduler/templates/index.ts
@@ -50,7 +50,23 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     if (wantCombined) {
       q = q.not('combined_client_ids', 'is', null)
     } else {
-      q = q.eq('client_id', clientId!).is('combined_client_ids', null)
+      // Per-client list: filter by client_id. The legacy ad-hoc combined-
+      // templates flow (CombinedSchedules dialog) sets client_id = the
+      // base MEMBER client, so those rows would otherwise leak into a
+      // member's per-client list. Exclude them — UNLESS the requested
+      // client_id is itself a combined client, in which case its own
+      // templates legitimately have combined_client_ids set (PR #215
+      // auto-fills them on create) and must NOT be filtered out.
+      const { data: cliRow } = await db
+        .from('clients')
+        .select('id, is_combined')
+        .eq('id', clientId!)
+        .maybeSingle()
+      const isCombinedClient = (cliRow as any)?.is_combined === true
+      q = q.eq('client_id', clientId!)
+      if (!isCombinedClient) {
+        q = q.is('combined_client_ids', null)
+      }
     }
     const status = req.query.status as string | undefined
     if (status) q = q.in('status', String(status).split(','))


### PR DESCRIPTION
## Bug
Templates created under a combined client save fine (you can run cycles, view them, etc.), but navigating away and back into the combined client shows an empty Templates list — the rows are in the DB but invisible to the listing endpoint.

## Root cause
\`GET /api/scheduler/templates?account_id=X&client_id=Y\` filters with \`.is('combined_client_ids', null)\`. That filter exists to exclude **legacy ad-hoc combined templates** (created via the old CombinedSchedules dialog with \`client_id = base member client\`) from a member's per-client list — a real concern.

But templates created under a **first-class combined client** (PR #215 onward) always have \`combined_client_ids\` set (auto-filled from \`member_client_ids\` at create time). So the filter excluded them too.

## Fix
Detect whether the requested \`client_id\` is itself a combined client:
- **Combined client** (\`is_combined=true\`) → drop the is-null filter; show all its templates regardless of \`combined_client_ids\` value.
- **Normal client** → keep the filter (legacy ad-hoc combined templates stay excluded from member lists).

## Test plan
- [ ] Create a routing template under a combined client → save it
- [ ] Navigate away (e.g. back to AccountDetail) → return to the combined client → Templates list shows the template
- [ ] Member client lists still exclude any legacy ad-hoc combined templates pinned to them
- [ ] Account-level Combined Schedules page still lists all combined templates (no change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)