### PR TITLE
Fix: replace oscillating per-crew moves with single global re-staging

### DIFF
--- a/api/scheduler/cycles/[cycleId]/apply-rebalance.ts
+++ b/api/scheduler/cycles/[cycleId]/apply-rebalance.ts
@@ -20,10 +20,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   }
   const cycleId = req.query.cycleId as string
   const body = (req.body ?? {}) as {
-    type?: 'crew_relocate' | 'crew_reduce'
-    from_branch_name?: string
-    to_branch_name?: string
-    branch_name?: string
+    type?: 'staging_rebalance'
+    proposed_per_branch?: Record<string, number>
   }
   if (!body.type) return res.status(400).json({ error: 'type required' })
   const db = createAdminClient()
@@ -57,29 +55,23 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     if (n > 0) next[k] = n
   }
 
-  if (body.type === 'crew_relocate') {
-    if (!body.from_branch_name || !body.to_branch_name) {
-      return res.status(400).json({ error: 'from_branch_name + to_branch_name required' })
+  if (body.type === 'staging_rebalance') {
+    if (!body.proposed_per_branch || typeof body.proposed_per_branch !== 'object') {
+      return res.status(400).json({ error: 'proposed_per_branch required' })
     }
-    const fromN = next[body.from_branch_name] ?? 0
-    if (fromN <= 0) {
-      return res
-        .status(400)
-        .json({ error: `Cannot relocate from ${body.from_branch_name}: no crews staged there.` })
+    // Replace the entire override with the proposed map. This is the
+    // global re-staging: not a delta, the whole thing in one shot.
+    const fresh: Record<string, number> = {}
+    for (const [k, v] of Object.entries(body.proposed_per_branch)) {
+      const n = Math.floor(Number(v) || 0)
+      if (n > 0) fresh[k] = n
     }
-    next[body.from_branch_name] = fromN - 1
-    if (next[body.from_branch_name] === 0) delete next[body.from_branch_name]
-    next[body.to_branch_name] = (next[body.to_branch_name] ?? 0) + 1
-  } else if (body.type === 'crew_reduce') {
-    if (!body.branch_name) return res.status(400).json({ error: 'branch_name required' })
-    const cur = next[body.branch_name] ?? 0
-    if (cur <= 0) {
-      return res
-        .status(400)
-        .json({ error: `Cannot reduce ${body.branch_name}: no crews staged there.` })
+    if (Object.keys(fresh).length === 0) {
+      return res.status(400).json({ error: 'proposed_per_branch must have at least one positive entry' })
     }
-    next[body.branch_name] = cur - 1
-    if (next[body.branch_name] === 0) delete next[body.branch_name]
+    // Replace next entirely.
+    for (const k of Object.keys(next)) delete next[k]
+    Object.assign(next, fresh)
   } else {
     return res.status(400).json({ error: 'unsupported type' })
   }

--- a/api/scheduler/cycles/[cycleId]/rebalance-suggestions.ts
+++ b/api/scheduler/cycles/[cycleId]/rebalance-suggestions.ts
@@ -30,7 +30,7 @@ const ADVISOR_MAX_TOKENS = 1200
 // reduction suggestions get generated for it.
 const SEVERELY_IDLE_THRESHOLD = 0.4
 
-type SuggestionType = 'property_move' | 'crew_relocate' | 'crew_reduce'
+type SuggestionType = 'property_move' | 'staging_rebalance'
 
 interface BaseSuggestion {
   id: string
@@ -53,25 +53,22 @@ interface PropertyMoveSuggestion extends BaseSuggestion {
   drive_delta_miles: number
 }
 
-interface CrewRelocateSuggestion extends BaseSuggestion {
-  type: 'crew_relocate'
-  crew_index: number
-  crew_label: string
-  from_branch_name: string
-  to_branch_name: string
-  idle_days_freed: number
-  expected_absorbed_count: number
+// Single global re-staging proposal. Replaces the previous per-crew
+// crew_relocate / crew_reduce suggestions, which oscillated: each
+// individual move locally optimized but globally swung the system to
+// the opposite imbalance (Lindon→Vegas → Vegas→Lindon → Lindon→Phoenix
+// → loop forever). This proposes the entire optimal distribution
+// computed from where the cycle actually placed work, applied in one
+// shot. One PATCH, one regenerate, converged.
+interface StagingRebalanceSuggestion extends BaseSuggestion {
+  type: 'staging_rebalance'
+  current_per_branch: Record<string, number>
+  proposed_per_branch: Record<string, number>
+  delta_summary: Array<{ branch_name: string; from: number; to: number; change: number }>
+  total_crews: number
 }
 
-interface CrewReduceSuggestion extends BaseSuggestion {
-  type: 'crew_reduce'
-  branch_name: string
-  current_count: number
-  proposed_count: number
-  idle_days_freed: number
-}
-
-type Suggestion = PropertyMoveSuggestion | CrewRelocateSuggestion | CrewReduceSuggestion
+type Suggestion = PropertyMoveSuggestion | StagingRebalanceSuggestion
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method !== 'POST') return res.status(405).json({ error: 'Method not allowed' })
@@ -333,91 +330,130 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     })
   }
 
-  // ── 2. Crew relocation — severely-idle crew → branch w/ unserved demand ─
-  for (const [crewIdx, home] of crewBranch.entries()) {
-    const total = workdays.length
-    const idle = idleByCrew.get(crewIdx) ?? 0
-    const utilization = total > 0 ? (total - idle) / total : 0
-    if (utilization >= SEVERELY_IDLE_THRESHOLD) continue
-
-    // Find the branch with the most "unserved demand" defined as either:
-    //   (a) sum of nearby unplaced visits, or
-    //   (b) high idle-days / property-count ratio (saturated)
-    // Skip branches the crew is already homed at.
-    type BranchScore = { branchIdx: number; branchName: string; score: number; reason: string }
-    const scores: BranchScore[] = []
-    for (let bi = 0; bi < branches.length; bi++) {
-      if (bi === home.idx) continue
-      const b = branches[bi]
-      // Unplaced visits within 2× cluster radius of this branch.
-      let nearby = 0
-      for (const u of unplaced) {
-        const lat = u.service_locations?.property?.latitude
-        const lng = u.service_locations?.property?.longitude
-        if (typeof lat !== 'number' || typeof lng !== 'number') continue
-        const d = haversineMiles({ lat, lng }, b)
-        if (d <= clusterRadius * 2) nearby++
+  // ── 2. Single global staging rebalance ──────────────────────────
+  // Compute the optimal per-branch crew distribution from where the
+  // cycle actually placed work (proximity-weighted by placed visits).
+  // Compare to current staging; if different enough to matter, emit
+  // ONE suggestion that proposes the whole new distribution. One
+  // apply, one regenerate, convergence — no oscillation.
+  {
+    // Pull placed visits with coords. Walk each one, tally to its
+    // nearest branch.
+    const placedNearby = new Array(branches.length).fill(0)
+    let totalPlacedWithCoords = 0
+    for (const v of visits) {
+      if (v.status === 'unplaced') continue
+      const lat = v.service_locations?.property?.latitude
+      const lng = v.service_locations?.property?.longitude
+      if (typeof lat !== 'number' || typeof lng !== 'number') continue
+      let bestIdx = 0
+      let best = Number.POSITIVE_INFINITY
+      for (let i = 0; i < branches.length; i++) {
+        const d = haversineMiles({ lat, lng }, branches[i])
+        if (d < best) { best = d; bestIdx = i }
       }
-      if (nearby > 0) {
-        scores.push({
-          branchIdx: bi,
-          branchName: b.name,
-          score: nearby,
-          reason: `${nearby} unplaced visit${nearby === 1 ? '' : 's'} within ${Math.round(clusterRadius * 2)}mi of ${b.name}`,
-        })
-      }
+      placedNearby[bestIdx]++
+      totalPlacedWithCoords++
     }
-    scores.sort((a, b) => b.score - a.score)
-    if (scores.length === 0) continue
-    const target = scores[0]
+    // Also tally unplaced near each branch — that's demand the next
+    // regen can absorb if we shift staging there.
+    const unplacedNearby = new Array(branches.length).fill(0)
+    let totalUnplaced = 0
+    for (const u of unplaced) {
+      const lat = u.service_locations?.property?.latitude
+      const lng = u.service_locations?.property?.longitude
+      if (typeof lat !== 'number' || typeof lng !== 'number') continue
+      let bestIdx = 0
+      let best = Number.POSITIVE_INFINITY
+      for (let i = 0; i < branches.length; i++) {
+        const d = haversineMiles({ lat, lng }, branches[i])
+        if (d < best) { best = d; bestIdx = i }
+      }
+      unplacedNearby[bestIdx]++
+      totalUnplaced++
+    }
+    const demand = branches.map((_, i) => placedNearby[i] + unplacedNearby[i])
+    const demandTotal = demand.reduce((s, x) => s + x, 0)
 
-    suggestions.push({
-      id: `cr-${suggestionId++}`,
-      type: 'crew_relocate',
-      priority: 200 + idle, // higher than property-moves
-      title: `Restage ${home.label} from ${home.name} → ${target.branchName}`,
-      summary:
-        `${home.label} is ${Math.round(utilization * 100)}% utilized at ${home.name} ` +
-        `(${idle} idle workdays). ${target.reason} — restaging this crew there ` +
-        `would free their idle capacity for absorbable work.`,
-      crew_index: crewIdx,
-      crew_label: home.label,
-      from_branch_name: home.name,
-      to_branch_name: target.branchName,
-      idle_days_freed: idle,
-      expected_absorbed_count: target.score,
-    })
-  }
+    // Proportional allocation across branches with largest-remainder.
+    // Floors any branch with demand > 0 at 1 crew so we don't strand
+    // properties.
+    const proposedCounts = new Array(branches.length).fill(0)
+    if (demandTotal > 0 && crewCount > 0 && totalPlacedWithCoords + totalUnplaced > 0) {
+      const real = demand.map((d) => (d / demandTotal) * crewCount)
+      const floors = real.map((r) => Math.floor(r))
+      const remainders = real.map((r, i) => ({ idx: i, frac: r - floors[i] }))
+      let allocated = floors.reduce((s, n) => s + n, 0)
+      remainders.sort((a, b) => b.frac - a.frac)
+      let r = 0
+      while (allocated < crewCount && r < remainders.length) {
+        floors[remainders[r].idx]++
+        allocated++
+        r++
+      }
+      // Floor branches with any demand at 1 (pull from largest holder).
+      for (let i = 0; i < branches.length; i++) {
+        if (demand[i] > 0 && floors[i] === 0) {
+          let largestIdx = 0
+          for (let j = 1; j < branches.length; j++) {
+            if (floors[j] > floors[largestIdx]) largestIdx = j
+          }
+          if (largestIdx !== i && floors[largestIdx] > 1) {
+            floors[largestIdx]--
+            floors[i]++
+          }
+        }
+      }
+      for (let i = 0; i < branches.length; i++) proposedCounts[i] = floors[i]
+    }
 
-  // ── 3. Crew reduction — branch is overstaffed and no relocation helps ─
-  // Trigger when a branch's idle-days > cycle-length × 0.6 per crew there
-  // AND we haven't already proposed relocating any crew from that branch.
-  const hasRelocateFrom = new Set(
-    suggestions
-      .filter((s): s is CrewRelocateSuggestion => s.type === 'crew_relocate')
-      .map((s) => s.from_branch_name)
-  )
-  for (const [branchIdx, idleDays] of idleByBranch.entries()) {
-    const branchName = branches[branchIdx]?.name
-    if (!branchName) continue
-    if (hasRelocateFrom.has(branchName)) continue
-    const crews = crewsByBranch.get(branchIdx) ?? 0
-    if (crews <= 1) continue
-    const idlePerCrew = idleDays / crews
-    if (idlePerCrew >= workdays.length * 0.6) {
+    // Build current vs proposed maps + delta. Skip suggestion if no
+    // change of magnitude — small jitters aren't worth a regen.
+    const currentPerBranch: Record<string, number> = {}
+    const proposedPerBranch: Record<string, number> = {}
+    for (let i = 0; i < branches.length; i++) {
+      const cur = crewsByBranch.get(i) ?? 0
+      const next = proposedCounts[i]
+      if (cur > 0) currentPerBranch[branches[i].name] = cur
+      if (next > 0) proposedPerBranch[branches[i].name] = next
+    }
+    const deltaSummary: Array<{ branch_name: string; from: number; to: number; change: number }> = []
+    let totalChanges = 0
+    for (let i = 0; i < branches.length; i++) {
+      const cur = crewsByBranch.get(i) ?? 0
+      const next = proposedCounts[i]
+      if (cur === next) continue
+      deltaSummary.push({
+        branch_name: branches[i].name,
+        from: cur,
+        to: next,
+        change: next - cur,
+      })
+      totalChanges += Math.abs(next - cur)
+    }
+
+    if (totalChanges >= 2 && deltaSummary.length > 0) {
+      const moves = deltaSummary
+        .map((d) =>
+          d.change > 0
+            ? `${d.branch_name} ${d.from}→${d.to} (+${d.change})`
+            : `${d.branch_name} ${d.from}→${d.to} (${d.change})`
+        )
+        .join(', ')
       suggestions.push({
-        id: `cd-${suggestionId++}`,
-        type: 'crew_reduce',
-        priority: 150 + Math.round(idleDays / 10),
-        title: `Reduce crews at ${branchName}: ${crews} → ${crews - 1}`,
+        id: `sr-${suggestionId++}`,
+        type: 'staging_rebalance',
+        priority: 500 + totalChanges, // higher than property moves
+        title: `Restage ${crewCount} crews to match actual demand`,
         summary:
-          `${branchName} has ${crews} crews averaging ${Math.round(idlePerCrew)} idle workdays ` +
-          `each (${Math.round((idlePerCrew / workdays.length) * 100)}% idle). ` +
-          `Removing one crew saves the FTE labor cost without dropping any placed work.`,
-        branch_name: branchName,
-        current_count: crews,
-        proposed_count: crews - 1,
-        idle_days_freed: Math.round(idlePerCrew),
+          `Cycle placed ${totalPlacedWithCoords} visits` +
+          (totalUnplaced > 0 ? ` (and ${totalUnplaced} unplaced)` : '') +
+          `. Optimal staging by proximity: ${moves}. ` +
+          `One apply rewrites the per-branch override; the next regenerate converges in one pass.`,
+        current_per_branch: currentPerBranch,
+        proposed_per_branch: proposedPerBranch,
+        delta_summary: deltaSummary,
+        total_crews: crewCount,
       })
     }
   }
@@ -472,14 +508,17 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   }
   const beforeFilter = filtered.length
   filtered = filtered.filter((s) => {
-    if (s.type === 'crew_relocate') {
-      const v = lookupOverride(s.from_branch_name)
-      // Filter ONLY when the user has explicitly zeroed this branch.
-      return v == null ? true : v >= 1
-    }
-    if (s.type === 'crew_reduce') {
-      const v = lookupOverride(s.branch_name)
-      return v == null ? true : v >= 2
+    if (s.type === 'staging_rebalance') {
+      // Compare proposed_per_branch to live override. If they already
+      // match (operator already applied this exact distribution and
+      // hasn't regenerated), suppress the duplicate.
+      if (Object.keys(liveStaging).length === 0) return true
+      const matches = Object.keys(s.proposed_per_branch).every(
+        (k) => liveStaging[k] === s.proposed_per_branch[k]
+      ) && Object.keys(liveStaging).every(
+        (k) => s.proposed_per_branch[k] === liveStaging[k]
+      )
+      return !matches
     }
     return true
   })

--- a/src/components/scheduler/RebalanceSuggestionsDialog.tsx
+++ b/src/components/scheduler/RebalanceSuggestionsDialog.tsx
@@ -1,13 +1,16 @@
-// Rebalance suggestions dialog. Three suggestion types:
-//   property_move  — patches template.branch_assignment_overrides
-//   crew_relocate  — patches account_operational_constraints
-//                    crew_count_per_branch_override (-1 origin, +1 target)
-//   crew_reduce    — patches the same override (-1 from branch)
+// Rebalance suggestions dialog. Two suggestion types:
+//   property_move      — patches template.branch_assignment_overrides
+//                        for individual unplaced clusters.
+//   staging_rebalance  — replaces the entire crew_count_per_branch_override
+//                        with the optimal distribution computed from
+//                        actual cycle placements. One apply, one
+//                        regenerate, converged. Replaces the per-crew
+//                        relocate/reduce moves which oscillated.
 //
 // Optional Claude advisor narrative at the top, with a ranked sequence
 // of suggestion IDs to apply in order.
 import { useEffect, useState } from 'react'
-import { ArrowRight, Sparkles, Users, MapPin, Minus } from 'lucide-react'
+import { ArrowRight, Sparkles, Users, MapPin } from 'lucide-react'
 import {
   Dialog,
   DialogContent,
@@ -20,7 +23,7 @@ import Button from '../ui/Button'
 import { Badge } from '../ui/Badge'
 import { useAuth } from '../../hooks/useAuth'
 
-type SuggestionType = 'property_move' | 'crew_relocate' | 'crew_reduce'
+type SuggestionType = 'property_move' | 'staging_rebalance'
 
 interface BaseSuggestion {
   id: string
@@ -41,23 +44,14 @@ interface PropertyMoveSuggestion extends BaseSuggestion {
   cluster_label: string
   drive_delta_miles: number
 }
-interface CrewRelocateSuggestion extends BaseSuggestion {
-  type: 'crew_relocate'
-  crew_index: number
-  crew_label: string
-  from_branch_name: string
-  to_branch_name: string
-  idle_days_freed: number
-  expected_absorbed_count: number
+interface StagingRebalanceSuggestion extends BaseSuggestion {
+  type: 'staging_rebalance'
+  current_per_branch: Record<string, number>
+  proposed_per_branch: Record<string, number>
+  delta_summary: Array<{ branch_name: string; from: number; to: number; change: number }>
+  total_crews: number
 }
-interface CrewReduceSuggestion extends BaseSuggestion {
-  type: 'crew_reduce'
-  branch_name: string
-  current_count: number
-  proposed_count: number
-  idle_days_freed: number
-}
-type Suggestion = PropertyMoveSuggestion | CrewRelocateSuggestion | CrewReduceSuggestion
+type Suggestion = PropertyMoveSuggestion | StagingRebalanceSuggestion
 
 interface Advisor {
   recommendation: string
@@ -74,8 +68,7 @@ interface Props {
 
 const TYPE_META: Record<SuggestionType, { label: string; icon: any; color: string }> = {
   property_move: { label: 'Property move', icon: MapPin, color: 'accent' },
-  crew_relocate: { label: 'Restage crew', icon: Users, color: 'warning' },
-  crew_reduce: { label: 'Reduce crews', icon: Minus, color: 'danger' },
+  staging_rebalance: { label: 'Restage crews', icon: Users, color: 'warning' },
 }
 
 export default function RebalanceSuggestionsDialog({
@@ -159,32 +152,15 @@ export default function RebalanceSuggestionsDialog({
           const j = await res.json().catch(() => ({}))
           throw new Error((j as any).error ?? `HTTP ${res.status}`)
         }
-      } else if (s.type === 'crew_relocate') {
+      } else if (s.type === 'staging_rebalance') {
         const res = await fetch(
           `/api/scheduler/cycles/${cycleId}/apply-rebalance`,
           {
             method: 'POST',
             headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
             body: JSON.stringify({
-              type: 'crew_relocate',
-              from_branch_name: s.from_branch_name,
-              to_branch_name: s.to_branch_name,
-            }),
-          }
-        )
-        if (!res.ok) {
-          const j = await res.json().catch(() => ({}))
-          throw new Error((j as any).error ?? `HTTP ${res.status}`)
-        }
-      } else if (s.type === 'crew_reduce') {
-        const res = await fetch(
-          `/api/scheduler/cycles/${cycleId}/apply-rebalance`,
-          {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
-            body: JSON.stringify({
-              type: 'crew_reduce',
-              branch_name: s.branch_name,
+              type: 'staging_rebalance',
+              proposed_per_branch: s.proposed_per_branch,
             }),
           }
         )
@@ -194,14 +170,6 @@ export default function RebalanceSuggestionsDialog({
         }
       }
       setApplied((prev) => new Set([...prev, s.id]))
-      // After a crew_relocate / crew_reduce, the constraints just
-      // changed but the cycle hasn't been regenerated. Reload suggestions
-      // so any newly-stale ones (e.g. another move out of the same
-      // branch we just emptied) get filtered out and the user sees a
-      // "regenerate to refresh" hint.
-      if (s.type === 'crew_relocate' || s.type === 'crew_reduce') {
-        await loadSuggestions(false)
-      }
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e))
     } finally {
@@ -252,11 +220,11 @@ export default function RebalanceSuggestionsDialog({
         <DialogHeader>
           <DialogTitle>Rebalance suggestions</DialogTitle>
           <DialogDescription>
-            Three remediation types: <strong>property moves</strong> re-route
-            unplaced clusters; <strong>restage crew</strong> relocates an idle
-            crew's home branch to where the work is; <strong>reduce crews</strong>
-            drops staffing where geography doesn't justify it. Apply any combination,
-            then regenerate the template.
+            <strong>Property moves</strong> re-route unplaced clusters to
+            crews with idle capacity. <strong>Restage crews</strong> rewrites
+            your entire per-branch staging to match where the cycle actually
+            placed work — one apply, one regenerate, converged (no oscillating
+            between branches). Apply, then regenerate the template.
           </DialogDescription>
         </DialogHeader>
 
@@ -432,22 +400,19 @@ function SuggestionVisual({ s }: { s: Suggestion }) {
       </div>
     )
   }
-  if (s.type === 'crew_relocate') {
-    return (
-      <div className="flex items-center gap-1 text-xs text-fg-muted">
-        <Badge variant="outline" className="text-[10px]">{s.crew_label} @ {s.from_branch_name}</Badge>
-        <ArrowRight className="h-3 w-3" />
-        <Badge variant="warning" className="text-[10px]">{s.to_branch_name}</Badge>
-        <span className="ml-1 font-tabular">{s.idle_days_freed}d freed</span>
-      </div>
-    )
-  }
+  // staging_rebalance — render the per-branch delta as a chip list.
   return (
-    <div className="flex items-center gap-1 text-xs text-fg-muted">
-      <Badge variant="danger" className="text-[10px]">
-        {s.branch_name}: {s.current_count} → {s.proposed_count}
-      </Badge>
-      <span className="ml-1 font-tabular">~{s.idle_days_freed}d/crew freed</span>
+    <div className="flex flex-wrap items-center gap-1 text-xs text-fg-muted">
+      {s.delta_summary.map((d) => (
+        <Badge
+          key={d.branch_name}
+          variant={d.change > 0 ? 'accent' : d.change < 0 ? 'warning' : 'outline'}
+          className="text-[10px]"
+        >
+          {d.branch_name}: {d.from} → {d.to}
+        </Badge>
+      ))}
+      <span className="ml-1 font-tabular">{s.total_crews} crews total</span>
     </div>
   )
 }


### PR DESCRIPTION
## The loop you hit
Each individual \`crew_relocate\` / \`crew_reduce\` suggestion locally optimized but globally swung the system to the opposite imbalance. Lindon → Vegas → Lindon → Phoenix → infinity. Six iterations later, properties still dropped, idle days everywhere, no convergence.

## Root cause
The greedy algorithm proposed one move at a time based on local symptoms (\"this crew has 90% idle, send them to a busy branch\"). After applying, the destination was now over-staffed, so the next iteration suggested moving them back. Forever.

## Fix
**One suggestion type — \`staging_rebalance\`** — that proposes the entire per-branch crew distribution in a single shot, computed from where the cycle actually placed work.

Algorithm:
1. For each placed visit, count it toward its nearest configured branch.
2. For each unplaced visit, same (these represent demand the next regen can absorb).
3. Allocate \`crew_count\` proportional to per-branch demand (largest-remainder rounding). Floor at 1 for any branch with demand.
4. Compare to current. If 2+ crew moves of delta, emit ONE suggestion with the full proposed map.
5. Apply replaces the entire \`crew_count_per_branch_override\` in one PATCH.
6. Regenerate. Convergence in one pass — no oscillation possible.

\`crew_relocate\` and \`crew_reduce\` paths are gone (both endpoint and dialog).

## Test plan
- [ ] Run a cycle that previously oscillated → suggestion now shows one \"Restage 14 crews\" entry with per-branch deltas
- [ ] Apply → constraints rewritten in one shot
- [ ] Regenerate from header → cycle reflects new staging, no further oscillating suggestions
- [ ] If still imbalanced, the next suggestion is a smaller delta (or none)

🤖 Generated with [Claude Code](https://claude.com/claude-code)