### PR TITLE
Rebalance: 3 remediation types + AI advisor

### DIFF
--- a/api/scheduler/cycles/[cycleId]/apply-rebalance.ts
+++ b/api/scheduler/cycles/[cycleId]/apply-rebalance.ts
@@ -1,0 +1,106 @@
+// POST /api/scheduler/cycles/[cycleId]/apply-rebalance
+//
+// Applies a non-property rebalance suggestion (crew_relocate or
+// crew_reduce) by patching the cycle's CLIENT operational_constraints
+// row's crew_count_per_branch_override.
+//
+// Why on the cycle path: the dialog operator is in the cycle context,
+// so we look up the cycle → template → client to find which constraints
+// row to write. Property moves still go through
+// /api/scheduler/templates/[templateId]/branch-overrides.
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { createAdminClient } from '../../../_lib/supabase.js'
+import { authenticateRequest, type AuthContext } from '../../../_lib/auth.js'
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'POST') return res.status(405).json({ error: 'Method not allowed' })
+  let ctx: AuthContext
+  try { ctx = await authenticateRequest(req) } catch (err: any) {
+    return res.status(err.statusCode ?? 401).json({ error: err.message ?? 'Unauthorized' })
+  }
+  const cycleId = req.query.cycleId as string
+  const body = (req.body ?? {}) as {
+    type?: 'crew_relocate' | 'crew_reduce'
+    from_branch_name?: string
+    to_branch_name?: string
+    branch_name?: string
+  }
+  if (!body.type) return res.status(400).json({ error: 'type required' })
+  const db = createAdminClient()
+
+  const { data: cycle } = await db
+    .from('cycle_instances')
+    .select('id, template_id')
+    .eq('id', cycleId)
+    .maybeSingle()
+  if (!cycle) return res.status(404).json({ error: 'Cycle not found' })
+  const { data: tpl } = await db
+    .from('routing_templates')
+    .select('account_id, client_id')
+    .eq('id', (cycle as any).template_id)
+    .maybeSingle()
+  if (!tpl) return res.status(404).json({ error: 'Template not found' })
+  const { account_id: accountId, client_id: clientId } = tpl as any
+
+  // Read the current per-branch override.
+  const { data: con } = await db
+    .from('account_operational_constraints')
+    .select('crew_count_per_branch_override')
+    .eq('account_id', accountId)
+    .eq('client_id', clientId)
+    .maybeSingle()
+  const current = ((con as any)?.crew_count_per_branch_override ?? {}) as Record<string, number>
+  const next: Record<string, number> = {}
+  for (const [k, v] of Object.entries(current)) {
+    if (k === '__roving') continue // legacy — drop
+    const n = Math.floor(Number(v) || 0)
+    if (n > 0) next[k] = n
+  }
+
+  if (body.type === 'crew_relocate') {
+    if (!body.from_branch_name || !body.to_branch_name) {
+      return res.status(400).json({ error: 'from_branch_name + to_branch_name required' })
+    }
+    const fromN = next[body.from_branch_name] ?? 0
+    if (fromN <= 0) {
+      return res
+        .status(400)
+        .json({ error: `Cannot relocate from ${body.from_branch_name}: no crews staged there.` })
+    }
+    next[body.from_branch_name] = fromN - 1
+    if (next[body.from_branch_name] === 0) delete next[body.from_branch_name]
+    next[body.to_branch_name] = (next[body.to_branch_name] ?? 0) + 1
+  } else if (body.type === 'crew_reduce') {
+    if (!body.branch_name) return res.status(400).json({ error: 'branch_name required' })
+    const cur = next[body.branch_name] ?? 0
+    if (cur <= 0) {
+      return res
+        .status(400)
+        .json({ error: `Cannot reduce ${body.branch_name}: no crews staged there.` })
+    }
+    next[body.branch_name] = cur - 1
+    if (next[body.branch_name] === 0) delete next[body.branch_name]
+  } else {
+    return res.status(400).json({ error: 'unsupported type' })
+  }
+
+  const { error: upErr } = await db
+    .from('account_operational_constraints')
+    .upsert(
+      {
+        account_id: accountId,
+        client_id: clientId,
+        crew_count_per_branch_override: next,
+        updated_at: new Date().toISOString(),
+        updated_by: ctx.userId ?? null,
+      },
+      { onConflict: 'account_id,client_id' }
+    )
+  if (upErr) return res.status(500).json({ error: `constraints upsert failed: ${upErr.message}` })
+
+  const newTotal = Object.values(next).reduce((s, v) => s + v, 0)
+  return res.status(200).json({
+    crew_count_per_branch_override: next,
+    new_total: newTotal,
+  })
+}

--- a/api/scheduler/cycles/[cycleId]/rebalance-suggestions.ts
+++ b/api/scheduler/cycles/[cycleId]/rebalance-suggestions.ts
@@ -1,27 +1,47 @@
 // POST /api/scheduler/cycles/[cycleId]/rebalance-suggestions
 //
-// After cycle generation, if anything's unplaced, find candidate
-// "trips" (clusters' visits that overflowed) and the best recipient
-// crews to move them to. Returns ranked recommendations the operator
-// can apply with one click.
+// Three remediation types after a cycle generates:
 //
-// Logic is deterministic — no LLM — so it's fast and predictable.
-// The recipient must have:
-//   - Idle workdays ≥ the unplaced count for that cluster
-//   - Branch within 2× cluster_radius_miles of the cluster centroid
-// Among feasible recipients, prefer (a) most idle days, (b) shortest
-// drive from their branch to cluster centroid.
+//   property_move   — re-route an unplaced cluster to a recipient crew
+//                     with idle capacity (existing behavior, looser
+//                     filters, allows partial absorption).
+//   crew_relocate   — a severely-idle crew's home branch has no nearby
+//                     work; restage them at a branch with unserved demand.
+//                     Updates crew_count_per_branch_override (-1 origin,
+//                     +1 target).
+//   crew_reduce     — no relocation helps (geography won't); reducing
+//                     crew_count saves labor cost. -1 from the most-idle
+//                     branch.
+//
+// Optional Claude advisor pass (if X-Advise: true on the request) takes
+// the heuristic candidates plus cycle context and returns a ranked
+// narrative recommendation explaining trade-offs.
 import type { VercelRequest, VercelResponse } from '@vercel/node'
+import Anthropic from '@anthropic-ai/sdk'
 import { createAdminClient } from '../../../_lib/supabase.js'
 import { authenticateRequest } from '../../../_lib/auth.js'
 import { haversineMiles } from '../../../_lib/analysis/haversine.js'
 
-export const config = { maxDuration: 30 }
+export const config = { maxDuration: 60 }
 
-interface Suggestion {
+const ADVISOR_MODEL = 'claude-sonnet-4-5'
+const ADVISOR_MAX_TOKENS = 1200
+// A crew below this utilization fraction is severely-idle; relocation /
+// reduction suggestions get generated for it.
+const SEVERELY_IDLE_THRESHOLD = 0.4
+
+type SuggestionType = 'property_move' | 'crew_relocate' | 'crew_reduce'
+
+interface BaseSuggestion {
   id: string
+  type: SuggestionType
   title: string
   summary: string
+  priority: number // higher = more impact
+}
+
+interface PropertyMoveSuggestion extends BaseSuggestion {
+  type: 'property_move'
   from_branch_idx: number
   from_branch_name: string
   to_branch_idx: number
@@ -33,15 +53,34 @@ interface Suggestion {
   drive_delta_miles: number
 }
 
+interface CrewRelocateSuggestion extends BaseSuggestion {
+  type: 'crew_relocate'
+  crew_index: number
+  crew_label: string
+  from_branch_name: string
+  to_branch_name: string
+  idle_days_freed: number
+  expected_absorbed_count: number
+}
+
+interface CrewReduceSuggestion extends BaseSuggestion {
+  type: 'crew_reduce'
+  branch_name: string
+  current_count: number
+  proposed_count: number
+  idle_days_freed: number
+}
+
+type Suggestion = PropertyMoveSuggestion | CrewRelocateSuggestion | CrewReduceSuggestion
+
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method !== 'POST') return res.status(405).json({ error: 'Method not allowed' })
-  try {
-    await authenticateRequest(req)
-  } catch (err: any) {
+  try { await authenticateRequest(req) } catch (err: any) {
     return res.status(err.statusCode ?? 401).json({ error: err.message ?? 'Unauthorized' })
   }
   const cycleId = req.query.cycleId as string
   if (!cycleId) return res.status(400).json({ error: 'cycleId required' })
+  const wantAdvisor = String(req.headers['x-advise'] ?? '').toLowerCase() === 'true'
   const db = createAdminClient()
 
   // ── Load cycle, template, visits, routes ──────────────────────────
@@ -63,7 +102,6 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   }
   if (!template) return res.status(404).json({ error: 'Template not found' })
 
-  // Page through visits + crew_day_routes (same pattern as cycle GET).
   const PAGE = 1000
   const visits: any[] = []
   for (let p = 0; p < 50; p++) {
@@ -80,7 +118,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   for (let p = 0; p < 50; p++) {
     const { data } = await db
       .from('crew_day_routes')
-      .select('id, crew_index, scheduled_date, day_type, total_work_minutes, total_drive_minutes, total_day_minutes, route, trip_id, start_location')
+      .select('id, crew_index, crew_label, scheduled_date, day_type, route, start_location')
       .eq('cycle_instance_id', cycleId)
       .range(p * PAGE, (p + 1) * PAGE - 1)
     const batch = data ?? []
@@ -88,48 +126,67 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     if (batch.length < PAGE) break
   }
 
-  const unplaced = visits.filter((v) => v.status === 'unplaced')
-  if (unplaced.length === 0) {
-    return res.status(200).json({ suggestions: [] })
-  }
-
-  // ── Build crew context: per-crew branch coords + idle workday count ─
   const branches = (template.branches ?? []) as Array<{ name: string; lat: number; lng: number }>
   const cfg = (template.config ?? {}) as Record<string, any>
   const clusterRadius = (cfg.cluster_radius_miles as number) ?? 30
+  const crewCount = (template.crew_count as number) ?? 0
+  const crewAssignments = (template.crew_assignments ?? []) as Array<{
+    index?: number
+    label?: string
+    home_branch_index?: number
+  }>
 
-  // Crew → branch coords (from any of their crew_day_routes' start_location).
-  const crewBranchByIdx = new Map<number, { idx: number; name: string; lat: number; lng: number }>()
-  for (const cd of crewDays) {
-    if (crewBranchByIdx.has(cd.crew_index)) continue
-    const sl = cd.start_location ?? null
-    if (!sl || typeof sl.lat !== 'number' || typeof sl.lng !== 'number') continue
-    // Match the crew's branch coords to one of template.branches by lat/lng.
-    let matchedIdx = 0
-    let bestDist = Number.POSITIVE_INFINITY
-    for (let i = 0; i < branches.length; i++) {
-      const d = haversineMiles({ lat: sl.lat, lng: sl.lng }, branches[i])
-      if (d < bestDist) {
-        bestDist = d
-        matchedIdx = i
-      }
-    }
-    crewBranchByIdx.set(cd.crew_index, {
-      idx: matchedIdx,
-      name: sl.name ?? branches[matchedIdx]?.name ?? `Crew ${cd.crew_index + 1}`,
-      lat: sl.lat,
-      lng: sl.lng,
+  // crew_index → home branch (template snapshot). Falls back to
+  // start_location coords matched against branches.
+  const crewBranch = new Map<number, { idx: number; name: string; lat: number; lng: number; label: string }>()
+  for (const ca of crewAssignments) {
+    const idx = typeof ca.index === 'number' ? ca.index : null
+    const home = typeof ca.home_branch_index === 'number' ? ca.home_branch_index : null
+    if (idx == null || home == null) continue
+    const b = branches[home]
+    if (!b) continue
+    crewBranch.set(idx, {
+      idx: home,
+      name: b.name,
+      lat: b.lat,
+      lng: b.lng,
+      label: ca.label ?? `Crew ${idx + 1}`,
     })
   }
-  // Fall back: any crews without routes get their template-order branch.
-  const declaredCrewCount = (template.crew_count as number) ?? crewBranchByIdx.size
-  for (let i = 0; i < declaredCrewCount; i++) {
-    if (crewBranchByIdx.has(i)) continue
-    const b = branches[i % Math.max(1, branches.length)]
-    if (b) crewBranchByIdx.set(i, { idx: i % branches.length, name: b.name, lat: b.lat, lng: b.lng })
+  // Fallback for any crew without a template assignment row.
+  for (let i = 0; i < crewCount; i++) {
+    if (crewBranch.has(i)) continue
+    const cd = crewDays.find((d: any) => d.crew_index === i)
+    const sl = cd?.start_location
+    if (sl && typeof sl.lat === 'number' && typeof sl.lng === 'number') {
+      let bestIdx = 0
+      let best = Number.POSITIVE_INFINITY
+      for (let j = 0; j < branches.length; j++) {
+        const d = haversineMiles({ lat: sl.lat, lng: sl.lng }, branches[j])
+        if (d < best) { best = d; bestIdx = j }
+      }
+      crewBranch.set(i, {
+        idx: bestIdx,
+        name: sl.name ?? branches[bestIdx]?.name ?? `Crew ${i + 1}`,
+        lat: sl.lat,
+        lng: sl.lng,
+        label: cd?.crew_label ?? `Crew ${i + 1}`,
+      })
+    } else {
+      const b = branches[i % Math.max(1, branches.length)]
+      if (b) {
+        crewBranch.set(i, {
+          idx: i % branches.length,
+          name: b.name,
+          lat: b.lat,
+          lng: b.lng,
+          label: cd?.crew_label ?? `Crew ${i + 1}`,
+        })
+      }
+    }
   }
 
-  // Compute idle workdays per crew (cycle workdays - days with routes).
+  // Workday calendar + per-crew busy/idle counts.
   const cycleStart = new Date(`${cycle.start_date}T00:00:00Z`)
   const cycleEnd = new Date(`${cycle.end_date}T00:00:00Z`)
   const workdays: string[] = []
@@ -144,20 +201,33 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     usedByCrew.set(cd.crew_index, set)
   }
   const idleByCrew = new Map<number, number>()
-  for (const idx of crewBranchByIdx.keys()) {
+  const busyByCrew = new Map<number, number>()
+  for (const idx of crewBranch.keys()) {
     const used = usedByCrew.get(idx) ?? new Set()
-    idleByCrew.set(idx, workdays.filter((d) => !used.has(d)).length)
+    const idle = workdays.filter((d) => !used.has(d)).length
+    idleByCrew.set(idx, idle)
+    busyByCrew.set(idx, workdays.length - idle)
+  }
+  // Idle days per branch (sum over crews homed there).
+  const idleByBranch = new Map<number, number>()
+  for (const [crewIdx, b] of crewBranch.entries()) {
+    idleByBranch.set(b.idx, (idleByBranch.get(b.idx) ?? 0) + (idleByCrew.get(crewIdx) ?? 0))
+  }
+  // Crews per branch.
+  const crewsByBranch = new Map<number, number>()
+  for (const b of crewBranch.values()) {
+    crewsByBranch.set(b.idx, (crewsByBranch.get(b.idx) ?? 0) + 1)
   }
 
-  // ── Group unplaced by their cluster_label (parsed from reason) ────
-  // The unplaced reason format is: "Trip ran out of cycle days for cluster <Label> ..."
-  // or "Trip "<Label>" extended past cycle end ..."
+  const unplaced = visits.filter((v) => v.status === 'unplaced')
+
+  // Group unplaced by parsed cluster_label.
   const groups = new Map<string, { label: string; props: any[] }>()
   for (const u of unplaced) {
     const reason: string = u.unplaced_reason ?? ''
     let label = 'Unknown'
-    const m1 = reason.match(/cluster\s+([^()]+?)(?:\s+\()/) // "cluster Frisco (local)"
-    const m2 = reason.match(/Trip\s+"([^"]+)"/) // 'Trip "Broken Arrow, OK"'
+    const m1 = reason.match(/cluster\s+([^()]+?)(?:\s+\()/)
+    const m2 = reason.match(/Trip\s+"([^"]+)"/)
     if (m1) label = m1[1].trim()
     else if (m2) label = m2[1].trim()
     const g = groups.get(label) ?? { label, props: [] }
@@ -165,11 +235,11 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     groups.set(label, g)
   }
 
-  // For each group, compute centroid + nearest-branch (the "from" branch),
-  // then find candidate recipients with capacity + reasonable geography.
   const overrides = (template.branch_assignment_overrides ?? {}) as Record<string, number>
   const suggestions: Suggestion[] = []
   let suggestionId = 1
+
+  // ── 1. Property-move suggestions (looser filters than v1) ─────────
   for (const [label, group] of groups) {
     const validProps = group.props.filter(
       (u) =>
@@ -183,57 +253,251 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     const centroidLng =
       validProps.reduce((s, u) => s + u.service_locations.property.longitude, 0) / validProps.length
 
-    // From: the closest crew branch (where these properties currently sit).
     let fromBranchIdx = 0
     let fromDist = Number.POSITIVE_INFINITY
-    for (const [, b] of crewBranchByIdx) {
+    for (const b of crewBranch.values()) {
       const d = haversineMiles({ lat: centroidLat, lng: centroidLng }, b)
-      if (d < fromDist) {
-        fromDist = d
-        fromBranchIdx = b.idx
-      }
+      if (d < fromDist) { fromDist = d; fromBranchIdx = b.idx }
     }
 
-    // To: best recipient = enough idle days + closest non-from branch within 2×radius.
-    const candidates = Array.from(crewBranchByIdx.values())
+    // Allow PARTIAL absorption — recipient just needs SOME idle capacity.
+    // Distance cap loosened to 4× cluster radius (combined-client
+    // portfolios span large geographies; 2× was too tight).
+    const candidates = Array.from(crewBranch.values())
       .filter((b) => b.idx !== fromBranchIdx)
-      .map((b) => ({
-        b,
-        dist: haversineMiles({ lat: centroidLat, lng: centroidLng }, b),
-        idle: idleByCrew.get(b.idx) ?? 0,
-      }))
-      .filter((c) => c.idle >= validProps.length)
-      .filter((c) => c.dist <= clusterRadius * 2)
-      .sort((a, c) => a.dist - c.dist)
+      .map((b) => {
+        const idleSum = Array.from(crewBranch.entries())
+          .filter(([, bb]) => bb.idx === b.idx)
+          .reduce((s, [crewIdx]) => s + (idleByCrew.get(crewIdx) ?? 0), 0)
+        return {
+          b,
+          dist: haversineMiles({ lat: centroidLat, lng: centroidLng }, b),
+          idle: idleSum,
+        }
+      })
+      .filter((c) => c.idle > 0)
+      .filter((c) => c.dist <= clusterRadius * 4)
+      .sort((a, c) => {
+        if (c.idle === a.idle) return a.dist - c.dist
+        return c.idle - a.idle
+      })
 
     if (candidates.length === 0) continue
     const best = candidates[0]
+    const absorbCount = Math.min(validProps.length, best.idle)
+    const absorbed = validProps.slice(0, absorbCount)
 
     suggestions.push({
-      id: `sug-${suggestionId++}`,
-      title: `Move ${label} (${validProps.length} propert${validProps.length === 1 ? 'y' : 'ies'}) → ${best.b.name}`,
+      id: `pm-${suggestionId++}`,
+      type: 'property_move',
+      priority: 100 + absorbed.length,
+      title: `Move ${absorbed.length} of ${validProps.length} ${label} → ${best.b.name}`,
       summary:
-        `${validProps.length} unplaced ${label} propert${validProps.length === 1 ? 'y' : 'ies'} ` +
+        `${absorbed.length} unplaced ${label} propert${absorbed.length === 1 ? 'y' : 'ies'} ` +
         `currently routed via ${branches[fromBranchIdx]?.name ?? 'origin'}. ` +
-        `${best.b.name} has ${best.idle} idle workdays and is ` +
+        `${best.b.name} has ${best.idle} idle workday${best.idle === 1 ? '' : 's'} and is ` +
         `${Math.round(best.dist)}mi from the cluster (vs ${Math.round(fromDist)}mi from ` +
-        `${branches[fromBranchIdx]?.name ?? 'origin'} — adds ~${Math.max(0, Math.round((best.dist - fromDist) * 2 / 60))}h drive per trip).`,
+        `${branches[fromBranchIdx]?.name ?? 'origin'}).` +
+        (validProps.length > absorbCount
+          ? ` ${validProps.length - absorbCount} would still need a separate solution.`
+          : ''),
       from_branch_idx: fromBranchIdx,
       from_branch_name: branches[fromBranchIdx]?.name ?? `Branch ${fromBranchIdx}`,
       to_branch_idx: best.b.idx,
       to_branch_name: best.b.name,
-      property_count: validProps.length,
-      service_location_ids: validProps.map((u) => u.service_location_id),
-      property_ids: validProps.map((u) => u.property_id),
+      property_count: absorbed.length,
+      service_location_ids: absorbed.map((u) => u.service_location_id),
+      property_ids: absorbed.map((u) => u.property_id),
       cluster_label: label,
       drive_delta_miles: Math.round(best.dist - fromDist),
     })
   }
 
-  // Skip suggestions whose targets the operator already overrode.
-  const filtered = suggestions.filter((s) =>
-    s.service_location_ids.some((sl) => overrides[sl] !== s.to_branch_idx)
-  )
+  // ── 2. Crew relocation — severely-idle crew → branch w/ unserved demand ─
+  for (const [crewIdx, home] of crewBranch.entries()) {
+    const total = workdays.length
+    const idle = idleByCrew.get(crewIdx) ?? 0
+    const utilization = total > 0 ? (total - idle) / total : 0
+    if (utilization >= SEVERELY_IDLE_THRESHOLD) continue
 
-  return res.status(200).json({ suggestions: filtered })
+    // Find the branch with the most "unserved demand" defined as either:
+    //   (a) sum of nearby unplaced visits, or
+    //   (b) high idle-days / property-count ratio (saturated)
+    // Skip branches the crew is already homed at.
+    type BranchScore = { branchIdx: number; branchName: string; score: number; reason: string }
+    const scores: BranchScore[] = []
+    for (let bi = 0; bi < branches.length; bi++) {
+      if (bi === home.idx) continue
+      const b = branches[bi]
+      // Unplaced visits within 2× cluster radius of this branch.
+      let nearby = 0
+      for (const u of unplaced) {
+        const lat = u.service_locations?.property?.latitude
+        const lng = u.service_locations?.property?.longitude
+        if (typeof lat !== 'number' || typeof lng !== 'number') continue
+        const d = haversineMiles({ lat, lng }, b)
+        if (d <= clusterRadius * 2) nearby++
+      }
+      if (nearby > 0) {
+        scores.push({
+          branchIdx: bi,
+          branchName: b.name,
+          score: nearby,
+          reason: `${nearby} unplaced visit${nearby === 1 ? '' : 's'} within ${Math.round(clusterRadius * 2)}mi of ${b.name}`,
+        })
+      }
+    }
+    scores.sort((a, b) => b.score - a.score)
+    if (scores.length === 0) continue
+    const target = scores[0]
+
+    suggestions.push({
+      id: `cr-${suggestionId++}`,
+      type: 'crew_relocate',
+      priority: 200 + idle, // higher than property-moves
+      title: `Restage ${home.label} from ${home.name} → ${target.branchName}`,
+      summary:
+        `${home.label} is ${Math.round(utilization * 100)}% utilized at ${home.name} ` +
+        `(${idle} idle workdays). ${target.reason} — restaging this crew there ` +
+        `would free their idle capacity for absorbable work.`,
+      crew_index: crewIdx,
+      crew_label: home.label,
+      from_branch_name: home.name,
+      to_branch_name: target.branchName,
+      idle_days_freed: idle,
+      expected_absorbed_count: target.score,
+    })
+  }
+
+  // ── 3. Crew reduction — branch is overstaffed and no relocation helps ─
+  // Trigger when a branch's idle-days > cycle-length × 0.6 per crew there
+  // AND we haven't already proposed relocating any crew from that branch.
+  const hasRelocateFrom = new Set(
+    suggestions
+      .filter((s): s is CrewRelocateSuggestion => s.type === 'crew_relocate')
+      .map((s) => s.from_branch_name)
+  )
+  for (const [branchIdx, idleDays] of idleByBranch.entries()) {
+    const branchName = branches[branchIdx]?.name
+    if (!branchName) continue
+    if (hasRelocateFrom.has(branchName)) continue
+    const crews = crewsByBranch.get(branchIdx) ?? 0
+    if (crews <= 1) continue
+    const idlePerCrew = idleDays / crews
+    if (idlePerCrew >= workdays.length * 0.6) {
+      suggestions.push({
+        id: `cd-${suggestionId++}`,
+        type: 'crew_reduce',
+        priority: 150 + Math.round(idleDays / 10),
+        title: `Reduce crews at ${branchName}: ${crews} → ${crews - 1}`,
+        summary:
+          `${branchName} has ${crews} crews averaging ${Math.round(idlePerCrew)} idle workdays ` +
+          `each (${Math.round((idlePerCrew / workdays.length) * 100)}% idle). ` +
+          `Removing one crew saves the FTE labor cost without dropping any placed work.`,
+        branch_name: branchName,
+        current_count: crews,
+        proposed_count: crews - 1,
+        idle_days_freed: Math.round(idlePerCrew),
+      })
+    }
+  }
+
+  // Skip property-moves the operator already overrode.
+  let filtered = suggestions
+  if (Object.keys(overrides).length > 0) {
+    filtered = suggestions.filter((s) => {
+      if (s.type !== 'property_move') return true
+      return s.service_location_ids.some((sl) => overrides[sl] !== s.to_branch_idx)
+    })
+  }
+  filtered.sort((a, b) => b.priority - a.priority)
+
+  // ── 4. Optional Claude advisor on top ─────────────────────────────
+  let advisor: { recommendation: string; ranked_actions: string[] } | null = null
+  const apiKey = process.env.ANTHROPIC_API_KEY
+  if (wantAdvisor && apiKey && filtered.length > 0) {
+    try {
+      const anthropic = new Anthropic({ apiKey })
+      const ctx = {
+        cycle: {
+          start: cycle.start_date,
+          end: cycle.end_date,
+          workdays: workdays.length,
+          crew_count: crewCount,
+          unplaced_count: unplaced.length,
+          total_idle_days: Array.from(idleByCrew.values()).reduce((s, n) => s + n, 0),
+        },
+        branches: branches.map((b, i) => ({
+          name: b.name,
+          crews_homed: crewsByBranch.get(i) ?? 0,
+          idle_days: idleByBranch.get(i) ?? 0,
+        })),
+        crews_critical: Array.from(crewBranch.entries())
+          .map(([idx, b]) => ({
+            label: b.label,
+            home: b.name,
+            idle: idleByCrew.get(idx) ?? 0,
+            busy: busyByCrew.get(idx) ?? 0,
+            utilization_pct: workdays.length > 0
+              ? Math.round(((busyByCrew.get(idx) ?? 0) / workdays.length) * 100)
+              : 0,
+          }))
+          .filter((c) => c.utilization_pct < 40)
+          .slice(0, 10),
+        suggestions: filtered.map((s) => ({
+          id: s.id,
+          type: s.type,
+          title: s.title,
+          summary: s.summary,
+          priority: s.priority,
+        })),
+      }
+
+      const systemPrompt =
+        `You are an operations analyst reviewing a routing-template cycle. The deterministic engine has produced a list of remediation suggestions. Your job: synthesize a concise recommended-actions narrative that:
+1. Names the highest-leverage move(s) — usually 1-3 actions.
+2. Explains WHY (cite specific numbers from the context).
+3. Notes trade-offs the engine can't see (e.g. dropping a crew has labor savings but capacity loss; relocation incurs setup cost).
+4. Lists a ranked sequence of suggestion IDs the operator should apply.
+
+Output format — JSON only, no prose around it:
+{
+  "recommendation": "short paragraph (≤4 sentences) describing the recommended path forward",
+  "ranked_actions": ["sug-id-1", "sug-id-2", ...]
+}
+
+Be terse. The operator scans, doesn't read.`
+
+      const userMsg = `Cycle context:\n${JSON.stringify(ctx, null, 2)}`
+      const resp = await anthropic.messages.create({
+        model: ADVISOR_MODEL,
+        max_tokens: ADVISOR_MAX_TOKENS,
+        system: systemPrompt,
+        messages: [{ role: 'user', content: userMsg }],
+      })
+      const text = resp.content
+        .filter((b: any) => b.type === 'text')
+        .map((b: any) => b.text)
+        .join('')
+      // Extract first JSON object.
+      const m = text.match(/\{[\s\S]*\}/)
+      if (m) {
+        try {
+          const parsed = JSON.parse(m[0])
+          if (typeof parsed.recommendation === 'string' && Array.isArray(parsed.ranked_actions)) {
+            advisor = {
+              recommendation: parsed.recommendation,
+              ranked_actions: parsed.ranked_actions.filter((s: any) => typeof s === 'string'),
+            }
+          }
+        } catch {
+          // ignore parse failure — advisor stays null
+        }
+      }
+    } catch {
+      // Advisor failures must never break the deterministic suggestions.
+    }
+  }
+
+  return res.status(200).json({ suggestions: filtered, advisor })
 }

--- a/src/components/scheduler/RebalanceSuggestionsDialog.tsx
+++ b/src/components/scheduler/RebalanceSuggestionsDialog.tsx
@@ -1,11 +1,13 @@
-// Phase 4.5j — Rebalance suggestions dialog.
-// Shown after generate-cycle when there are unplaced visits. The
-// /rebalance-suggestions endpoint returns deterministic recommendations
-// like "Move Broken Arrow OK trip from Frisco → Sugar Land". The
-// operator clicks Apply, we batch-override the affected properties on
-// the template, and prompt to regenerate.
+// Rebalance suggestions dialog. Three suggestion types:
+//   property_move  — patches template.branch_assignment_overrides
+//   crew_relocate  — patches account_operational_constraints
+//                    crew_count_per_branch_override (-1 origin, +1 target)
+//   crew_reduce    — patches the same override (-1 from branch)
+//
+// Optional Claude advisor narrative at the top, with a ranked sequence
+// of suggestion IDs to apply in order.
 import { useEffect, useState } from 'react'
-import { ArrowRight } from 'lucide-react'
+import { ArrowRight, Sparkles, Users, MapPin, Minus } from 'lucide-react'
 import {
   Dialog,
   DialogContent,
@@ -18,10 +20,17 @@ import Button from '../ui/Button'
 import { Badge } from '../ui/Badge'
 import { useAuth } from '../../hooks/useAuth'
 
-interface Suggestion {
+type SuggestionType = 'property_move' | 'crew_relocate' | 'crew_reduce'
+
+interface BaseSuggestion {
   id: string
+  type: SuggestionType
   title: string
   summary: string
+  priority: number
+}
+interface PropertyMoveSuggestion extends BaseSuggestion {
+  type: 'property_move'
   from_branch_idx: number
   from_branch_name: string
   to_branch_idx: number
@@ -32,16 +41,41 @@ interface Suggestion {
   cluster_label: string
   drive_delta_miles: number
 }
+interface CrewRelocateSuggestion extends BaseSuggestion {
+  type: 'crew_relocate'
+  crew_index: number
+  crew_label: string
+  from_branch_name: string
+  to_branch_name: string
+  idle_days_freed: number
+  expected_absorbed_count: number
+}
+interface CrewReduceSuggestion extends BaseSuggestion {
+  type: 'crew_reduce'
+  branch_name: string
+  current_count: number
+  proposed_count: number
+  idle_days_freed: number
+}
+type Suggestion = PropertyMoveSuggestion | CrewRelocateSuggestion | CrewReduceSuggestion
+
+interface Advisor {
+  recommendation: string
+  ranked_actions: string[]
+}
 
 interface Props {
   cycleId: string
   templateId: string
   open: boolean
   onClose: () => void
-  // Called after the operator applies one or more recommendations and
-  // chooses to regenerate. Parent triggers the regenerate API and
-  // reloads cycle data.
   onRegenerate: () => Promise<void>
+}
+
+const TYPE_META: Record<SuggestionType, { label: string; icon: any; color: string }> = {
+  property_move: { label: 'Property move', icon: MapPin, color: 'accent' },
+  crew_relocate: { label: 'Restage crew', icon: Users, color: 'warning' },
+  crew_reduce: { label: 'Reduce crews', icon: Minus, color: 'danger' },
 }
 
 export default function RebalanceSuggestionsDialog({
@@ -55,63 +89,103 @@ export default function RebalanceSuggestionsDialog({
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [suggestions, setSuggestions] = useState<Suggestion[]>([])
+  const [advisor, setAdvisor] = useState<Advisor | null>(null)
+  const [advisorLoading, setAdvisorLoading] = useState(false)
   const [applied, setApplied] = useState<Set<string>>(new Set())
   const [applying, setApplying] = useState<string | null>(null)
   const [regenerating, setRegenerating] = useState(false)
 
+  const loadSuggestions = async (withAdvisor: boolean) => {
+    setLoading(!withAdvisor)
+    if (withAdvisor) setAdvisorLoading(true)
+    setError(null)
+    try {
+      const token = await getToken()
+      const headers: Record<string, string> = {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      }
+      if (withAdvisor) headers['X-Advise'] = 'true'
+      const res = await fetch(
+        `/api/scheduler/cycles/${cycleId}/rebalance-suggestions`,
+        { method: 'POST', headers, body: JSON.stringify({}) }
+      )
+      const json = await res.json().catch(() => ({}))
+      if (!res.ok) throw new Error((json as any).error ?? `HTTP ${res.status}`)
+      setSuggestions((json as any).suggestions ?? [])
+      if (withAdvisor) setAdvisor((json as any).advisor ?? null)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e))
+    } finally {
+      setLoading(false)
+      setAdvisorLoading(false)
+    }
+  }
+
   useEffect(() => {
     if (!open) return
-    let cancelled = false
-    const load = async () => {
-      setLoading(true)
-      setError(null)
-      setApplied(new Set())
-      try {
-        const token = await getToken()
-        const res = await fetch(
-          `/api/scheduler/cycles/${cycleId}/rebalance-suggestions`,
-          {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
-            body: JSON.stringify({}),
-          }
-        )
-        const json = await res.json().catch(() => ({}))
-        if (!res.ok) throw new Error((json as any).error ?? `HTTP ${res.status}`)
-        if (!cancelled) setSuggestions((json as any).suggestions ?? [])
-      } catch (e) {
-        if (!cancelled) setError(e instanceof Error ? e.message : String(e))
-      } finally {
-        if (!cancelled) setLoading(false)
-      }
-    }
-    load()
-    return () => {
-      cancelled = true
-    }
-  }, [open, cycleId, getToken])
+    setApplied(new Set())
+    setAdvisor(null)
+    void loadSuggestions(false)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, cycleId])
 
   const apply = async (s: Suggestion) => {
     setApplying(s.id)
     setError(null)
     try {
       const token = await getToken()
-      const res = await fetch(
-        `/api/scheduler/templates/${templateId}/branch-overrides`,
-        {
-          method: 'PATCH',
-          headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
-          body: JSON.stringify({
-            batch: s.service_location_ids.map((sl) => ({
-              service_location_id: sl,
-              branch_idx: s.to_branch_idx,
-            })),
-          }),
+      if (s.type === 'property_move') {
+        const res = await fetch(
+          `/api/scheduler/templates/${templateId}/branch-overrides`,
+          {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+            body: JSON.stringify({
+              batch: s.service_location_ids.map((sl) => ({
+                service_location_id: sl,
+                branch_idx: s.to_branch_idx,
+              })),
+            }),
+          }
+        )
+        if (!res.ok) {
+          const j = await res.json().catch(() => ({}))
+          throw new Error((j as any).error ?? `HTTP ${res.status}`)
         }
-      )
-      if (!res.ok) {
-        const j = await res.json().catch(() => ({}))
-        throw new Error((j as any).error ?? `HTTP ${res.status}`)
+      } else if (s.type === 'crew_relocate') {
+        const res = await fetch(
+          `/api/scheduler/cycles/${cycleId}/apply-rebalance`,
+          {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+            body: JSON.stringify({
+              type: 'crew_relocate',
+              from_branch_name: s.from_branch_name,
+              to_branch_name: s.to_branch_name,
+            }),
+          }
+        )
+        if (!res.ok) {
+          const j = await res.json().catch(() => ({}))
+          throw new Error((j as any).error ?? `HTTP ${res.status}`)
+        }
+      } else if (s.type === 'crew_reduce') {
+        const res = await fetch(
+          `/api/scheduler/cycles/${cycleId}/apply-rebalance`,
+          {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+            body: JSON.stringify({
+              type: 'crew_reduce',
+              branch_name: s.branch_name,
+            }),
+          }
+        )
+        if (!res.ok) {
+          const j = await res.json().catch(() => ({}))
+          throw new Error((j as any).error ?? `HTTP ${res.status}`)
+        }
       }
       setApplied((prev) => new Set([...prev, s.id]))
     } catch (e) {
@@ -122,7 +196,12 @@ export default function RebalanceSuggestionsDialog({
   }
 
   const applyAll = async () => {
-    for (const s of suggestions) {
+    // If advisor ranked actions exist, follow that order.
+    const queue =
+      advisor?.ranked_actions
+        ?.map((id) => suggestions.find((s) => s.id === id))
+        .filter((s): s is Suggestion => !!s) ?? suggestions
+    for (const s of queue) {
       if (applied.has(s.id)) continue
       await apply(s)
     }
@@ -140,15 +219,58 @@ export default function RebalanceSuggestionsDialog({
 
   return (
     <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
-      <DialogContent className="max-w-2xl">
+      <DialogContent className="max-w-3xl">
         <DialogHeader>
           <DialogTitle>Rebalance suggestions</DialogTitle>
           <DialogDescription>
-            Some properties didn't fit. Here's how we'd move trips to other
-            branches that have idle capacity. Apply any you want; regenerate
-            the template to put them into effect.
+            Three remediation types: <strong>property moves</strong> re-route
+            unplaced clusters; <strong>restage crew</strong> relocates an idle
+            crew's home branch to where the work is; <strong>reduce crews</strong>
+            drops staffing where geography doesn't justify it. Apply any combination,
+            then regenerate the template.
           </DialogDescription>
         </DialogHeader>
+
+        {/* Advisor card */}
+        <div className="rounded-md border border-accent/20 bg-accent-subtle/30 p-3 space-y-2">
+          <div className="flex items-center justify-between gap-2 flex-wrap">
+            <div className="flex items-center gap-1.5 text-xs font-semibold text-fg">
+              <Sparkles className="h-3.5 w-3.5 text-accent" />
+              AI advisor
+            </div>
+            {!advisor && !advisorLoading && (
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={() => loadSuggestions(true)}
+                disabled={suggestions.length === 0 || loading}
+              >
+                Generate recommendation
+              </Button>
+            )}
+          </div>
+          {advisorLoading && (
+            <p className="text-xs text-fg-muted">
+              Synthesizing recommendation…
+            </p>
+          )}
+          {!advisor && !advisorLoading && (
+            <p className="text-xs text-fg-subtle">
+              Have Claude rank these suggestions and explain trade-offs the
+              engine can't see (labor cost vs capacity, setup overhead, etc.).
+            </p>
+          )}
+          {advisor && (
+            <>
+              <p className="text-sm text-fg leading-relaxed">{advisor.recommendation}</p>
+              {advisor.ranked_actions.length > 0 && (
+                <p className="text-[11px] text-fg-subtle">
+                  Recommended order: {advisor.ranked_actions.join(' → ')}
+                </p>
+              )}
+            </>
+          )}
+        </div>
 
         {loading && (
           <p className="text-sm text-fg-muted py-4">Computing suggestions…</p>
@@ -162,15 +284,11 @@ export default function RebalanceSuggestionsDialog({
 
         {!loading && suggestions.length === 0 && !error && (
           <div className="py-3 space-y-2">
-            <p className="text-sm text-fg">
-              No automatic recommendations available.
-            </p>
+            <p className="text-sm text-fg">No automatic recommendations available.</p>
             <p className="text-xs text-fg-muted">
-              Either every recipient is already at capacity, or the
-              overflow is geographically too far for any other branch
-              to absorb. Use the Branch Assignments map view to manually
-              reassign individual properties, or extend the cycle / add
-              a crew.
+              Either every recipient is at capacity, the geography is too far,
+              or no crew is severely idle. Use the Branch Assignments map view
+              to manually reassign individual properties.
             </p>
           </div>
         )}
@@ -180,6 +298,8 @@ export default function RebalanceSuggestionsDialog({
             {suggestions.map((s) => {
               const isApplied = applied.has(s.id)
               const isApplying = applying === s.id
+              const meta = TYPE_META[s.type]
+              const Icon = meta.icon
               return (
                 <li
                   key={s.id}
@@ -191,31 +311,26 @@ export default function RebalanceSuggestionsDialog({
                   }
                 >
                   <div className="flex items-start justify-between gap-3">
-                    <div className="min-w-0 flex-1">
-                      <p className="text-sm font-semibold text-fg flex items-center gap-2 flex-wrap">
-                        {s.cluster_label}{' '}
-                        <span className="inline-flex items-center gap-1 text-xs text-fg-muted">
-                          <Badge variant="outline" className="text-[10px]">
-                            {s.from_branch_name}
-                          </Badge>
-                          <ArrowRight className="h-3 w-3" />
-                          <Badge variant="accent" className="text-[10px]">
-                            {s.to_branch_name}
-                          </Badge>
-                        </span>
-                      </p>
-                      <p className="text-xs text-fg-muted mt-1">{s.summary}</p>
+                    <div className="min-w-0 flex-1 space-y-1">
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <Badge
+                          variant={meta.color as any}
+                          className="text-[10px] inline-flex items-center gap-1"
+                        >
+                          <Icon className="h-3 w-3" />
+                          {meta.label}
+                        </Badge>
+                        <p className="text-sm font-semibold text-fg">{s.title}</p>
+                      </div>
+                      <p className="text-xs text-fg-muted">{s.summary}</p>
+                      <SuggestionVisual s={s} />
                     </div>
                     {isApplied ? (
                       <Badge variant="success" className="text-[10px] flex-shrink-0">
                         Applied
                       </Badge>
                     ) : (
-                      <Button
-                        size="sm"
-                        onClick={() => apply(s)}
-                        loading={isApplying}
-                      >
+                      <Button size="sm" onClick={() => apply(s)} loading={isApplying}>
                         Apply
                       </Button>
                     )}
@@ -234,11 +349,7 @@ export default function RebalanceSuggestionsDialog({
               </Button>
             )}
             {applied.size > 0 && (
-              <Button
-                size="sm"
-                onClick={regenerateAndClose}
-                loading={regenerating}
-              >
+              <Button size="sm" onClick={regenerateAndClose} loading={regenerating}>
                 Regenerate template ({applied.size} applied)
               </Button>
             )}
@@ -249,5 +360,38 @@ export default function RebalanceSuggestionsDialog({
         </DialogFooter>
       </DialogContent>
     </Dialog>
+  )
+}
+
+function SuggestionVisual({ s }: { s: Suggestion }) {
+  if (s.type === 'property_move') {
+    return (
+      <div className="flex items-center gap-1 text-xs text-fg-muted">
+        <Badge variant="outline" className="text-[10px]">{s.from_branch_name}</Badge>
+        <ArrowRight className="h-3 w-3" />
+        <Badge variant="accent" className="text-[10px]">{s.to_branch_name}</Badge>
+        <span className="ml-1 font-tabular">
+          {s.property_count} propert{s.property_count === 1 ? 'y' : 'ies'}
+        </span>
+      </div>
+    )
+  }
+  if (s.type === 'crew_relocate') {
+    return (
+      <div className="flex items-center gap-1 text-xs text-fg-muted">
+        <Badge variant="outline" className="text-[10px]">{s.crew_label} @ {s.from_branch_name}</Badge>
+        <ArrowRight className="h-3 w-3" />
+        <Badge variant="warning" className="text-[10px]">{s.to_branch_name}</Badge>
+        <span className="ml-1 font-tabular">{s.idle_days_freed}d freed</span>
+      </div>
+    )
+  }
+  return (
+    <div className="flex items-center gap-1 text-xs text-fg-muted">
+      <Badge variant="danger" className="text-[10px]">
+        {s.branch_name}: {s.current_count} → {s.proposed_count}
+      </Badge>
+      <span className="ml-1 font-tabular">~{s.idle_days_freed}d/crew freed</span>
+    </div>
   )
 }

--- a/src/pages/accounts/scheduler/CycleDetail.tsx
+++ b/src/pages/accounts/scheduler/CycleDetail.tsx
@@ -519,13 +519,20 @@ export default function CycleDetailPage() {
               )}
             </div>
             <div className="flex items-center gap-2">
-              {unplacedVisits.length > 0 && cycle?.template_id && (
+              {cycle?.template_id && (
                 <Button
                   size="sm"
                   variant="secondary"
                   onClick={() => setRebalanceOpen(true)}
+                  title={
+                    unplacedVisits.length > 0
+                      ? `${unplacedVisits.length} unplaced — get rebalance suggestions`
+                      : 'Open the rebalance analyzer (also surfaces severely-idle crews)'
+                  }
                 >
-                  Suggest rebalance ({unplacedVisits.length})
+                  {unplacedVisits.length > 0
+                    ? `Suggest rebalance (${unplacedVisits.length})`
+                    : 'Suggest rebalance'}
                 </Button>
               )}
               <CycleChatDrawer


### PR DESCRIPTION
## Why
Previous endpoint produced only \`property_move\` suggestions and only when unplaced > 0, with strict filters that often returned nothing. Reported case: 14 crews, 191 idle, 82 dropped, Crew 6 worked 3 days — \"no recommendations.\"

## Three remediation types

**property_move** (looser): partial absorption (recipient just needs SOME idle capacity, not full cluster); distance cap 2× → 4× cluster radius.

**crew_relocate** (NEW): crew below 40% utilization gets a relocate-to-branch-with-unserved-demand suggestion. Apply patches \`crew_count_per_branch_override\` (−1 origin, +1 target).

**crew_reduce** (NEW): branch with >0.6 idle-fraction per crew and not already a relocate source → suggest dropping a crew. Apply patches the same override (−1).

## AI advisor
Send \`X-Advise: true\` header → endpoint synthesizes via \`claude-sonnet-4-5\` with cycle context (idle-by-branch, low-util crews, unplaced count) and the heuristic candidates. Returns ranked_actions JSON. Dialog displays as a top callout; \"Apply all\" follows the ranked order. LLM failures never break the deterministic suggestions.

## Apply
- property_move → existing \`templates/[id]/branch-overrides\`
- crew_relocate / crew_reduce → new \`cycles/[id]/apply-rebalance\` (resolves cycle → template → client → patches constraints)

## Dialog
- Type-aware row icons + visuals
- \"Generate recommendation\" opts into LLM (not auto-fired — saves quota)
- \"Suggest rebalance\" button no longer requires unplaced > 0; opens whenever there's a cycle

## Test plan
- [ ] Cycle with 191 idle days + 1 crew working 3 days → suggestions list shows crew_relocate + possibly crew_reduce
- [ ] Cycle with unplaced visits → property_move suggestions appear with partial absorption when recipient idle < cluster size
- [ ] Click \"Generate recommendation\" → advisor card shows narrative
- [ ] Apply crew_relocate → constraints \`crew_count_per_branch_override\` updated; Regenerate → next cycle reflects relocation

🤖 Generated with [Claude Code](https://claude.com/claude-code)