### PR TITLE
Audit: fix crew labeling + residual padding cascade

### DIFF
--- a/api/_lib/scheduler/build-routing-template.ts
+++ b/api/_lib/scheduler/build-routing-template.ts
@@ -140,6 +140,8 @@ export interface TemplateBuildResult {
   crew_assignments: Array<{
     crew_index: number
     crew_label: string
+    home_branch_index: number
+    home_branch_name: string
     cluster_ids: string[]
     total_work_hours: number
     total_drive_hours: number
@@ -1383,6 +1385,8 @@ export function buildRoutingTemplate(input: BuildTemplateInput): TemplateBuildRe
     crew_assignments: crews.map((c) => ({
       crew_index: c.index,
       crew_label: c.label,
+      home_branch_index: c.home_branch_index,
+      home_branch_name: input.branches[c.home_branch_index]?.name ?? `Branch ${c.home_branch_index + 1}`,
       cluster_ids: c.cluster_ids,
       total_work_hours: c.total_work_hours,
       total_drive_hours: c.total_drive_hours,

--- a/api/_lib/scheduler/derive-home-branches.ts
+++ b/api/_lib/scheduler/derive-home-branches.ts
@@ -56,17 +56,60 @@ export function deriveHomeBranchIndices(
     }
   }
 
-  // Build the flat array: for each entry, push idx repeated count times.
+  // Residuals when sum(per_branch) < crew_count. Distribute them
+  // PROPORTIONALLY to the existing per-branch weights (largest-
+  // remainder method) instead of dumping every extra at branch 0.
+  // Previously this caused a hidden bug: with override = {Albuquerque:
+  // 1, Lindon: 4, Phoenix: 2} sum=7 and crew_count=14, the engine put
+  // 7 extras at Albuquerque → 8 crews there, then suggestions showed
+  // "Albuquerque Crew 1, 2, 3" when the operator only staged 1.
+  const residual = crewCount - counts.reduce((s, c) => s + c.count, 0)
+  if (residual > 0) {
+    const sumExisting = counts.reduce((s, c) => s + c.count, 0)
+    if (sumExisting > 0) {
+      const fracs = counts.map((c) => ({
+        idx: c.idx,
+        whole: 0,
+        rem: 0,
+      }))
+      let assigned = 0
+      for (let i = 0; i < counts.length; i++) {
+        const want = (counts[i].count / sumExisting) * residual
+        fracs[i].whole = Math.floor(want)
+        fracs[i].rem = want - fracs[i].whole
+        assigned += fracs[i].whole
+      }
+      // Largest-remainder: top up the entries with the biggest
+      // fractional parts first.
+      const order = [...fracs].sort((a, b) => b.rem - a.rem)
+      let r = 0
+      while (assigned < residual && r < order.length) {
+        order[r].whole++
+        assigned++
+        r++
+      }
+      for (let i = 0; i < counts.length; i++) {
+        counts[i].count += fracs[i].whole
+      }
+    }
+    // If still under (no existing weights to scale), round-robin across
+    // branches so we don't all-pile on branch 0.
+    if (counts.reduce((s, c) => s + c.count, 0) < crewCount) {
+      const needed = crewCount - counts.reduce((s, c) => s + c.count, 0)
+      for (let i = 0; i < needed; i++) {
+        const targetIdx = i % branches.length
+        // Find existing entry or add a new one.
+        const existing = counts.find((c) => c.idx === targetIdx)
+        if (existing) existing.count++
+        else counts.push({ idx: targetIdx, count: 1 })
+      }
+    }
+  }
+
+  // Build the flat array.
   const result: number[] = []
   for (const c of counts) {
     for (let j = 0; j < c.count; j++) result.push(c.idx)
   }
-
-  // Residual crews when sum(per_branch) < crew_count: stage at branch
-  // index 0 (operator UI in PR2 will require sum = total to remove this
-  // case). For now, branch 0 is a defensible default — it's typically
-  // the primary branch in operator input order.
-  while (result.length < crewCount) result.push(0)
-
   return result
 }

--- a/api/scheduler/cycles/[cycleId]/idle-analysis.ts
+++ b/api/scheduler/cycles/[cycleId]/idle-analysis.ts
@@ -14,6 +14,7 @@ import type { VercelRequest, VercelResponse } from '@vercel/node'
 import { createAdminClient } from '../../../_lib/supabase.js'
 import { authenticateRequest } from '../../../_lib/auth.js'
 import { computeCrewUtilization } from '../../../_lib/scheduler/crew-utilization.js'
+import { haversineMiles } from '../../../_lib/analysis/haversine.js'
 
 interface IdleStreak {
   start_date: string
@@ -74,10 +75,16 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     .maybeSingle()
   const crewCount = (tpl as any)?.crew_count ?? 1
   const branches = ((tpl as any)?.branches ?? []) as Array<{ name: string; lat: number; lng: number }>
+  // Persisted crew_assignments use the crew_-prefixed keys (the engine
+  // renames index→crew_index / label→crew_label on emit). Read the
+  // prefixed form. home_branch_index has been written since the audit
+  // fix — older templates may not have it; we derive from crew_day_routes'
+  // start_location below as a defensive fallback.
   const crewAssignments = ((tpl as any)?.crew_assignments ?? []) as Array<{
-    index?: number
-    label?: string
+    crew_index?: number
+    crew_label?: string
     home_branch_index?: number
+    home_branch_name?: string
   }>
 
   // Unplaced visits — we use the count to compute "what you'd actually
@@ -91,29 +98,15 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     .eq('status', 'unplaced')
   const unplacedCount = unplacedCountRaw ?? 0
 
-  // crew_index → home_branch_index (template snapshot, taken at build time).
+  // crew_index → home_branch_index. Prefer the template snapshot;
+  // for legacy templates (pre-audit) the field may be missing — derive
+  // from crew_day_routes start_location matched against branches by
+  // haversine distance.
   const homeByCrewIdx = new Map<number, number>()
   for (const ca of crewAssignments) {
-    const idx = ca.index
+    const idx = ca.crew_index
     if (typeof idx === 'number' && typeof ca.home_branch_index === 'number') {
       homeByCrewIdx.set(idx, ca.home_branch_index)
-    }
-  }
-
-  // Per-branch counter so labels are sequential (Lindon Crew 1, 2, …).
-  // Walk crewAssignments in index order so numbering is stable.
-  const crewLabelByIdx = new Map<number, string>()
-  {
-    const counter = new Map<number, number>()
-    const sorted = [...crewAssignments].sort((a, b) => (a.index ?? 0) - (b.index ?? 0))
-    for (const ca of sorted) {
-      const idx = ca.index
-      const home = ca.home_branch_index
-      if (typeof idx !== 'number' || typeof home !== 'number') continue
-      const branchName = branches[home]?.name ?? `Branch ${home + 1}`
-      const n = (counter.get(home) ?? 0) + 1
-      counter.set(home, n)
-      crewLabelByIdx.set(idx, `${branchName} Crew ${n}`)
     }
   }
 
@@ -122,6 +115,54 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   // We only care about workdays here (between_trips, travel, rest, idle,
   // overnight_continuation, fully_utilized are all workday categories).
   const workdays = days.filter((d) => d.is_workday)
+
+  // Defensive fallback: any crew without a snapshot home_branch_index,
+  // resolve via crew_day_routes start_location → nearest branch by
+  // haversine. Necessary for templates generated before the audit fix.
+  if (homeByCrewIdx.size < crewCount && branches.length > 0) {
+    const { data: cdRows } = await db
+      .from('crew_day_routes')
+      .select('crew_index, start_location')
+      .eq('cycle_instance_id', cycleId)
+      .not('start_location', 'is', null)
+      .limit(crewCount * 5) // a few rows per crew is enough
+    const seen = new Set<number>()
+    for (const r of (cdRows ?? []) as any[]) {
+      if (seen.has(r.crew_index)) continue
+      const sl = r.start_location
+      if (!sl || typeof sl.lat !== 'number' || typeof sl.lng !== 'number') continue
+      let bestIdx = 0
+      let best = Number.POSITIVE_INFINITY
+      for (let j = 0; j < branches.length; j++) {
+        const d = haversineMiles({ lat: sl.lat, lng: sl.lng }, branches[j])
+        if (d < best) { best = d; bestIdx = j }
+      }
+      if (!homeByCrewIdx.has(r.crew_index)) {
+        homeByCrewIdx.set(r.crew_index, bestIdx)
+      }
+      seen.add(r.crew_index)
+    }
+    // Final fallback: any still-unmapped crew → branch 0.
+    for (let i = 0; i < crewCount; i++) {
+      if (!homeByCrewIdx.has(i)) homeByCrewIdx.set(i, 0)
+    }
+  }
+
+  // Build labels from the now-complete homeByCrewIdx. Sequential per
+  // home (Lindon Crew 1, Lindon Crew 2, …) by ascending crew_index for
+  // stable numbering across regenerates.
+  const crewLabelByIdx = new Map<number, string>()
+  {
+    const counter = new Map<number, number>()
+    const indices = Array.from(homeByCrewIdx.keys()).sort((a, b) => a - b)
+    for (const idx of indices) {
+      const home = homeByCrewIdx.get(idx)!
+      const branchName = branches[home]?.name ?? `Branch ${home + 1}`
+      const n = (counter.get(home) ?? 0) + 1
+      counter.set(home, n)
+      crewLabelByIdx.set(idx, `${branchName} Crew ${n}`)
+    }
+  }
 
   // Group by crew index for streak analysis.
   const byCrew = new Map<number, typeof workdays>()

--- a/api/scheduler/cycles/[cycleId]/rebalance-suggestions.ts
+++ b/api/scheduler/cycles/[cycleId]/rebalance-suggestions.ts
@@ -130,10 +130,14 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   const cfg = (template.config ?? {}) as Record<string, any>
   const clusterRadius = (cfg.cluster_radius_miles as number) ?? 30
   const crewCount = (template.crew_count as number) ?? 0
+  // Persisted with crew_-prefixed keys. home_branch_index has been
+  // emitted since the audit fix; older templates fall through to the
+  // start_location fallback below.
   const crewAssignments = (template.crew_assignments ?? []) as Array<{
-    index?: number
-    label?: string
+    crew_index?: number
+    crew_label?: string
     home_branch_index?: number
+    home_branch_name?: string
   }>
 
   // crew_index → home branch (template snapshot). Always rebuild the
@@ -146,12 +150,12 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   const branchCounters = new Map<number, number>()
   // Walk in crew-index order so numbering is stable.
   const sortedAssignments = [...crewAssignments].sort((a, b) => {
-    const ai = typeof a.index === 'number' ? a.index : 0
-    const bi = typeof b.index === 'number' ? b.index : 0
+    const ai = typeof a.crew_index === 'number' ? a.crew_index : 0
+    const bi = typeof b.crew_index === 'number' ? b.crew_index : 0
     return ai - bi
   })
   for (const ca of sortedAssignments) {
-    const idx = typeof ca.index === 'number' ? ca.index : null
+    const idx = typeof ca.crew_index === 'number' ? ca.crew_index : null
     const home = typeof ca.home_branch_index === 'number' ? ca.home_branch_index : null
     if (idx == null || home == null) continue
     const b = branches[home]


### PR DESCRIPTION
## Symptoms
1. No crew names anywhere — just \"Crew 1\" through \"Crew 14\" with no home
2. Suggestions to relocate \"Albuquerque Crew 1, 2, 3\" when only 1 crew was staged at Albuquerque
3. Apply All looped without effect

## Three cascading bugs

**Bug 1 — Engine never persisted \`home_branch_index\`.**
\`TemplateBuildResult.crew_assignments[]\` interface omitted the field; the \`.map()\` emit didn't include it. Every reader of \`template.crew_assignments[i].home_branch_index\` got \`undefined\`.

**Bug 2 — Field-name mismatch.**
Engine writes \`crew_index\` / \`crew_label\` (with prefix); rebalance-suggestions and idle-analysis both read \`.index\` / \`.label\` (no prefix). They've been getting \`null\` and falling through to the modulo fallback the whole time.

**Bug 3 — Residual crews all dumped on branch 0.**
\`deriveHomeBranchIndices\` padded with \`while (result.length < crewCount) result.push(0)\`. With override \`{Albuquerque: 1, Lindon: 4, Phoenix: 2}\` sum=7 + crew_count=14, the engine put 8 crews at Albuquerque (1 + 7 residuals). That's the source of \"3 Albuquerque crews\" suggestions.

## Fixes
- Engine: emit \`home_branch_index\` + \`home_branch_name\` in \`crew_assignments\`, update the interface.
- Readers: use \`crew_index\` / \`crew_label\`.
- \`deriveHomeBranchIndices\`: distribute residuals proportional to existing per-branch weights (largest-remainder); fall back to round-robin if no weights, never all-on-branch-0.
- Idle-analysis: defensive fallback for legacy templates — derive each crew's home by haversine-matching \`crew_day_routes.start_location\` to branches when \`home_branch_index\` is missing.

## Test plan
- [ ] Regenerate a template — utilization tab shows \"{Branch} Crew N\" labels everywhere
- [ ] Rebalance dialog shows full home-prefixed labels even on existing cycles (defensive fallback)
- [ ] Suggestion counts match actual staging (no phantom extras)
- [ ] Apply a relocate → constraints update visibly → next refetch shows the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)