### PR TITLE
Cycle calibration card — Crew Strategy prediction vs reality

### DIFF
--- a/api/scheduler/cycles/[cycleId]/idle-analysis.ts
+++ b/api/scheduler/cycles/[cycleId]/idle-analysis.ts
@@ -80,6 +80,17 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     home_branch_index?: number
   }>
 
+  // Unplaced visits — we use the count to compute "what you'd actually
+  // need to cover everything" (the recommended crew count in the
+  // calibration block below). One unplaced visit ≈ one crew-day of
+  // missing capacity (conservative; some unplaced are partial-day).
+  const { count: unplacedCountRaw } = await db
+    .from('scheduled_visits')
+    .select('id', { count: 'exact', head: true })
+    .eq('cycle_instance_id', cycleId)
+    .eq('status', 'unplaced')
+  const unplacedCount = unplacedCountRaw ?? 0
+
   // crew_index → home_branch_index (template snapshot, taken at build time).
   const homeByCrewIdx = new Map<number, number>()
   for (const ca of crewAssignments) {
@@ -213,23 +224,64 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     crew_count: crewSummaries.length,
     workdays_total: crewSummaries.reduce((s, c) => s + c.workdays_total, 0),
     idle_days_total: crewSummaries.reduce((s, c) => s + c.idle_days, 0),
+    busy_days_total: 0,
+    unplaced_count: unplacedCount,
     utilization_pct: 0,
     longest_streak: crewSummaries.reduce((m, c) => Math.max(m, c.longest_streak), 0),
   }
+  portfolio.busy_days_total = portfolio.workdays_total - portfolio.idle_days_total
   portfolio.utilization_pct =
     portfolio.workdays_total > 0
+      ? Math.round((portfolio.busy_days_total / portfolio.workdays_total) * 100)
+      : 0
+
+  // Calibration: compare the predicted crew count (what Crew Strategy
+  // recommended and what the template was built with) against what was
+  // actually consumed. Two flavors of recommendation:
+  //   effective_crews — minimum crews needed to cover what got placed
+  //                     (busy_days / workdays_per_crew). If the predicted
+  //                     count is higher, you have wasted capacity.
+  //   recommended_crews — minimum crews needed to cover busy + unplaced.
+  //                     If the predicted count is lower (or equal), you
+  //                     dropped work that more crews could have absorbed.
+  const workdaysPerCrew =
+    crewSummaries.length > 0
       ? Math.round(
-          ((portfolio.workdays_total - portfolio.idle_days_total) /
-            portfolio.workdays_total) *
-            100
+          crewSummaries.reduce((s, c) => s + c.workdays_total, 0) / crewSummaries.length
         )
       : 0
+  const effectiveCrews =
+    workdaysPerCrew > 0
+      ? Math.max(0, Math.ceil(portfolio.busy_days_total / workdaysPerCrew))
+      : 0
+  const recommendedCrews =
+    workdaysPerCrew > 0
+      ? Math.max(
+          0,
+          Math.ceil((portfolio.busy_days_total + unplacedCount) / workdaysPerCrew)
+        )
+      : 0
+  let calibrationVerdict: 'overstaffed' | 'understaffed' | 'balanced'
+  if (recommendedCrews > crewCount) calibrationVerdict = 'understaffed'
+  else if (effectiveCrews < crewCount) calibrationVerdict = 'overstaffed'
+  else calibrationVerdict = 'balanced'
+  const calibration = {
+    predicted_crews: crewCount,
+    effective_crews: effectiveCrews,
+    recommended_crews: recommendedCrews,
+    workdays_per_crew: workdaysPerCrew,
+    busy_days_total: portfolio.busy_days_total,
+    unplaced_count: unplacedCount,
+    delta_vs_recommended: crewCount - recommendedCrews,
+    verdict: calibrationVerdict,
+  }
 
   return res.status(200).json({
     cycle_id: cycleId,
     cycle_start: (cycle as any).start_date,
     cycle_end: (cycle as any).end_date,
     portfolio,
+    calibration,
     by_branch: branchSummaries,
     by_crew: crewSummaries,
   })

--- a/src/components/scheduler/UtilizationPanel.tsx
+++ b/src/components/scheduler/UtilizationPanel.tsx
@@ -10,6 +10,7 @@ import { useEffect, useMemo, useState } from 'react'
 import { useAuth } from '../../hooks/useAuth'
 import { Card, CardTitle } from '../ui/Card'
 import { Badge } from '../ui/Badge'
+import Button from '../ui/Button'
 import { cn } from '../../lib/cn'
 
 interface IdleStreak {
@@ -54,8 +55,20 @@ interface IdleAnalysis {
     crew_count: number
     workdays_total: number
     idle_days_total: number
+    busy_days_total?: number
+    unplaced_count?: number
     utilization_pct: number
     longest_streak: number
+  }
+  calibration?: {
+    predicted_crews: number
+    effective_crews: number
+    recommended_crews: number
+    workdays_per_crew: number
+    busy_days_total: number
+    unplaced_count: number
+    delta_vs_recommended: number
+    verdict: 'overstaffed' | 'understaffed' | 'balanced'
   }
   by_branch: BranchSummary[]
   by_crew: CrewSummary[]
@@ -75,12 +88,126 @@ const PATTERN_BADGE: Record<BranchSummary['pattern'], 'success' | 'warning' | 'a
   none: 'success',
 }
 
-export default function UtilizationPanel({ cycleId }: { cycleId: string }) {
+export default function UtilizationPanel({
+  cycleId,
+  accountId,
+  clientId,
+}: {
+  cycleId: string
+  accountId?: string | null
+  clientId?: string | null
+}) {
   const { getToken } = useAuth()
   const [data, setData] = useState<IdleAnalysis | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [selectedBranchKey, setSelectedBranchKey] = useState<string | null>(null)
+  const [applyingCalibration, setApplyingCalibration] = useState(false)
+  const [calibrationApplied, setCalibrationApplied] = useState<{
+    new_total: number
+    new_per_branch: Record<string, number>
+  } | null>(null)
+  const [calibrationError, setCalibrationError] = useState<string | null>(null)
+
+  async function applyCalibration() {
+    if (!data?.calibration || !accountId || !clientId) return
+    setApplyingCalibration(true)
+    setCalibrationError(null)
+    try {
+      const token = await getToken()
+      // Read the current per-branch override so we can scale it down
+      // (or up) to match the recommended total. Falls back to even
+      // distribution across branches with crews if no override exists.
+      const conRes = await fetch(
+        `/api/accounts/${accountId}/clients/${clientId}/operational-constraints`,
+        { headers: { Authorization: `Bearer ${token}` } }
+      )
+      if (!conRes.ok) throw new Error(`Constraints load failed (${conRes.status})`)
+      const con = await conRes.json()
+      const current = (con?.crew_count_per_branch_override ?? {}) as Record<string, number>
+      // Drop the legacy '__roving' key — calibration assumes every crew
+      // has a home (the new model).
+      const cleaned: Record<string, number> = {}
+      let curTotal = 0
+      for (const [k, v] of Object.entries(current)) {
+        if (k === '__roving') continue
+        const n = Math.floor(Number(v) || 0)
+        if (n > 0) {
+          cleaned[k] = n
+          curTotal += n
+        }
+      }
+      // If nothing's set, fall back to seeding from by_branch (one crew
+      // per branch with crews). Better than blanking the override.
+      if (Object.keys(cleaned).length === 0) {
+        for (const b of data.by_branch) {
+          if (b.crew_count > 0 && b.branch_name) {
+            cleaned[b.branch_name] = b.crew_count
+            curTotal += b.crew_count
+          }
+        }
+      }
+      const target = data.calibration.recommended_crews
+      let next: Record<string, number> = {}
+      if (curTotal === target || curTotal === 0) {
+        next = cleaned
+      } else {
+        // Largest-remainder scaling so sum = target exactly.
+        const scale = target / curTotal
+        const real: Record<string, number> = {}
+        const floors: Array<{ key: string; floor: number; rem: number }> = []
+        let alloc = 0
+        for (const [k, v] of Object.entries(cleaned)) {
+          real[k] = v * scale
+          const f = Math.floor(real[k])
+          floors.push({ key: k, floor: f, rem: real[k] - f })
+          alloc += f
+        }
+        floors.sort((a, b) => b.rem - a.rem)
+        let i = 0
+        while (alloc < target && i < floors.length) {
+          floors[i].floor++
+          alloc++
+          i++
+        }
+        // If we OVERSHOT (target is small), trim from smallest floors.
+        if (alloc > target) {
+          floors.sort((a, b) => a.floor - b.floor)
+          let j = 0
+          while (alloc > target && j < floors.length) {
+            if (floors[j].floor > 0) {
+              floors[j].floor--
+              alloc--
+            }
+            j++
+          }
+        }
+        for (const f of floors) {
+          if (f.floor > 0) next[f.key] = f.floor
+        }
+      }
+      const writeRes = await fetch(
+        `/api/accounts/${accountId}/clients/${clientId}/operational-constraints`,
+        {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({ crew_count_per_branch_override: next }),
+        }
+      )
+      if (!writeRes.ok) {
+        const body = await writeRes.json().catch(() => ({}))
+        throw new Error(body?.error ?? `Save failed (${writeRes.status})`)
+      }
+      setCalibrationApplied({ new_total: target, new_per_branch: next })
+    } catch (err) {
+      setCalibrationError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setApplyingCalibration(false)
+    }
+  }
 
   useEffect(() => {
     let cancelled = false
@@ -136,6 +263,15 @@ export default function UtilizationPanel({ cycleId }: { cycleId: string }) {
   if (error) return <p className="text-sm text-danger">{error}</p>
   if (!data) return null
 
+  const cal = data.calibration
+  const calBorder =
+    cal?.verdict === 'overstaffed'
+      ? 'border-warning/40 bg-warning-subtle/40'
+      : cal?.verdict === 'understaffed'
+        ? 'border-danger/40 bg-danger-subtle/40'
+        : cal?.verdict === 'balanced'
+          ? 'border-success/40 bg-success-subtle/40'
+          : ''
   return (
     <div className="space-y-4">
       <Card>
@@ -154,6 +290,102 @@ export default function UtilizationPanel({ cycleId }: { cycleId: string }) {
           </div>
         </div>
       </Card>
+
+      {/* Calibration card — Crew Strategy is a *prediction* off
+          aggregate building-days; this cycle is the *measurement*. The
+          card surfaces the gap and offers to scale the per-branch
+          staging to the recommended count for the next regen. */}
+      {cal && (
+        <Card className={cn('border', calBorder)}>
+          <div className="flex items-start justify-between gap-4 flex-wrap">
+            <div className="space-y-2 min-w-0 max-w-2xl">
+              <div className="flex items-center gap-2 flex-wrap">
+                <CardTitle>Crew count calibration</CardTitle>
+                <Badge
+                  variant={
+                    cal.verdict === 'overstaffed'
+                      ? 'warning'
+                      : cal.verdict === 'understaffed'
+                        ? 'danger'
+                        : 'success'
+                  }
+                  className="text-[10px] uppercase"
+                >
+                  {cal.verdict}
+                </Badge>
+              </div>
+              <p className="text-sm text-fg">
+                Crew Strategy predicted{' '}
+                <span className="font-tabular font-semibold">{cal.predicted_crews}</span>{' '}
+                crews. This cycle actually consumed{' '}
+                <span className="font-tabular font-semibold">{cal.busy_days_total}</span>{' '}
+                busy crew-days
+                {cal.unplaced_count > 0 && (
+                  <>
+                    {' '}and dropped{' '}
+                    <span className="font-tabular font-semibold">{cal.unplaced_count}</span>{' '}
+                    visit{cal.unplaced_count === 1 ? '' : 's'}
+                  </>
+                )}
+                . If you scale to what the schedule actually needs, you'd run with{' '}
+                <span className="font-tabular font-semibold">{cal.recommended_crews}</span>{' '}
+                crew{cal.recommended_crews === 1 ? '' : 's'}
+                {cal.delta_vs_recommended > 0
+                  ? ` — ${cal.delta_vs_recommended} fewer than the prediction.`
+                  : cal.delta_vs_recommended < 0
+                    ? ` — ${Math.abs(cal.delta_vs_recommended)} more than the prediction.`
+                    : '.'}
+              </p>
+              <div className="grid grid-cols-3 gap-3 max-w-lg">
+                <CalStat label="Predicted" value={cal.predicted_crews} />
+                <CalStat
+                  label="Effective"
+                  value={cal.effective_crews}
+                  tooltip="Minimum crews needed to cover what got placed (busy days only)."
+                />
+                <CalStat
+                  label="Recommended"
+                  value={cal.recommended_crews}
+                  tooltip="Minimum crews needed to cover busy + dropped — what next regen should target."
+                  emphasized
+                />
+              </div>
+              {calibrationApplied && (
+                <p className="text-xs text-success">
+                  Saved. Per-branch staging scaled to {calibrationApplied.new_total} total —
+                  re-generate the template to apply.
+                </p>
+              )}
+              {calibrationError && (
+                <p className="text-xs text-danger">{calibrationError}</p>
+              )}
+            </div>
+            <div className="flex flex-col items-stretch gap-2 shrink-0">
+              <Button
+                size="sm"
+                onClick={applyCalibration}
+                loading={applyingCalibration}
+                disabled={
+                  cal.recommended_crews === cal.predicted_crews ||
+                  !accountId ||
+                  !clientId ||
+                  cal.recommended_crews === 0
+                }
+                title={
+                  cal.recommended_crews === cal.predicted_crews
+                    ? 'Predicted matches the schedule — nothing to recalibrate.'
+                    : `Scale per-branch staging to sum=${cal.recommended_crews}.`
+                }
+              >
+                Apply: {cal.recommended_crews} crews
+              </Button>
+              <p className="text-[10px] text-fg-subtle text-right max-w-[12rem]">
+                Updates per-branch staging proportionally. You then re-generate the template.
+              </p>
+            </div>
+          </div>
+        </Card>
+      )}
 
       <div className="grid grid-cols-1 lg:grid-cols-5 gap-4">
         {/* Per-branch rollup */}
@@ -331,6 +563,40 @@ function Stat({ label, value }: { label: string; value: string }) {
       <span className="text-[10px] uppercase tracking-wide text-fg-subtle">
         {label}
       </span>
+    </div>
+  )
+}
+
+function CalStat({
+  label,
+  value,
+  tooltip,
+  emphasized,
+}: {
+  label: string
+  value: number
+  tooltip?: string
+  emphasized?: boolean
+}) {
+  return (
+    <div
+      className={cn(
+        'rounded-md border px-3 py-2 leading-tight',
+        emphasized
+          ? 'border-accent bg-accent-subtle/40'
+          : 'border-border bg-surface-subtle/40'
+      )}
+      title={tooltip}
+    >
+      <p
+        className={cn(
+          'font-mono font-semibold tabular-nums',
+          emphasized ? 'text-2xl text-fg' : 'text-xl text-fg'
+        )}
+      >
+        {value}
+      </p>
+      <p className="text-[10px] uppercase tracking-wide text-fg-subtle">{label}</p>
     </div>
   )
 }

--- a/src/pages/accounts/scheduler/CycleDetail.tsx
+++ b/src/pages/accounts/scheduler/CycleDetail.tsx
@@ -872,7 +872,11 @@ export default function CycleDetailPage() {
         )}
 
         {view === 'utilization' && cycleId && (
-          <UtilizationPanel cycleId={cycleId} />
+          <UtilizationPanel
+            cycleId={cycleId}
+            accountId={accountId ?? null}
+            clientId={clientId ?? null}
+          />
         )}
 
         {/* List view: existing crew_days + visits tables */}


### PR DESCRIPTION
## Why
Crew Strategy gives a *prediction* off aggregate building-days. Cycle generation is the *measurement* — actual placement can show massive idle / dropped / crews working 3 days. The system never closed that loop. Iteration 1 is a calibration card that surfaces the gap and offers to scale staging to what the schedule actually needs.

## Backend
\`/api/scheduler/cycles/[id]/idle-analysis\` now counts unplaced visits and adds a \`calibration\` block:
- \`predicted_crews\` — what the template was built with
- \`effective_crews\` — \`ceil(busy_days / workdays_per_crew)\`
- \`recommended_crews\` — \`ceil((busy_days + unplaced) / workdays_per_crew)\`
- \`delta_vs_recommended\`
- \`verdict\` — overstaffed / understaffed / balanced

## Frontend
New card at the top of the Utilization tab:
- Verdict badge + one-sentence explanation tying math to cycle outcome.
- Three stat cards: Predicted / Effective / Recommended (recommended is emphasized).
- **Apply: N crews** button scales \`crew_count_per_branch_override\` proportionally to the recommended total (largest-remainder rounding). Drops legacy \`__roving\` keys during the rewrite. After save, prompts \"re-generate to apply.\"

## What this is *not*
- Doesn't auto-regenerate. Operator triggers Regenerate themselves.
- Doesn't relocate crews between branches (that's the rebalance-suggestions PR coming next).
- Doesn't feed back into Crew Strategy's *inputs* (working_days_per_year, drive overhead) — future iteration. This just corrects the *count* post-hoc.

## Test plan
- [ ] On a cycle that ran with 14 crews and 191 idle days: Calibration card shows \"overstaffed\", recommends fewer crews, Apply scales the override
- [ ] On a cycle with 13 crews and 82 unplaced: card shows \"understaffed\", recommends more, Apply scales up
- [ ] Predicted = recommended → button disabled with tooltip
- [ ] After apply, regenerate template → new cycle reflects the new staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)