### PR TITLE
Fix: Cycle Regenerate button + Apply All loop trap + orphan crew labels

### DIFF
--- a/api/scheduler/cycles/[cycleId]/idle-analysis.ts
+++ b/api/scheduler/cycles/[cycleId]/idle-analysis.ts
@@ -116,16 +116,21 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   // overnight_continuation, fully_utilized are all workday categories).
   const workdays = days.filter((d) => d.is_workday)
 
-  // Defensive fallback: any crew without a snapshot home_branch_index,
-  // resolve via crew_day_routes start_location → nearest branch by
-  // haversine. Necessary for templates generated before the audit fix.
-  if (homeByCrewIdx.size < crewCount && branches.length > 0) {
+  // Defensive fallback (always runs): any crew not already mapped to a
+  // home_branch_index, resolve via crew_day_routes start_location →
+  // nearest branch by haversine. Then any STILL-unmapped crew (idle
+  // crews with zero crew_day_routes rows) anchors to branch 0.
+  // This is unconditional because trusting the snapshot alone has
+  // burned us — older templates / partial writes / engine bugs have
+  // all produced "ghost crews" with no home, which then surface in the
+  // UI as "Crew 6" with no branch context.
+  if (branches.length > 0) {
     const { data: cdRows } = await db
       .from('crew_day_routes')
       .select('crew_index, start_location')
       .eq('cycle_instance_id', cycleId)
       .not('start_location', 'is', null)
-      .limit(crewCount * 5) // a few rows per crew is enough
+      .limit(crewCount * 5)
     const seen = new Set<number>()
     for (const r of (cdRows ?? []) as any[]) {
       if (seen.has(r.crew_index)) continue
@@ -142,7 +147,9 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       }
       seen.add(r.crew_index)
     }
-    // Final fallback: any still-unmapped crew → branch 0.
+    // Final fallback for any still-unmapped crew → branch 0. Without
+    // this, idle crews (no crew_day_routes at all) would never get a
+    // home and would show as bare "Crew N" in the UI.
     for (let i = 0; i < crewCount; i++) {
       if (!homeByCrewIdx.has(i)) homeByCrewIdx.set(i, 0)
     }

--- a/src/components/scheduler/RebalanceSuggestionsDialog.tsx
+++ b/src/components/scheduler/RebalanceSuggestionsDialog.tsx
@@ -215,9 +215,24 @@ export default function RebalanceSuggestionsDialog({
       advisor?.ranked_actions
         ?.map((id) => suggestions.find((s) => s.id === id))
         .filter((s): s is Suggestion => !!s) ?? suggestions
-    for (const s of queue) {
-      if (applied.has(s.id)) continue
+    // Snapshot up front. apply() may refetch and mutate `suggestions`;
+    // we work off this frozen list so we don't re-apply or skip.
+    const queueSnapshot = queue.slice()
+    let appliedSomething = false
+    for (const s of queueSnapshot) {
+      // Apply takes the suggestion object directly — it doesn't need
+      // to look up the latest `suggestions` array, so refetches between
+      // iterations don't cause issues.
       await apply(s)
+      appliedSomething = true
+    }
+    // After applying everything, push the user toward regenerate
+    // automatically — leaving the dialog in "applied but stale" state
+    // is the loop the operator was complaining about. Without this,
+    // the dialog refetches stale-validated suggestions and shows
+    // "click apply or skip" with no path forward.
+    if (appliedSomething) {
+      await regenerateAndClose()
     }
   }
 

--- a/src/pages/accounts/scheduler/CycleDetail.tsx
+++ b/src/pages/accounts/scheduler/CycleDetail.tsx
@@ -208,17 +208,17 @@ export default function CycleDetailPage() {
     }
   }, [cycle?.template_id, cycle?.start_date, cycle?.cycle_number, getToken, load])
 
-  // Regenerate the parent template in-place. The cycle reads its
-  // unplaced_visits from the template, so when engine code changes
-  // (e.g. a recent fix to surface ungeocoded properties) the template
-  // must be rebuilt for the cycle UI to reflect the new logic.
+  // Regenerate the parent template AND re-derive this cycle from the
+  // new template in one shot. This is the "apply changes" button on
+  // the Cycle Detail header — the user just changed staging /
+  // calibration / rebalance and wants to see the result.
   const regenerateTemplate = useCallback(async () => {
     if (!cycle?.template_id) return
     setRegeneratingTemplate(true)
     setError(null)
     try {
       const token = await getToken()
-      const res = await fetch(
+      const tplRes = await fetch(
         `/api/scheduler/templates/${cycle.template_id}/regenerate`,
         {
           method: 'POST',
@@ -226,9 +226,29 @@ export default function CycleDetailPage() {
           body: JSON.stringify({}),
         }
       )
-      if (!res.ok) {
-        const j = await res.json().catch(() => ({}))
-        throw new Error((j as any).error ?? `HTTP ${res.status}`)
+      if (!tplRes.ok) {
+        const j = await tplRes.json().catch(() => ({}))
+        throw new Error((j as any).error ?? `Template regen HTTP ${tplRes.status}`)
+      }
+      // Also re-derive THIS cycle so the Cycle Detail page reflects
+      // the new template — without this, the user keeps seeing stale
+      // crew assignments + idle days even after the template has been
+      // rebuilt with new staging.
+      const cycleRes = await fetch(
+        `/api/scheduler/templates/${cycle.template_id}/generate-cycle`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+          body: JSON.stringify({
+            start_date: cycle.start_date,
+            cycle_number: cycle.cycle_number,
+            apply_template_changes: true,
+          }),
+        }
+      )
+      if (!cycleRes.ok) {
+        const j = await cycleRes.json().catch(() => ({}))
+        throw new Error((j as any).error ?? `Cycle regen HTTP ${cycleRes.status}`)
       }
       await load()
     } catch (err) {
@@ -236,7 +256,7 @@ export default function CycleDetailPage() {
     } finally {
       setRegeneratingTemplate(false)
     }
-  }, [cycle?.template_id, getToken, load])
+  }, [cycle?.template_id, cycle?.start_date, cycle?.cycle_number, getToken, load])
 
   const placedVisits = visits.filter((v) => v.status === 'placed')
   const unplacedVisits = visits.filter((v) => v.status === 'unplaced')
@@ -520,20 +540,31 @@ export default function CycleDetailPage() {
             </div>
             <div className="flex items-center gap-2">
               {cycle?.template_id && (
-                <Button
-                  size="sm"
-                  variant="secondary"
-                  onClick={() => setRebalanceOpen(true)}
-                  title={
-                    unplacedVisits.length > 0
-                      ? `${unplacedVisits.length} unplaced — get rebalance suggestions`
-                      : 'Open the rebalance analyzer (also surfaces severely-idle crews)'
-                  }
-                >
-                  {unplacedVisits.length > 0
-                    ? `Suggest rebalance (${unplacedVisits.length})`
-                    : 'Suggest rebalance'}
-                </Button>
+                <>
+                  <Button
+                    size="sm"
+                    variant="secondary"
+                    onClick={() => setRebalanceOpen(true)}
+                    title={
+                      unplacedVisits.length > 0
+                        ? `${unplacedVisits.length} unplaced — get rebalance suggestions`
+                        : 'Open the rebalance analyzer (also surfaces severely-idle crews)'
+                    }
+                  >
+                    {unplacedVisits.length > 0
+                      ? `Suggest rebalance (${unplacedVisits.length})`
+                      : 'Suggest rebalance'}
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="secondary"
+                    onClick={regenerateTemplate}
+                    loading={regeneratingTemplate}
+                    title="Re-run the template build with current constraints, then refresh this cycle from the new template. Use after applying staging/calibration/rebalance changes."
+                  >
+                    Regenerate
+                  </Button>
+                </>
               )}
               <CycleChatDrawer
                 cycleId={cycleId!}


### PR DESCRIPTION
## Three fixes for the rebalance / calibration loop

### 1. No Regenerate trigger on cycle page
The only Regenerate buttons were buried in the unplaced-visits banner — invisible when unplaced is 0. After applying calibration / rebalance / staging changes, the operator had no way to actually run the change.

**Fix:** Add a Regenerate button next to \"Suggest rebalance\" in the Cycle Detail header. Single button does **both** template regen and cycle re-derive, so one click takes you from \"applied changes\" to \"see the result.\"

### 2. Apply All gets stuck
After Apply All, the dialog refetched and showed stale-validated suggestions with no clear next step — only \"Apply\" (which loops on the same suggestions) or \"Skip + regenerate later.\"

**Fix:** Apply All now auto-triggers regenerate-and-close after the queue completes. Also fixes a React state-staleness bug where the inner loop checked \`applied.has()\` but the closure didn't see the latest set.

### 3. Some crews still labeled \"Crew 6\" / \"Crew 7\"
The defensive home-branch fallback in idle-analysis was conditional on \`homeByCrewIdx.size < crewCount\`. If a partial write produced \`crew_assignments\` rows with home_branch_index missing for SOME crews, the condition might pass while still leaving holes.

**Fix:** Run the fallback unconditionally. Cheap to do; trustier than relying on the snapshot.

## Test plan
- [ ] Open Cycle Detail → see Regenerate button in header
- [ ] Apply 3 rebalance suggestions via Apply All → dialog closes and regenerates automatically
- [ ] Cycle returns to Detail showing the new state — no orphan \"Crew N\" labels
- [ ] Calibration card → Apply 13 crews → click Regenerate from header → cycle reflects 13 crews

🤖 Generated with [Claude Code](https://claude.com/claude-code)