### PR TITLE
Fix: rebalance suggestions validate against live constraints

### DIFF
--- a/api/scheduler/cycles/[cycleId]/rebalance-suggestions.ts
+++ b/api/scheduler/cycles/[cycleId]/rebalance-suggestions.ts
@@ -410,6 +410,46 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       return s.service_location_ids.some((sl) => overrides[sl] !== s.to_branch_idx)
     })
   }
+
+  // Cross-check crew_relocate / crew_reduce against the LIVE constraints.
+  // Earlier Applies in this session patch crew_count_per_branch_override
+  // before the user regenerates — the cycle still shows the old staging,
+  // so without this check we'd offer stale suggestions like "relocate a
+  // crew from Lindon" after Lindon's count was already zeroed.
+  const { data: conRow } = await db
+    .from('account_operational_constraints')
+    .select('crew_count_per_branch_override')
+    .eq('account_id', (template as any).account_id)
+    .eq('client_id', (template as any).client_id)
+    .maybeSingle()
+  const liveStaging: Record<string, number> = {}
+  const overrideSrc = ((conRow as any)?.crew_count_per_branch_override ?? null) as
+    | Record<string, number>
+    | null
+  if (overrideSrc) {
+    for (const [k, v] of Object.entries(overrideSrc)) {
+      if (k === '__roving') continue
+      const n = Math.floor(Number(v) || 0)
+      if (n > 0) liveStaging[k] = n
+    }
+  }
+  // Lookup is case-insensitive on branch names.
+  const liveLookup = (name: string): number => {
+    if (Object.keys(liveStaging).length === 0) return Number.POSITIVE_INFINITY
+    if (liveStaging[name] != null) return liveStaging[name]
+    const ci = Object.entries(liveStaging).find(
+      ([k]) => k.toLowerCase() === name.toLowerCase()
+    )
+    return ci ? ci[1] : 0
+  }
+  const beforeFilter = filtered.length
+  filtered = filtered.filter((s) => {
+    if (s.type === 'crew_relocate') return liveLookup(s.from_branch_name) >= 1
+    if (s.type === 'crew_reduce') return liveLookup(s.branch_name) >= 2
+    return true
+  })
+  const stalenessSkipped = beforeFilter - filtered.length
+
   filtered.sort((a, b) => b.priority - a.priority)
 
   // ── 4. Optional Claude advisor on top ─────────────────────────────
@@ -499,5 +539,10 @@ Be terse. The operator scans, doesn't read.`
     }
   }
 
-  return res.status(200).json({ suggestions: filtered, advisor })
+  return res.status(200).json({
+    suggestions: filtered,
+    advisor,
+    stale_skipped: stalenessSkipped,
+    needs_regenerate: stalenessSkipped > 0,
+  })
 }

--- a/src/components/scheduler/RebalanceSuggestionsDialog.tsx
+++ b/src/components/scheduler/RebalanceSuggestionsDialog.tsx
@@ -94,6 +94,8 @@ export default function RebalanceSuggestionsDialog({
   const [applied, setApplied] = useState<Set<string>>(new Set())
   const [applying, setApplying] = useState<string | null>(null)
   const [regenerating, setRegenerating] = useState(false)
+  const [staleSkipped, setStaleSkipped] = useState(0)
+  const [needsRegenerate, setNeedsRegenerate] = useState(false)
 
   const loadSuggestions = async (withAdvisor: boolean) => {
     setLoading(!withAdvisor)
@@ -113,6 +115,8 @@ export default function RebalanceSuggestionsDialog({
       const json = await res.json().catch(() => ({}))
       if (!res.ok) throw new Error((json as any).error ?? `HTTP ${res.status}`)
       setSuggestions((json as any).suggestions ?? [])
+      setStaleSkipped(Number((json as any).stale_skipped ?? 0))
+      setNeedsRegenerate(Boolean((json as any).needs_regenerate))
       if (withAdvisor) setAdvisor((json as any).advisor ?? null)
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e))
@@ -126,6 +130,8 @@ export default function RebalanceSuggestionsDialog({
     if (!open) return
     setApplied(new Set())
     setAdvisor(null)
+    setStaleSkipped(0)
+    setNeedsRegenerate(false)
     void loadSuggestions(false)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open, cycleId])
@@ -188,6 +194,14 @@ export default function RebalanceSuggestionsDialog({
         }
       }
       setApplied((prev) => new Set([...prev, s.id]))
+      // After a crew_relocate / crew_reduce, the constraints just
+      // changed but the cycle hasn't been regenerated. Reload suggestions
+      // so any newly-stale ones (e.g. another move out of the same
+      // branch we just emptied) get filtered out and the user sees a
+      // "regenerate to refresh" hint.
+      if (s.type === 'crew_relocate' || s.type === 'crew_reduce') {
+        await loadSuggestions(false)
+      }
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e))
     } finally {
@@ -230,6 +244,33 @@ export default function RebalanceSuggestionsDialog({
             then regenerate the template.
           </DialogDescription>
         </DialogHeader>
+
+        {/* Staleness banner — fires when current constraints differ
+            from the cycle's snapshot (e.g. user already applied a
+            relocate/reduce and hasn't regenerated yet). Without this,
+            the suggestion list reads against the cycle and proposes
+            moves that no longer apply. */}
+        {needsRegenerate && (
+          <div className="rounded-md border border-warning/40 bg-warning-subtle/40 px-3 py-2 text-sm text-fg flex items-center justify-between gap-3 flex-wrap">
+            <div>
+              <strong>Regenerate to refresh.</strong>{' '}
+              <span className="text-fg-muted">
+                {staleSkipped > 0
+                  ? `${staleSkipped} suggestion${staleSkipped === 1 ? '' : 's'} hidden because constraints have already been updated since this cycle ran.`
+                  : 'Constraints have changed since this cycle was generated.'}
+                {' '}Re-run the template to get a fresh analysis.
+              </span>
+            </div>
+            <Button
+              size="sm"
+              variant="secondary"
+              onClick={regenerateAndClose}
+              loading={regenerating}
+            >
+              Regenerate now
+            </Button>
+          </div>
+        )}
 
         {/* Advisor card */}
         <div className="rounded-md border border-accent/20 bg-accent-subtle/30 p-3 space-y-2">


### PR DESCRIPTION
## Bug
After applying a crew_relocate or crew_reduce, the next set of suggestions kept proposing moves out of branches that had already been zeroed. \"Three recommendations that can't be made because there isn't a crew it wants to move out of.\"

## Why
The suggestion engine reads CYCLE state (which is stale until regenerate). Apply patches CONSTRAINTS (live). Without cross-checking, suggestions reflect the pre-apply staging.

## Fix
- After computing suggestions, read live \`crew_count_per_branch_override\`.
- Drop \`crew_relocate\` whose \`from_branch_name\` has < 1 crew live.
- Drop \`crew_reduce\` whose \`branch_name\` has < 2 crews live (need >1 to drop one).
- Endpoint surfaces \`needs_regenerate\` + \`stale_skipped\`.

## Dialog
- Auto-refetch suggestions after a successful crew_relocate / crew_reduce apply.
- New banner at the top when needs_regenerate=true, with one-click \"Regenerate now\".

## Test plan
- [ ] Apply a crew_relocate → suggestions auto-refresh; no stale moves out of the now-empty branch
- [ ] If suggestions get filtered out, banner says \"X hidden — regenerate to refresh\"
- [ ] property_move suggestions unaffected (don't depend on constraints)

🤖 Generated with [Claude Code](https://claude.com/claude-code)