### PR TITLE
Fix: crew labels always include home branch

### DIFF
--- a/api/_lib/scheduler/build-routing-template.ts
+++ b/api/_lib/scheduler/build-routing-template.ts
@@ -864,35 +864,24 @@ export function buildRoutingTemplate(input: BuildTemplateInput): TemplateBuildRe
     target.workdays_assigned += clusterWorkdays
   }
 
-  // Branch-prefixed crew labels: pick each crew's dominant branch
-  // (most work hours among assigned clusters) and number per-branch so
-  // labels read "Frisco TX Crew 1", "Frisco TX Crew 2", "Sugarland Crew 1".
+  // Branch-prefixed crew labels: every crew is labeled by its HOME
+  // branch — the place its drive math starts each day — never just
+  // "Crew 5". A crew that ended up idle (no clusters assigned) still
+  // belongs to a home; an idle "Crew 6" with no label provenance is a
+  // worse experience than "Lindon Crew 4" that happens to be idle.
+  //
+  // Number sequentially within each home branch (Lindon Crew 1,
+  // Lindon Crew 2, Phoenix Crew 1, ...) in crew-index order so the
+  // numbering is stable across regenerates.
   if (input.branches.length > 0) {
     const branchCounters = new Map<number, number>()
     for (const crew of crews) {
-      const workByBranch = new Map<number, number>()
-      for (const clusterId of crew.cluster_ids) {
-        const cluster = clusters.find((c) => c.cluster_id === clusterId)
-        if (!cluster) continue
-        workByBranch.set(
-          cluster.base_branch_index,
-          (workByBranch.get(cluster.base_branch_index) ?? 0) + cluster.total_work_hours
-        )
-      }
-      let dominantBranchIdx = -1
-      let dominantHours = -1
-      for (const [idx, hours] of workByBranch) {
-        if (hours > dominantHours) {
-          dominantHours = hours
-          dominantBranchIdx = idx
-        }
-      }
-      if (dominantBranchIdx >= 0) {
-        const branchName = input.branches[dominantBranchIdx]?.name ?? `Branch ${dominantBranchIdx + 1}`
-        const counter = (branchCounters.get(dominantBranchIdx) ?? 0) + 1
-        branchCounters.set(dominantBranchIdx, counter)
-        crew.label = `${branchName} Crew ${counter}`
-      }
+      const homeIdx = crew.home_branch_index
+      const branchName =
+        input.branches[homeIdx]?.name ?? `Branch ${homeIdx + 1}`
+      const counter = (branchCounters.get(homeIdx) ?? 0) + 1
+      branchCounters.set(homeIdx, counter)
+      crew.label = `${branchName} Crew ${counter}`
     }
   }
 

--- a/api/scheduler/cycles/[cycleId]/idle-analysis.ts
+++ b/api/scheduler/cycles/[cycleId]/idle-analysis.ts
@@ -100,6 +100,23 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     }
   }
 
+  // Per-branch counter so labels are sequential (Lindon Crew 1, 2, …).
+  // Walk crewAssignments in index order so numbering is stable.
+  const crewLabelByIdx = new Map<number, string>()
+  {
+    const counter = new Map<number, number>()
+    const sorted = [...crewAssignments].sort((a, b) => (a.index ?? 0) - (b.index ?? 0))
+    for (const ca of sorted) {
+      const idx = ca.index
+      const home = ca.home_branch_index
+      if (typeof idx !== 'number' || typeof home !== 'number') continue
+      const branchName = branches[home]?.name ?? `Branch ${home + 1}`
+      const n = (counter.get(home) ?? 0) + 1
+      counter.set(home, n)
+      crewLabelByIdx.set(idx, `${branchName} Crew ${n}`)
+    }
+  }
+
   // Per-day utilization (reuses scheduler's authoritative classifier).
   const days = await computeCrewUtilization(db, cycleId, { include_weekends: false })
   // We only care about workdays here (between_trips, travel, rest, idle,
@@ -161,9 +178,12 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       else pattern = 'mixed'
     }
 
+    const homeLabel =
+      crewLabelByIdx.get(crewIdx) ??
+      (homeName ? `${homeName} Crew ${crewIdx + 1}` : `Crew ${crewIdx + 1}`)
     crewSummaries.push({
       crew_index: crewIdx,
-      crew_label: arr[0]?.crew_label ?? `Crew ${crewIdx + 1}`,
+      crew_label: homeLabel,
       home_branch_index: homeIdx,
       home_branch_name: homeName,
       workdays_total: total,

--- a/api/scheduler/cycles/[cycleId]/rebalance-suggestions.ts
+++ b/api/scheduler/cycles/[cycleId]/rebalance-suggestions.ts
@@ -136,28 +136,45 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     home_branch_index?: number
   }>
 
-  // crew_index → home branch (template snapshot). Falls back to
-  // start_location coords matched against branches.
+  // crew_index → home branch (template snapshot). Always rebuild the
+  // human label from the home branch — even legacy templates with
+  // unprefixed "Crew N" labels get clean "Lindon Crew 1" style names
+  // here without requiring a regenerate.
   const crewBranch = new Map<number, { idx: number; name: string; lat: number; lng: number; label: string }>()
-  for (const ca of crewAssignments) {
+  // First pass: bucket crews by home_branch_index so the per-branch
+  // counter is sequential (Lindon Crew 1, Lindon Crew 2, etc.).
+  const branchCounters = new Map<number, number>()
+  // Walk in crew-index order so numbering is stable.
+  const sortedAssignments = [...crewAssignments].sort((a, b) => {
+    const ai = typeof a.index === 'number' ? a.index : 0
+    const bi = typeof b.index === 'number' ? b.index : 0
+    return ai - bi
+  })
+  for (const ca of sortedAssignments) {
     const idx = typeof ca.index === 'number' ? ca.index : null
     const home = typeof ca.home_branch_index === 'number' ? ca.home_branch_index : null
     if (idx == null || home == null) continue
     const b = branches[home]
     if (!b) continue
+    const counter = (branchCounters.get(home) ?? 0) + 1
+    branchCounters.set(home, counter)
     crewBranch.set(idx, {
       idx: home,
       name: b.name,
       lat: b.lat,
       lng: b.lng,
-      label: ca.label ?? `Crew ${idx + 1}`,
+      label: `${b.name} Crew ${counter}`,
     })
   }
   // Fallback for any crew without a template assignment row.
+  // Resolve a home branch from start_location coords (or modulo as a
+  // last resort) and ALWAYS build a branch-prefixed label.
   for (let i = 0; i < crewCount; i++) {
     if (crewBranch.has(i)) continue
     const cd = crewDays.find((d: any) => d.crew_index === i)
     const sl = cd?.start_location
+    let resolvedIdx: number
+    let resolvedBranch: { name: string; lat: number; lng: number }
     if (sl && typeof sl.lat === 'number' && typeof sl.lng === 'number') {
       let bestIdx = 0
       let best = Number.POSITIVE_INFINITY
@@ -165,25 +182,24 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         const d = haversineMiles({ lat: sl.lat, lng: sl.lng }, branches[j])
         if (d < best) { best = d; bestIdx = j }
       }
-      crewBranch.set(i, {
-        idx: bestIdx,
-        name: sl.name ?? branches[bestIdx]?.name ?? `Crew ${i + 1}`,
-        lat: sl.lat,
-        lng: sl.lng,
-        label: cd?.crew_label ?? `Crew ${i + 1}`,
-      })
+      resolvedIdx = bestIdx
+      resolvedBranch = branches[bestIdx] ?? { name: sl.name ?? `Branch ${bestIdx + 1}`, lat: sl.lat, lng: sl.lng }
     } else {
-      const b = branches[i % Math.max(1, branches.length)]
-      if (b) {
-        crewBranch.set(i, {
-          idx: i % branches.length,
-          name: b.name,
-          lat: b.lat,
-          lng: b.lng,
-          label: cd?.crew_label ?? `Crew ${i + 1}`,
-        })
-      }
+      const fallbackIdx = i % Math.max(1, branches.length)
+      const b = branches[fallbackIdx]
+      if (!b) continue
+      resolvedIdx = fallbackIdx
+      resolvedBranch = b
     }
+    const counter = (branchCounters.get(resolvedIdx) ?? 0) + 1
+    branchCounters.set(resolvedIdx, counter)
+    crewBranch.set(i, {
+      idx: resolvedIdx,
+      name: resolvedBranch.name,
+      lat: resolvedBranch.lat,
+      lng: resolvedBranch.lng,
+      label: `${resolvedBranch.name} Crew ${counter}`,
+    })
   }
 
   // Workday calendar + per-crew busy/idle counts.


### PR DESCRIPTION
## Bug
Idle crews showed up as just \"Crew 5\" / \"Crew 6\" with no home context. The engine's labeling pass picked each crew's \"dominant branch\" (most cluster work hours); crews with no clusters got no prefix.

## Fix
Build labels from \`crew.home_branch_index\` everywhere — every crew has a home (the new model), so every label reads \"Lindon Crew 1\", \"Phoenix Crew 2\", etc. Stable sequential numbering within each home.

Three surfaces:
- **Engine** (\`build-routing-template.ts\`): label pass uses home_branch_index instead of cluster domination.
- **Rebalance suggestions endpoint**: defensively rebuilds labels in the endpoint, so existing templates get clean labels without requiring a regenerate.
- **Idle analyzer endpoint**: same, so Utilization tab is consistent.

## Test plan
- [ ] Open the rebalance dialog on an existing cycle with idle crews → suggestions show \"Lindon Crew 4 @ Lindon, UT\" not \"Crew 6\"
- [ ] Open Utilization tab → idle crews show with full label
- [ ] After regenerating a template, new \`crew_assignments\` rows have prefixed labels too

🤖 Generated with [Claude Code](https://claude.com/claude-code)