### PR TITLE
Regenerate honors crew_count override + label fallback for empty branch names

### DIFF
--- a/api/_lib/scheduler/build-routing-template.ts
+++ b/api/_lib/scheduler/build-routing-template.ts
@@ -879,8 +879,12 @@ export function buildRoutingTemplate(input: BuildTemplateInput): TemplateBuildRe
     const branchCounters = new Map<number, number>()
     for (const crew of crews) {
       const homeIdx = crew.home_branch_index
-      const branchName =
-        input.branches[homeIdx]?.name ?? `Branch ${homeIdx + 1}`
+      // Use || (not ??) so empty / whitespace-only branch names fall
+      // through to the "Branch N" placeholder. Without this, branches
+      // ingested with empty names produced bare "Crew 1" labels for
+      // crews homed there.
+      const rawName = (input.branches[homeIdx]?.name ?? '').trim()
+      const branchName = rawName || `Branch ${homeIdx + 1}`
       const counter = (branchCounters.get(homeIdx) ?? 0) + 1
       branchCounters.set(homeIdx, counter)
       crew.label = `${branchName} Crew ${counter}`

--- a/api/scheduler/cycles/[cycleId]/idle-analysis.ts
+++ b/api/scheduler/cycles/[cycleId]/idle-analysis.ts
@@ -158,13 +158,18 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   // Build labels from the now-complete homeByCrewIdx. Sequential per
   // home (Lindon Crew 1, Lindon Crew 2, …) by ascending crew_index for
   // stable numbering across regenerates.
+  // Use || (not ??) so empty-string branch names fall through to the
+  // "Branch N" placeholder. Also strip leading/trailing whitespace —
+  // some legacy branch entries had names like " " that produced labels
+  // such as "  Crew 1" (Frisco-style ghost entries).
   const crewLabelByIdx = new Map<number, string>()
   {
     const counter = new Map<number, number>()
     const indices = Array.from(homeByCrewIdx.keys()).sort((a, b) => a - b)
     for (const idx of indices) {
       const home = homeByCrewIdx.get(idx)!
-      const branchName = branches[home]?.name ?? `Branch ${home + 1}`
+      const rawName = (branches[home]?.name ?? '').trim()
+      const branchName = rawName || `Branch ${home + 1}`
       const n = (counter.get(home) ?? 0) + 1
       counter.set(home, n)
       crewLabelByIdx.set(idx, `${branchName} Crew ${n}`)
@@ -189,7 +194,10 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       a.scheduled_date.localeCompare(b.scheduled_date)
     )
     const homeIdx = homeByCrewIdx.get(crewIdx) ?? null
-    const homeName = homeIdx != null ? (branches[homeIdx]?.name ?? null) : null
+    // Use trimmed-truthy fallback — empty / whitespace-only branch
+    // names should resolve to "Branch N", not produce a bare "Crew K".
+    const rawHomeName = homeIdx != null ? (branches[homeIdx]?.name ?? '').trim() : ''
+    const homeName = homeIdx != null ? (rawHomeName || `Branch ${homeIdx + 1}`) : null
 
     const streaks: IdleStreak[] = []
     let cur: { start: string; end: string; length: number } | null = null

--- a/api/scheduler/cycles/[cycleId]/rebalance-suggestions.ts
+++ b/api/scheduler/cycles/[cycleId]/rebalance-suggestions.ts
@@ -159,12 +159,14 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     if (!b) continue
     const counter = (branchCounters.get(home) ?? 0) + 1
     branchCounters.set(home, counter)
+    // Empty / whitespace-only branch names fall back to "Branch N".
+    const branchName = (b.name ?? '').trim() || `Branch ${home + 1}`
     crewBranch.set(idx, {
       idx: home,
-      name: b.name,
+      name: branchName,
       lat: b.lat,
       lng: b.lng,
-      label: `${b.name} Crew ${counter}`,
+      label: `${branchName} Crew ${counter}`,
     })
   }
   // Fallback for any crew without a template assignment row.

--- a/api/scheduler/templates/[templateId]/regenerate.ts
+++ b/api/scheduler/templates/[templateId]/regenerate.ts
@@ -74,12 +74,34 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   const allClientIds = combinedClientIds && combinedClientIds.length > 1
     ? combinedClientIds
     : [clientId]
-  const crewCount = body.crew_count ?? tpl.crew_count ?? 1
   const customCycleDays = body.custom_cycle_length_days !== undefined
     ? body.custom_cycle_length_days ?? undefined
     : (tpl.is_custom_cycle_length ? tpl.cycle_length_days : undefined)
 
   const constraints = await loadConstraints(db, accountId, clientId)
+
+  // crew_count source-of-truth priority:
+  //   1. body.crew_count if explicitly passed in this regen request
+  //   2. sum(crew_count_per_branch_override) — this reflects the
+  //      operator's most recent staging intent (e.g. via the
+  //      Calibration card's "Apply N crews" button or the staging_
+  //      rebalance suggestion). Without this, regen used tpl.crew_count
+  //      (snapshot at template creation) and ignored later changes.
+  //   3. tpl.crew_count fallback for templates without an override.
+  const overrideMap = (constraints.crew_count_per_branch_override ?? null) as
+    | Record<string, number>
+    | null
+  let overrideSum = 0
+  if (overrideMap) {
+    for (const [k, v] of Object.entries(overrideMap)) {
+      if (k === '__roving') continue
+      const n = Math.floor(Number(v) || 0)
+      if (n > 0) overrideSum += n
+    }
+  }
+  const crewCount =
+    (body.crew_count as number | undefined) ??
+    (overrideSum > 0 ? overrideSum : (tpl.crew_count ?? 1))
   const branches = (tpl.branches ?? []) as Array<{ name: string; lat: number; lng: number }>
   if (branches.length === 0) {
     return res.status(400).json({ error: 'Template has no branches snapshot' })


### PR DESCRIPTION
## Two fixes

### 1. Calibration's \"Apply 13 crews\" didn't take effect
Calibration writes \`crew_count_per_branch_override\` summing to 13. Regenerate read \`crewCount\` from \`tpl.crew_count\` (still 14 from creation time) and built 14 crews regardless.

Fix: \`regenerate.ts\` now prefers \`sum(crew_count_per_branch_override)\` when an override exists. Body \`crew_count\` still wins if explicitly passed; \`tpl.crew_count\` is the last fallback.

### 2. Frisco crews labeled \"Crew 1\" / \"Crew 2\" with no prefix
Branch entries with empty (or whitespace-only) names slipped past the \`??\` fallback. Empty string isn't null/undefined, so \`branches[home]?.name ?? \"Branch N\"\` returned \"\".

Fix: trim() + \`||\` instead of \`??\` on three surfaces (engine label pass, idle-analysis, rebalance-suggestions). Empty / whitespace names now fall through to \"Branch N\". Bare \"Crew K\" labels are structurally unreachable.

## Test plan
- [ ] On the existing cycle, click Apply 13 crews → Regenerate from header → cycle has 13 crews (not 14)
- [ ] Frisco crews now show \"Frisco Crew 1\" / \"Frisco Crew 2\" (or \"Branch N Crew 1\" if the underlying branch name is genuinely missing)
- [ ] Other clients/templates unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)