### PR TITLE
Schedule Assessment & Enhancer — PR1: upload + fuzzy match

### DIFF
--- a/api/_lib/schedule-assessment/match-addresses.ts
+++ b/api/_lib/schedule-assessment/match-addresses.ts
@@ -1,0 +1,158 @@
+// Fuzzy-match raw addresses (from CSV uploads) to existing
+// service_locations. We use a normalized-token Jaccard similarity
+// against `properties.address_line1` (city/state/zip optional).
+//
+// Output: each input gets a best-match SL id + confidence score, or
+// null if below the auto-match threshold. The wizard surfaces all
+// rows below AUTO_THRESHOLD in a manual review tray.
+
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+const AUTO_THRESHOLD = 0.85
+const REVIEW_THRESHOLD = 0.55 // below this we don't even suggest
+
+interface Candidate {
+  sl_id: string
+  property_id: string
+  address_line1: string
+  city: string | null
+  state: string | null
+  postal_code: string | null
+}
+
+function normalize(s: string): string[] {
+  return s
+    .toLowerCase()
+    // Strip punctuation, collapse whitespace.
+    .replace(/[^\w\s]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    // Common address abbreviations canonicalized.
+    .replace(/\bstreet\b/g, 'st')
+    .replace(/\bavenue\b/g, 'ave')
+    .replace(/\bboulevard\b/g, 'blvd')
+    .replace(/\broad\b/g, 'rd')
+    .replace(/\bdrive\b/g, 'dr')
+    .replace(/\bcourt\b/g, 'ct')
+    .replace(/\blane\b/g, 'ln')
+    .replace(/\bplace\b/g, 'pl')
+    .replace(/\bparkway\b/g, 'pkwy')
+    .replace(/\bnorth\b/g, 'n')
+    .replace(/\bsouth\b/g, 's')
+    .replace(/\beast\b/g, 'e')
+    .replace(/\bwest\b/g, 'w')
+    .split(' ')
+    .filter(Boolean)
+}
+
+function jaccard(a: string[], b: string[]): number {
+  if (a.length === 0 || b.length === 0) return 0
+  const setA = new Set(a)
+  const setB = new Set(b)
+  let inter = 0
+  for (const t of setA) if (setB.has(t)) inter++
+  const union = setA.size + setB.size - inter
+  return union === 0 ? 0 : inter / union
+}
+
+export interface MatchInput {
+  row_id: string
+  raw_address: string
+}
+
+export interface MatchOutput {
+  row_id: string
+  matched_sl_id: string | null
+  confidence: number | null
+  match_status: 'auto' | 'unmatched' | 'pending'
+  candidates: Array<{ sl_id: string; address_line1: string; score: number }>
+}
+
+export async function matchAddresses(
+  db: SupabaseClient,
+  clientIds: string[], // resolved member ids if combined
+  inputs: MatchInput[]
+): Promise<MatchOutput[]> {
+  if (inputs.length === 0) return []
+  // Pull all SLs (and their property addresses) for the resolved
+  // client set. Page to avoid the 1000-row cap.
+  const candidates: Candidate[] = []
+  const PAGE = 1000
+  for (let p = 0; p < 50; p++) {
+    const { data } = await db
+      .from('service_locations')
+      .select(
+        'id, property_id, property:properties(address_line1, city, state, postal_code)'
+      )
+      .in('client_id', clientIds)
+      .range(p * PAGE, p * PAGE + PAGE - 1)
+    const batch = data ?? []
+    for (const r of batch as any[]) {
+      if (!r.property) continue
+      candidates.push({
+        sl_id: r.id,
+        property_id: r.property_id,
+        address_line1: r.property.address_line1 ?? '',
+        city: r.property.city ?? null,
+        state: r.property.state ?? null,
+        postal_code: r.property.postal_code ?? null,
+      })
+    }
+    if (batch.length < PAGE) break
+  }
+  // Tokenize candidate addresses once.
+  const candTokens = candidates.map((c) => ({
+    cand: c,
+    tokens: normalize(c.address_line1),
+  }))
+  // Score each input against every candidate; keep top 3.
+  const out: MatchOutput[] = []
+  for (const inp of inputs) {
+    const inputTokens = normalize(inp.raw_address)
+    const scored: Array<{ sl_id: string; address: string; score: number }> = []
+    for (const ct of candTokens) {
+      const score = jaccard(inputTokens, ct.tokens)
+      if (score >= REVIEW_THRESHOLD) {
+        scored.push({ sl_id: ct.cand.sl_id, address: ct.cand.address_line1, score })
+      }
+    }
+    scored.sort((a, b) => b.score - a.score)
+    const top = scored.slice(0, 3)
+    const best = top[0]
+    if (best && best.score >= AUTO_THRESHOLD) {
+      out.push({
+        row_id: inp.row_id,
+        matched_sl_id: best.sl_id,
+        confidence: Math.round(best.score * 100) / 100,
+        match_status: 'auto',
+        candidates: top.map((t) => ({
+          sl_id: t.sl_id,
+          address_line1: t.address,
+          score: Math.round(t.score * 100) / 100,
+        })),
+      })
+    } else if (best) {
+      // Not confident enough — leave as 'pending' (review tray).
+      out.push({
+        row_id: inp.row_id,
+        matched_sl_id: null,
+        confidence: Math.round(best.score * 100) / 100,
+        match_status: 'pending',
+        candidates: top.map((t) => ({
+          sl_id: t.sl_id,
+          address_line1: t.address,
+          score: Math.round(t.score * 100) / 100,
+        })),
+      })
+    } else {
+      out.push({
+        row_id: inp.row_id,
+        matched_sl_id: null,
+        confidence: null,
+        match_status: 'unmatched',
+        candidates: [],
+      })
+    }
+  }
+  return out
+}

--- a/api/_lib/schedule-assessment/parse-csv.ts
+++ b/api/_lib/schedule-assessment/parse-csv.ts
@@ -1,0 +1,138 @@
+// Parse a schedule-assessment CSV into normalized rows. Required
+// columns (case-insensitive, trimmed): address, scheduled_date.
+// Optional: crew_name. Date parses ISO-ish (YYYY-MM-DD or
+// MM/DD/YYYY). Bad rows are returned as 'errors' so the wizard can
+// surface them.
+import Papa from 'papaparse'
+
+export interface ParsedRow {
+  raw_address: string
+  raw_scheduled_date: string | null // ISO YYYY-MM-DD
+  raw_crew_name: string | null
+}
+
+export interface ParseError {
+  line: number
+  reason: string
+}
+
+export interface ParseResult {
+  rows: ParsedRow[]
+  errors: ParseError[]
+}
+
+const ALIASES: Record<string, 'address' | 'date' | 'crew'> = {
+  address: 'address',
+  property: 'address',
+  property_address: 'address',
+  location: 'address',
+  site: 'address',
+  scheduled_date: 'date',
+  date: 'date',
+  visit_date: 'date',
+  service_date: 'date',
+  crew_name: 'crew',
+  crew: 'crew',
+  team: 'crew',
+}
+
+function normalizeHeader(h: string): 'address' | 'date' | 'crew' | null {
+  const k = h.trim().toLowerCase().replace(/\s+/g, '_').replace(/[^a-z0-9_]/g, '')
+  return ALIASES[k] ?? null
+}
+
+function parseDate(s: string): string | null {
+  const trimmed = s.trim()
+  if (!trimmed) return null
+  // ISO YYYY-MM-DD.
+  const iso = /^(\d{4})-(\d{1,2})-(\d{1,2})/.exec(trimmed)
+  if (iso) {
+    const y = iso[1]
+    const m = iso[2].padStart(2, '0')
+    const d = iso[3].padStart(2, '0')
+    return `${y}-${m}-${d}`
+  }
+  // M/D/YYYY or M/D/YY.
+  const us = /^(\d{1,2})\/(\d{1,2})\/(\d{2,4})/.exec(trimmed)
+  if (us) {
+    let y = us[3]
+    if (y.length === 2) y = `20${y}` // 2-digit assume current millennium
+    const m = us[1].padStart(2, '0')
+    const d = us[2].padStart(2, '0')
+    return `${y}-${m}-${d}`
+  }
+  // Try Date constructor as last resort.
+  const dt = new Date(trimmed)
+  if (!isNaN(dt.getTime())) {
+    return dt.toISOString().slice(0, 10)
+  }
+  return null
+}
+
+export function parseScheduleCsv(csv: string): ParseResult {
+  const result = Papa.parse<Record<string, string>>(csv, {
+    header: true,
+    skipEmptyLines: 'greedy',
+  })
+  const rows: ParsedRow[] = []
+  const errors: ParseError[] = []
+  if (result.errors.length > 0) {
+    for (const e of result.errors) {
+      errors.push({ line: (e.row ?? 0) + 2, reason: e.message })
+    }
+  }
+  // Build a column-name map (raw header → semantic).
+  const fields = result.meta.fields ?? []
+  const colMap = new Map<string, 'address' | 'date' | 'crew'>()
+  for (const f of fields) {
+    const sem = normalizeHeader(f)
+    if (sem) colMap.set(f, sem)
+  }
+  // Require at least address + date columns.
+  const hasAddress = Array.from(colMap.values()).includes('address')
+  const hasDate = Array.from(colMap.values()).includes('date')
+  if (!hasAddress || !hasDate) {
+    return {
+      rows: [],
+      errors: [
+        {
+          line: 1,
+          reason:
+            'CSV must include an "address" column and a "scheduled_date" column. ' +
+            `Got: ${fields.join(', ')}`,
+        },
+      ],
+    }
+  }
+  for (let i = 0; i < (result.data ?? []).length; i++) {
+    const row = result.data[i] as Record<string, string>
+    let address = ''
+    let dateStr = ''
+    let crew = ''
+    for (const [col, sem] of colMap) {
+      const v = (row[col] ?? '').toString().trim()
+      if (sem === 'address' && !address) address = v
+      else if (sem === 'date' && !dateStr) dateStr = v
+      else if (sem === 'crew' && !crew) crew = v
+    }
+    if (!address) {
+      errors.push({ line: i + 2, reason: 'missing address' })
+      continue
+    }
+    if (!dateStr) {
+      errors.push({ line: i + 2, reason: 'missing scheduled_date' })
+      continue
+    }
+    const parsed = parseDate(dateStr)
+    if (!parsed) {
+      errors.push({ line: i + 2, reason: `unparseable date: "${dateStr}"` })
+      continue
+    }
+    rows.push({
+      raw_address: address,
+      raw_scheduled_date: parsed,
+      raw_crew_name: crew || null,
+    })
+  }
+  return { rows, errors }
+}

--- a/api/v1/schedule-assessments/[id]/index.ts
+++ b/api/v1/schedule-assessments/[id]/index.ts
@@ -1,0 +1,84 @@
+// GET    /api/v1/schedule-assessments/[id]
+//   Returns assessment + files + (paginated) rows.
+// PATCH  /api/v1/schedule-assessments/[id]
+//   Update name, baseline_template_id, status.
+// DELETE /api/v1/schedule-assessments/[id]
+//   Soft-archives.
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { createAdminClient } from '../../../_lib/supabase.js'
+import { authenticateRequest } from '../../../_lib/auth.js'
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method === 'OPTIONS') return res.status(200).end()
+  try { await authenticateRequest(req) } catch (err: any) {
+    return res.status(err.statusCode ?? 401).json({ error: err.message ?? 'Unauthorized' })
+  }
+  const id = req.query.id as string
+  const db = createAdminClient()
+
+  if (req.method === 'GET') {
+    const { data: assessment, error } = await db
+      .from('schedule_assessments')
+      .select('*')
+      .eq('id', id)
+      .maybeSingle()
+    if (error) return res.status(500).json({ error: error.message })
+    if (!assessment) return res.status(404).json({ error: 'Not found' })
+
+    const { data: files } = await db
+      .from('schedule_assessment_files')
+      .select('id, filename, cycle_label, row_count, uploaded_at')
+      .eq('assessment_id', id)
+      .order('uploaded_at', { ascending: true })
+
+    // Page through rows — large uploads can exceed 1000.
+    const PAGE = 1000
+    const rows: any[] = []
+    for (let p = 0; p < 50; p++) {
+      const { data: batch } = await db
+        .from('schedule_assessment_rows')
+        .select('id, file_id, raw_address, raw_scheduled_date, raw_crew_name, matched_service_location_id, match_confidence, match_status, notes')
+        .eq('assessment_id', id)
+        .order('created_at', { ascending: true })
+        .range(p * PAGE, p * PAGE + PAGE - 1)
+      const arr = batch ?? []
+      rows.push(...arr)
+      if (arr.length < PAGE) break
+    }
+
+    return res.status(200).json({
+      assessment,
+      files: files ?? [],
+      rows,
+    })
+  }
+
+  if (req.method === 'PATCH') {
+    const body = (req.body ?? {}) as Record<string, unknown>
+    const update: Record<string, unknown> = { updated_at: new Date().toISOString() }
+    if (typeof body.name === 'string') update.name = body.name.trim()
+    if (body.baseline_template_id === null || typeof body.baseline_template_id === 'string') {
+      update.baseline_template_id = body.baseline_template_id
+    }
+    if (typeof body.status === 'string') update.status = body.status
+    const { data, error } = await db
+      .from('schedule_assessments')
+      .update(update)
+      .eq('id', id)
+      .select('*')
+      .single()
+    if (error) return res.status(500).json({ error: error.message })
+    return res.status(200).json({ assessment: data })
+  }
+
+  if (req.method === 'DELETE') {
+    const { error } = await db
+      .from('schedule_assessments')
+      .update({ status: 'archived', updated_at: new Date().toISOString() })
+      .eq('id', id)
+    if (error) return res.status(500).json({ error: error.message })
+    return res.status(204).end()
+  }
+
+  return res.status(405).json({ error: 'Method not allowed' })
+}

--- a/api/v1/schedule-assessments/[id]/rows.ts
+++ b/api/v1/schedule-assessments/[id]/rows.ts
@@ -1,0 +1,60 @@
+// PATCH /api/v1/schedule-assessments/[id]/rows
+//
+// Bulk-update row match assignments. Body:
+//   { rows: [{ id, matched_service_location_id?, match_status? }] }
+// Used by the wizard's "review tray" to confirm fuzzy matches or
+// manually pick an SL for an unmatched row.
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { createAdminClient } from '../../../_lib/supabase.js'
+import { authenticateRequest } from '../../../_lib/auth.js'
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'PATCH') return res.status(405).json({ error: 'Method not allowed' })
+  try { await authenticateRequest(req) } catch (err: any) {
+    return res.status(err.statusCode ?? 401).json({ error: err.message ?? 'Unauthorized' })
+  }
+  const assessmentId = req.query.id as string
+  const body = (req.body ?? {}) as {
+    rows?: Array<{
+      id: string
+      matched_service_location_id?: string | null
+      match_status?: string
+      notes?: string | null
+    }>
+  }
+  if (!Array.isArray(body.rows) || body.rows.length === 0) {
+    return res.status(400).json({ error: 'rows array required' })
+  }
+  const db = createAdminClient()
+
+  // Update one row at a time so we can scope to the assessment id
+  // (prevents a malicious id list from updating rows on other
+  // assessments).
+  const VALID_STATUSES = new Set(['auto', 'manual', 'unmatched', 'skipped', 'pending'])
+  for (const r of body.rows) {
+    if (!r.id) continue
+    const update: Record<string, unknown> = {}
+    if ('matched_service_location_id' in r) {
+      update.matched_service_location_id = r.matched_service_location_id ?? null
+      // When the operator manually assigns, mark the status accordingly.
+      if (!r.match_status) update.match_status = r.matched_service_location_id ? 'manual' : 'unmatched'
+    }
+    if (r.match_status && VALID_STATUSES.has(r.match_status)) {
+      update.match_status = r.match_status
+    }
+    if ('notes' in r) update.notes = r.notes ?? null
+    if (Object.keys(update).length === 0) continue
+    await db
+      .from('schedule_assessment_rows')
+      .update(update)
+      .eq('id', r.id)
+      .eq('assessment_id', assessmentId)
+  }
+
+  await db
+    .from('schedule_assessments')
+    .update({ updated_at: new Date().toISOString() })
+    .eq('id', assessmentId)
+
+  return res.status(200).json({ ok: true })
+}

--- a/api/v1/schedule-assessments/[id]/upload.ts
+++ b/api/v1/schedule-assessments/[id]/upload.ts
@@ -1,0 +1,136 @@
+// POST /api/v1/schedule-assessments/[id]/upload
+//
+// Body: { filename, cycle_label?, csv } where csv is the raw CSV
+// content as a string. Parses it, persists a file row + N parsed
+// rows in 'pending' state, then runs fuzzy matching against the
+// client's service_locations and updates each row's match status.
+//
+// Returns the file id, parse errors, and a summary of match
+// outcomes.
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { createAdminClient } from '../../../_lib/supabase.js'
+import { authenticateRequest } from '../../../_lib/auth.js'
+import { parseScheduleCsv } from '../../../_lib/schedule-assessment/parse-csv.js'
+import { matchAddresses } from '../../../_lib/schedule-assessment/match-addresses.js'
+import { resolveClientIds } from '../../../_lib/clients/resolve-client-ids.js'
+
+export const config = {
+  api: { bodyParser: { sizeLimit: '10mb' } },
+  maxDuration: 120,
+}
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'POST') return res.status(405).json({ error: 'Method not allowed' })
+  try { await authenticateRequest(req) } catch (err: any) {
+    return res.status(err.statusCode ?? 401).json({ error: err.message ?? 'Unauthorized' })
+  }
+  const assessmentId = req.query.id as string
+  const body = (req.body ?? {}) as { filename?: string; cycle_label?: string; csv?: string }
+  if (!body.csv) return res.status(400).json({ error: 'csv required' })
+  const filename = (body.filename ?? 'upload.csv').trim() || 'upload.csv'
+  const cycleLabel = body.cycle_label ?? null
+  const db = createAdminClient()
+
+  const { data: assessment } = await db
+    .from('schedule_assessments')
+    .select('id, client_id')
+    .eq('id', assessmentId)
+    .maybeSingle()
+  if (!assessment) return res.status(404).json({ error: 'Assessment not found' })
+  const clientId = (assessment as any).client_id as string
+
+  // Parse CSV.
+  const { rows, errors } = parseScheduleCsv(body.csv)
+  if (rows.length === 0) {
+    return res.status(400).json({
+      error: 'No valid rows parsed.',
+      parse_errors: errors,
+    })
+  }
+
+  // Insert file.
+  const { data: file, error: fileErr } = await db
+    .from('schedule_assessment_files')
+    .insert({
+      assessment_id: assessmentId,
+      filename,
+      cycle_label: cycleLabel,
+      row_count: rows.length,
+    })
+    .select('id')
+    .single()
+  if (fileErr || !file) {
+    return res.status(500).json({ error: `file insert: ${fileErr?.message ?? 'unknown'}` })
+  }
+  const fileId = (file as any).id
+
+  // Bulk-insert parsed rows. Chunk to keep payload sizes sane.
+  const INSERT_CHUNK = 500
+  const insertedRows: Array<{ id: string; raw_address: string }> = []
+  for (let i = 0; i < rows.length; i += INSERT_CHUNK) {
+    const chunk = rows.slice(i, i + INSERT_CHUNK).map((r) => ({
+      assessment_id: assessmentId,
+      file_id: fileId,
+      raw_address: r.raw_address,
+      raw_scheduled_date: r.raw_scheduled_date,
+      raw_crew_name: r.raw_crew_name,
+    }))
+    const { data: inserted, error: insErr } = await db
+      .from('schedule_assessment_rows')
+      .insert(chunk)
+      .select('id, raw_address')
+    if (insErr) {
+      return res.status(500).json({ error: `rows insert: ${insErr.message}` })
+    }
+    if (inserted) insertedRows.push(...(inserted as any[]))
+  }
+
+  // Resolve client_ids (combined → members) and run fuzzy matching.
+  const memberIds = await resolveClientIds(db, clientId)
+  const matches = await matchAddresses(
+    db,
+    memberIds,
+    insertedRows.map((r) => ({ row_id: r.id, raw_address: r.raw_address }))
+  )
+
+  // Persist match results. Group updates by status to minimize round-trips.
+  const updates: Array<{ id: string; matched_service_location_id: string | null; match_confidence: number | null; match_status: string }> = []
+  for (const m of matches) {
+    updates.push({
+      id: m.row_id,
+      matched_service_location_id: m.matched_sl_id,
+      match_confidence: m.confidence,
+      match_status: m.match_status === 'auto' ? 'auto' : (m.match_status === 'unmatched' ? 'unmatched' : 'pending'),
+    })
+  }
+  // Batch the row-by-row updates. Supabase doesn't support a single
+  // bulk UPDATE without a CTE; use upsert-by-id which is fine here.
+  for (let i = 0; i < updates.length; i += INSERT_CHUNK) {
+    const chunk = updates.slice(i, i + INSERT_CHUNK)
+    const { error: upErr } = await db
+      .from('schedule_assessment_rows')
+      .upsert(chunk, { onConflict: 'id' })
+    if (upErr) {
+      // Non-fatal — surface but don't fail the whole upload.
+      // eslint-disable-next-line no-console
+      console.warn(`match update batch failed: ${upErr.message}`)
+    }
+  }
+
+  // Bump assessment status to 'matched' if anything matched; otherwise leave 'draft'.
+  if (matches.some((m) => m.match_status === 'auto')) {
+    await db
+      .from('schedule_assessments')
+      .update({ status: 'matched', updated_at: new Date().toISOString() })
+      .eq('id', assessmentId)
+  }
+
+  const summary = {
+    rows_parsed: rows.length,
+    auto_matched: matches.filter((m) => m.match_status === 'auto').length,
+    review_needed: matches.filter((m) => m.match_status === 'pending').length,
+    unmatched: matches.filter((m) => m.match_status === 'unmatched').length,
+    parse_errors: errors,
+  }
+  return res.status(201).json({ file_id: fileId, summary })
+}

--- a/api/v1/schedule-assessments/index.ts
+++ b/api/v1/schedule-assessments/index.ts
@@ -1,0 +1,61 @@
+// GET  /api/v1/schedule-assessments?client_id=...
+//   List assessments for a client.
+// POST /api/v1/schedule-assessments
+//   Create a new assessment. Body: { account_id, client_id, name,
+//   baseline_template_id? }.
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { createAdminClient } from '../../_lib/supabase.js'
+import { authenticateRequest, type AuthContext } from '../../_lib/auth.js'
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method === 'OPTIONS') return res.status(200).end()
+  let ctx: AuthContext
+  try { ctx = await authenticateRequest(req) } catch (err: any) {
+    return res.status(err.statusCode ?? 401).json({ error: err.message ?? 'Unauthorized' })
+  }
+  const db = createAdminClient()
+
+  if (req.method === 'GET') {
+    const clientId = req.query.client_id as string | undefined
+    if (!clientId) return res.status(400).json({ error: 'client_id required' })
+    const { data, error } = await db
+      .from('schedule_assessments')
+      .select('id, name, status, baseline_template_id, created_at, updated_at')
+      .eq('client_id', clientId)
+      .neq('status', 'archived')
+      .order('updated_at', { ascending: false })
+    if (error) return res.status(500).json({ error: error.message })
+    return res.status(200).json({ assessments: data ?? [] })
+  }
+
+  if (req.method === 'POST') {
+    const body = (req.body ?? {}) as {
+      account_id?: string
+      client_id?: string
+      name?: string
+      baseline_template_id?: string | null
+    }
+    const accountId = body.account_id
+    const clientId = body.client_id
+    const name = (body.name ?? '').trim()
+    if (!accountId || !clientId || !name) {
+      return res.status(400).json({ error: 'account_id, client_id, and name required' })
+    }
+    const { data, error } = await db
+      .from('schedule_assessments')
+      .insert({
+        account_id: accountId,
+        client_id: clientId,
+        name,
+        baseline_template_id: body.baseline_template_id ?? null,
+        status: 'draft',
+        created_by: ctx.userId ?? null,
+      })
+      .select('*')
+      .single()
+    if (error) return res.status(500).json({ error: error.message })
+    return res.status(201).json({ assessment: data })
+  }
+
+  return res.status(405).json({ error: 'Method not allowed' })
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -39,6 +39,8 @@ import TemplateDetailPage from './pages/accounts/scheduler/TemplateDetail'
 import CycleComparePage from './pages/accounts/scheduler/CycleCompare'
 import CycleDetailPage from './pages/accounts/scheduler/CycleDetail'
 import CombinedSchedulesPage from './pages/accounts/scheduler/CombinedSchedules'
+import ScheduleAssessmentListPage from './pages/accounts/scheduler/ScheduleAssessmentList'
+import ScheduleAssessmentDetailPage from './pages/accounts/scheduler/ScheduleAssessmentDetail'
 import TravelPlannerPage from './pages/accounts/TravelPlanner'
 import CustomFieldsAdminPage from './pages/accounts/CustomFieldsAdmin'
 import NewAccountClientPage from './pages/accounts/NewAccountClient'
@@ -177,6 +179,14 @@ export default function App() {
           <Route
             path="/accounts/:accountId/combined-schedules"
             element={<AuthGuard><CombinedSchedulesPage /></AuthGuard>}
+          />
+          <Route
+            path="/accounts/:accountId/clients/:clientId/schedule-assessment"
+            element={<AuthGuard><ScheduleAssessmentListPage /></AuthGuard>}
+          />
+          <Route
+            path="/accounts/:accountId/clients/:clientId/schedule-assessment/:id"
+            element={<AuthGuard><ScheduleAssessmentDetailPage /></AuthGuard>}
           />
           <Route
             path="/accounts/:accountId/clients/:clientId/travel"

--- a/src/pages/accounts/AccountAnalysis.tsx
+++ b/src/pages/accounts/AccountAnalysis.tsx
@@ -1364,6 +1364,12 @@ function AnalysisSidebar({
         >
           Travel & trips
         </SidebarItem>
+        <SidebarItem
+          icon={Sparkles}
+          to={`/accounts/${accountId}/clients/${clientId}/schedule-assessment`}
+        >
+          Schedule Assessment
+        </SidebarItem>
       </SidebarSection>
 
       <SidebarSection title="Settings">

--- a/src/pages/accounts/scheduler/ScheduleAssessmentDetail.tsx
+++ b/src/pages/accounts/scheduler/ScheduleAssessmentDetail.tsx
@@ -1,0 +1,401 @@
+import { useState, useEffect, useCallback, useMemo } from 'react'
+import { useParams } from 'react-router-dom'
+import { Upload, AlertCircle, CheckCircle2 } from 'lucide-react'
+import { useAuth } from '../../../hooks/useAuth'
+import AppShell from '../../../components/layout/AppShell'
+import Button from '../../../components/ui/Button'
+import { Card, CardTitle } from '../../../components/ui/Card'
+import { Badge } from '../../../components/ui/Badge'
+import { Input, FormField, Textarea } from '../../../components/ui/Input'
+import {
+  Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
+} from '../../../components/ui/Table'
+
+interface Assessment {
+  id: string
+  name: string
+  status: string
+  baseline_template_id: string | null
+  client_id: string
+  account_id: string
+}
+
+interface FileRow {
+  id: string
+  filename: string
+  cycle_label: string | null
+  row_count: number
+  uploaded_at: string
+}
+
+interface AssessmentRowData {
+  id: string
+  file_id: string
+  raw_address: string
+  raw_scheduled_date: string | null
+  raw_crew_name: string | null
+  matched_service_location_id: string | null
+  match_confidence: number | null
+  match_status: string
+  notes: string | null
+}
+
+interface SLOption {
+  id: string
+  display_name: string | null
+  property: { address_line1: string | null } | null
+}
+
+const STATUS_VARIANT: Record<string, 'outline' | 'accent' | 'success' | 'warning' | 'danger'> = {
+  auto: 'success',
+  manual: 'success',
+  pending: 'warning',
+  unmatched: 'danger',
+  skipped: 'outline',
+}
+
+export default function ScheduleAssessmentDetailPage() {
+  const { accountId, clientId, id } = useParams<{ accountId: string; clientId: string; id: string }>()
+  const { getToken } = useAuth()
+  const [assessment, setAssessment] = useState<Assessment | null>(null)
+  const [files, setFiles] = useState<FileRow[]>([])
+  const [rows, setRows] = useState<AssessmentRowData[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [uploading, setUploading] = useState(false)
+  const [uploadCsv, setUploadCsv] = useState('')
+  const [uploadName, setUploadName] = useState('')
+  const [uploadCycleLabel, setUploadCycleLabel] = useState('')
+  const [slOptions, setSlOptions] = useState<SLOption[]>([])
+
+  const load = useCallback(async () => {
+    if (!id) return
+    setLoading(true)
+    try {
+      const token = await getToken()
+      const res = await fetch(`/api/v1/schedule-assessments/${id}`, {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      const j = await res.json()
+      if (!res.ok) throw new Error(j.error ?? `Load failed (${res.status})`)
+      setAssessment(j.assessment)
+      setFiles(j.files ?? [])
+      setRows(j.rows ?? [])
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setLoading(false)
+    }
+  }, [id, getToken])
+
+  useEffect(() => { load() }, [load])
+
+  // Lazy-load SL options for the manual-match dropdowns when the
+  // operator opens the review tray.
+  const loadSlOptions = useCallback(async () => {
+    if (slOptions.length > 0 || !clientId) return
+    try {
+      const token = await getToken()
+      const res = await fetch(`/api/v1/service-locations?client_id=${clientId}`, {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      if (res.ok) {
+        const arr = (await res.json()) as Array<{ id: string; display_name: string | null; property: any }>
+        setSlOptions(arr.map((s) => ({ id: s.id, display_name: s.display_name, property: s.property })))
+      }
+    } catch {
+      // non-fatal
+    }
+  }, [clientId, slOptions.length, getToken])
+
+  async function handleFileUpload(file: File) {
+    if (!id) return
+    const text = await file.text()
+    setUploadCsv(text)
+    setUploadName(file.name)
+  }
+
+  async function submitUpload() {
+    if (!uploadCsv || !id) return
+    setUploading(true)
+    setError(null)
+    try {
+      const token = await getToken()
+      const res = await fetch(`/api/v1/schedule-assessments/${id}/upload`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        body: JSON.stringify({
+          filename: uploadName || 'upload.csv',
+          cycle_label: uploadCycleLabel || null,
+          csv: uploadCsv,
+        }),
+      })
+      const j = await res.json()
+      if (!res.ok) throw new Error(j.error ?? `Upload failed (${res.status})`)
+      setUploadCsv('')
+      setUploadName('')
+      setUploadCycleLabel('')
+      await load()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setUploading(false)
+    }
+  }
+
+  async function updateRow(rowId: string, patch: Partial<AssessmentRowData>) {
+    if (!id) return
+    try {
+      const token = await getToken()
+      await fetch(`/api/v1/schedule-assessments/${id}/rows`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        body: JSON.stringify({
+          rows: [{ id: rowId, ...patch }],
+        }),
+      })
+      // Optimistic local update so the user doesn't wait for a re-fetch.
+      setRows((prev) => prev.map((r) => (r.id === rowId ? { ...r, ...patch } as AssessmentRowData : r)))
+    } catch {
+      // ignore — user can re-try
+    }
+  }
+
+  const counts = useMemo(() => {
+    let auto = 0, pending = 0, unmatched = 0, skipped = 0, manual = 0
+    for (const r of rows) {
+      if (r.match_status === 'auto') auto++
+      else if (r.match_status === 'manual') manual++
+      else if (r.match_status === 'pending') pending++
+      else if (r.match_status === 'unmatched') unmatched++
+      else if (r.match_status === 'skipped') skipped++
+    }
+    return { auto, manual, pending, unmatched, skipped, total: rows.length }
+  }, [rows])
+
+  const reviewRows = useMemo(
+    () => rows.filter((r) => r.match_status === 'pending' || r.match_status === 'unmatched'),
+    [rows]
+  )
+
+  if (loading) {
+    return (
+      <AppShell><div className="p-10 text-fg-muted">Loading…</div></AppShell>
+    )
+  }
+  if (!assessment) {
+    return (
+      <AppShell><div className="p-10 text-danger">Assessment not found.</div></AppShell>
+    )
+  }
+
+  return (
+    <AppShell
+      breadcrumb={[
+        { label: 'Accounts', to: '/accounts' },
+        { label: 'Smart Analysis', to: `/accounts/${accountId}/clients/${clientId}/analysis` },
+        { label: 'Schedule Assessment', to: `/accounts/${accountId}/clients/${clientId}/schedule-assessment` },
+        { label: assessment.name },
+      ]}
+    >
+      <div className="mx-auto max-w-5xl px-6 py-10 space-y-6">
+        <header>
+          <h1 className="text-2xl font-semibold tracking-tight text-fg">{assessment.name}</h1>
+          <p className="text-sm text-fg-muted">Status: <Badge variant="outline">{assessment.status}</Badge></p>
+        </header>
+
+        {error && <p className="text-sm text-danger">{error}</p>}
+
+        {/* Step 1: Upload */}
+        <Card className="space-y-3">
+          <CardTitle>Upload schedule files</CardTitle>
+          <p className="text-sm text-fg-muted">
+            CSV with columns <code>address</code>, <code>scheduled_date</code>, optional <code>crew_name</code>.
+            Upload one file per historical cycle to enable per-property pattern detection (PR3).
+          </p>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <FormField label="Cycle label (optional)">
+              <Input
+                value={uploadCycleLabel}
+                onChange={(e) => setUploadCycleLabel(e.target.value)}
+                placeholder='e.g. "2024 cycle"'
+              />
+            </FormField>
+            <FormField label="CSV file">
+              <input
+                type="file"
+                accept=".csv,text/csv"
+                onChange={(e) => {
+                  const f = e.target.files?.[0]
+                  if (f) handleFileUpload(f)
+                }}
+                className="text-sm text-fg"
+              />
+            </FormField>
+          </div>
+          {uploadCsv && (
+            <FormField label="Preview (first 200 chars)">
+              <Textarea
+                rows={3}
+                readOnly
+                value={uploadCsv.slice(0, 200) + (uploadCsv.length > 200 ? '…' : '')}
+              />
+            </FormField>
+          )}
+          <div>
+            <Button onClick={submitUpload} disabled={!uploadCsv || uploading} loading={uploading}>
+              <Upload className="h-4 w-4" />
+              Upload
+            </Button>
+          </div>
+        </Card>
+
+        {files.length > 0 && (
+          <Card padding="none">
+            <div className="px-4 py-3 border-b border-border">
+              <CardTitle>Uploaded files</CardTitle>
+            </div>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Filename</TableHead>
+                  <TableHead>Cycle label</TableHead>
+                  <TableHead className="text-right">Rows</TableHead>
+                  <TableHead>Uploaded</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {files.map((f) => (
+                  <TableRow key={f.id}>
+                    <TableCell className="font-mono text-xs">{f.filename}</TableCell>
+                    <TableCell className="text-xs">{f.cycle_label ?? '—'}</TableCell>
+                    <TableCell numeric>{f.row_count.toLocaleString()}</TableCell>
+                    <TableCell className="text-xs text-fg-muted">
+                      {new Date(f.uploaded_at).toLocaleString()}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </Card>
+        )}
+
+        {/* Step 2: Match summary */}
+        {rows.length > 0 && (
+          <Card className="space-y-3">
+            <CardTitle>Address match summary</CardTitle>
+            <div className="grid grid-cols-2 sm:grid-cols-5 gap-3">
+              <Stat label="Auto-matched" value={counts.auto + counts.manual} icon={<CheckCircle2 className="h-3 w-3 text-success" />} />
+              <Stat label="Needs review" value={counts.pending} icon={<AlertCircle className="h-3 w-3 text-warning" />} />
+              <Stat label="Unmatched" value={counts.unmatched} icon={<AlertCircle className="h-3 w-3 text-danger" />} />
+              <Stat label="Skipped" value={counts.skipped} />
+              <Stat label="Total" value={counts.total} />
+            </div>
+          </Card>
+        )}
+
+        {/* Review tray */}
+        {reviewRows.length > 0 && (
+          <Card padding="none">
+            <div className="px-4 py-3 border-b border-border flex items-center justify-between">
+              <div>
+                <CardTitle>Review unmatched / low-confidence rows</CardTitle>
+                <p className="text-xs text-fg-muted mt-0.5">
+                  Pick the right service location, or skip rows that aren't part of this client's portfolio.
+                </p>
+              </div>
+              <Button size="sm" variant="ghost" onClick={loadSlOptions}>
+                Load SL list
+              </Button>
+            </div>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Raw address</TableHead>
+                  <TableHead>Date</TableHead>
+                  <TableHead>Crew</TableHead>
+                  <TableHead className="text-right">Confidence</TableHead>
+                  <TableHead>Match</TableHead>
+                  <TableHead />
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {reviewRows.slice(0, 200).map((r) => (
+                  <TableRow key={r.id}>
+                    <TableCell className="text-xs">{r.raw_address}</TableCell>
+                    <TableCell className="text-xs font-tabular">{r.raw_scheduled_date ?? '—'}</TableCell>
+                    <TableCell className="text-xs">{r.raw_crew_name ?? '—'}</TableCell>
+                    <TableCell numeric className="text-xs">
+                      {r.match_confidence != null ? `${Math.round(r.match_confidence * 100)}%` : '—'}
+                    </TableCell>
+                    <TableCell>
+                      {slOptions.length > 0 ? (
+                        <select
+                          value={r.matched_service_location_id ?? ''}
+                          onChange={(e) =>
+                            updateRow(r.id, {
+                              matched_service_location_id: e.target.value || null,
+                              match_status: e.target.value ? 'manual' : 'unmatched',
+                            })
+                          }
+                          className="h-8 max-w-xs rounded-md border border-border bg-surface px-2 text-xs"
+                        >
+                          <option value="">— pick SL —</option>
+                          {slOptions.map((s) => (
+                            <option key={s.id} value={s.id}>
+                              {s.display_name ?? s.property?.address_line1 ?? s.id.slice(0, 8)}
+                            </option>
+                          ))}
+                        </select>
+                      ) : (
+                        <span className="text-xs text-fg-subtle">click "Load SL list"</span>
+                      )}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        onClick={() =>
+                          updateRow(r.id, { match_status: 'skipped' })
+                        }
+                      >
+                        Skip
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+            {reviewRows.length > 200 && (
+              <p className="px-4 py-2 text-xs text-fg-subtle border-t border-border">
+                Showing 200 of {reviewRows.length} — resolve a batch and refresh.
+              </p>
+            )}
+          </Card>
+        )}
+
+        {/* Placeholder for next-PR work */}
+        <Card>
+          <CardTitle>Next steps (PR2 / PR3)</CardTitle>
+          <p className="text-sm text-fg-muted mt-2">
+            Once your matches are resolved, the next iteration ships the
+            optimized baseline + diff dashboard (PR2) and constraint
+            detection (PR3). For now, the upload + match flow is live.
+          </p>
+        </Card>
+      </div>
+    </AppShell>
+  )
+}
+
+function Stat({ label, value, icon }: { label: string; value: number; icon?: React.ReactNode }) {
+  return (
+    <div className="rounded-md border border-border bg-surface-subtle/40 px-3 py-2">
+      <p className="text-[10px] uppercase tracking-wide text-fg-subtle flex items-center gap-1">
+        {icon}
+        {label}
+      </p>
+      <p className="font-mono text-lg font-semibold text-fg tabular-nums">{value}</p>
+    </div>
+  )
+}

--- a/src/pages/accounts/scheduler/ScheduleAssessmentList.tsx
+++ b/src/pages/accounts/scheduler/ScheduleAssessmentList.tsx
@@ -1,0 +1,200 @@
+import { useState, useEffect, useCallback } from 'react'
+import { useParams, useNavigate, Link } from 'react-router-dom'
+import { Plus, Sparkles } from 'lucide-react'
+import { useAuth } from '../../../hooks/useAuth'
+import AppShell from '../../../components/layout/AppShell'
+import Button from '../../../components/ui/Button'
+import { Card, CardTitle } from '../../../components/ui/Card'
+import { Badge } from '../../../components/ui/Badge'
+import { EmptyState } from '../../../components/ui/EmptyState'
+import {
+  Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle,
+} from '../../../components/ui/Dialog'
+import { Input, FormField } from '../../../components/ui/Input'
+
+interface AssessmentRow {
+  id: string
+  name: string
+  status: string
+  baseline_template_id: string | null
+  created_at: string
+  updated_at: string
+}
+
+const STATUS_VARIANT: Record<string, 'outline' | 'accent' | 'success' | 'warning'> = {
+  draft: 'outline',
+  matched: 'accent',
+  baseline: 'warning',
+  finalized: 'success',
+}
+
+export default function ScheduleAssessmentListPage() {
+  const { accountId, clientId } = useParams<{ accountId: string; clientId: string }>()
+  const { getToken } = useAuth()
+  const navigate = useNavigate()
+  const [items, setItems] = useState<AssessmentRow[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [createOpen, setCreateOpen] = useState(false)
+
+  const load = useCallback(async () => {
+    if (!clientId) return
+    setLoading(true)
+    try {
+      const token = await getToken()
+      const res = await fetch(`/api/v1/schedule-assessments?client_id=${clientId}`, {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      const j = await res.json()
+      if (!res.ok) throw new Error(j.error ?? `Load failed (${res.status})`)
+      setItems(j.assessments ?? [])
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setLoading(false)
+    }
+  }, [clientId, getToken])
+
+  useEffect(() => { load() }, [load])
+
+  return (
+    <AppShell
+      breadcrumb={[
+        { label: 'Accounts', to: '/accounts' },
+        { label: 'Smart Analysis', to: `/accounts/${accountId}/clients/${clientId}/analysis` },
+        { label: 'Schedule Assessment' },
+      ]}
+    >
+      <div className="mx-auto max-w-5xl px-6 py-10 space-y-6">
+        <header className="flex items-start justify-between gap-4">
+          <div className="space-y-1">
+            <h1 className="text-2xl font-semibold tracking-tight text-fg flex items-center gap-2">
+              <Sparkles className="h-6 w-6 text-accent" />
+              Schedule Assessment
+            </h1>
+            <p className="text-sm text-fg-muted max-w-2xl">
+              Upload one or more historical schedules. The app matches them
+              against this client's properties, detects implicit constraints
+              from the patterns, generates an optimized baseline, and lets
+              you iterate to a hybrid you can save as a routing template.
+            </p>
+          </div>
+          <Button onClick={() => setCreateOpen(true)}>
+            <Plus className="h-4 w-4" />
+            New assessment
+          </Button>
+        </header>
+
+        {error && <p className="text-sm text-danger">{error}</p>}
+
+        {loading ? (
+          <p className="text-sm text-fg-muted">Loading…</p>
+        ) : items.length === 0 ? (
+          <EmptyState
+            title="No assessments yet"
+            description="Create one to upload your current schedule and compare against an optimized version."
+          />
+        ) : (
+          <div className="space-y-2">
+            {items.map((a) => (
+              <Card key={a.id} className="flex items-center justify-between gap-4">
+                <div className="space-y-0.5 min-w-0">
+                  <Link
+                    to={`/accounts/${accountId}/clients/${clientId}/schedule-assessment/${a.id}`}
+                    className="text-base font-semibold text-accent hover:underline"
+                  >
+                    {a.name}
+                  </Link>
+                  <p className="text-xs text-fg-muted">
+                    Updated {new Date(a.updated_at).toLocaleString()}
+                  </p>
+                </div>
+                <Badge variant={STATUS_VARIANT[a.status] ?? 'outline'}>
+                  {a.status}
+                </Badge>
+              </Card>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {createOpen && (
+        <CreateAssessmentDialog
+          accountId={accountId!}
+          clientId={clientId!}
+          onClose={() => setCreateOpen(false)}
+          onCreated={(id) =>
+            navigate(`/accounts/${accountId}/clients/${clientId}/schedule-assessment/${id}`)
+          }
+        />
+      )}
+    </AppShell>
+  )
+}
+
+function CreateAssessmentDialog({
+  accountId,
+  clientId,
+  onClose,
+  onCreated,
+}: {
+  accountId: string
+  clientId: string
+  onClose: () => void
+  onCreated: (id: string) => void
+}) {
+  const { getToken } = useAuth()
+  const [name, setName] = useState('')
+  const [creating, setCreating] = useState(false)
+  const [err, setErr] = useState<string | null>(null)
+
+  async function create() {
+    if (!name.trim()) { setErr('Name is required'); return }
+    setCreating(true)
+    setErr(null)
+    try {
+      const token = await getToken()
+      const res = await fetch(`/api/v1/schedule-assessments`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        body: JSON.stringify({
+          account_id: accountId,
+          client_id: clientId,
+          name: name.trim(),
+        }),
+      })
+      const j = await res.json()
+      if (!res.ok) throw new Error(j.error ?? `Create failed (${res.status})`)
+      onCreated(j.assessment.id)
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e))
+    } finally {
+      setCreating(false)
+    }
+  }
+
+  return (
+    <Dialog open onOpenChange={(o) => !o && onClose()}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>New schedule assessment</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-3">
+          <FormField label="Name">
+            <Input
+              autoFocus
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder='e.g. "2025 schedule review"'
+            />
+          </FormField>
+          {err && <p className="text-xs text-danger">{err}</p>}
+        </div>
+        <DialogFooter>
+          <Button variant="ghost" onClick={onClose} disabled={creating}>Cancel</Button>
+          <Button onClick={create} loading={creating}>Create</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/supabase/migrations/20260503021926_schedule_assessment_entity.sql
+++ b/supabase/migrations/20260503021926_schedule_assessment_entity.sql
@@ -1,0 +1,93 @@
+-- Schedule assessment & enhancer.
+--
+-- Operators upload N historical schedule CSVs (one per cycle), the
+-- system fuzzy-matches addresses to existing service_locations,
+-- detects implicit constraints across the aggregate, generates an
+-- optimized baseline, and lets the user iterate to a hybrid that can
+-- be saved as a routing template.
+--
+-- This migration lands the data model. PR2 + PR3 add baseline /
+-- diff / detection logic on top.
+
+CREATE TABLE IF NOT EXISTS public.schedule_assessments (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  account_id uuid NOT NULL REFERENCES public.accounts(id) ON DELETE CASCADE,
+  client_id uuid NOT NULL REFERENCES public.clients(id) ON DELETE CASCADE,
+  name text NOT NULL,
+  -- Lifecycle: draft → matched → baseline → finalized.
+  -- 'archived' is a soft-delete that keeps the row around for audit.
+  status text NOT NULL DEFAULT 'draft'
+    CHECK (status IN ('draft','matched','baseline','finalized','archived')),
+  -- When set, the diff dashboard compares the uploaded schedule against
+  -- this template's most recent generated cycle. Otherwise the
+  -- baseline is a fresh engine run from current constraints.
+  baseline_template_id uuid REFERENCES public.routing_templates(id) ON DELETE SET NULL,
+  -- Per-property iteration choices. Keys are service_location_id;
+  -- each entry is { source: 'current'|'optimized', date?, crew_name? }.
+  hybrid_overrides jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  created_by uuid REFERENCES auth.users(id) ON DELETE SET NULL
+);
+
+CREATE INDEX IF NOT EXISTS schedule_assessments_account_idx
+  ON public.schedule_assessments(account_id);
+CREATE INDEX IF NOT EXISTS schedule_assessments_client_idx
+  ON public.schedule_assessments(client_id);
+
+-- One row per uploaded CSV. Filename + parsed row count for the UI;
+-- the actual rows live in schedule_assessment_rows.
+CREATE TABLE IF NOT EXISTS public.schedule_assessment_files (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  assessment_id uuid NOT NULL REFERENCES public.schedule_assessments(id) ON DELETE CASCADE,
+  filename text NOT NULL,
+  cycle_label text, -- operator-supplied label like "2024 cycle" or "Last spring"
+  row_count int NOT NULL DEFAULT 0,
+  uploaded_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS schedule_assessment_files_assessment_idx
+  ON public.schedule_assessment_files(assessment_id);
+
+-- Parsed rows from uploaded CSVs. Keep raw + matched columns side by
+-- side so the operator can review unmatched rows and re-pick.
+CREATE TABLE IF NOT EXISTS public.schedule_assessment_rows (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  assessment_id uuid NOT NULL REFERENCES public.schedule_assessments(id) ON DELETE CASCADE,
+  file_id uuid NOT NULL REFERENCES public.schedule_assessment_files(id) ON DELETE CASCADE,
+  raw_address text NOT NULL,
+  raw_scheduled_date date,
+  raw_crew_name text,
+  matched_service_location_id uuid REFERENCES public.service_locations(id) ON DELETE SET NULL,
+  match_confidence numeric, -- 0..1; null when unmatched
+  match_status text NOT NULL DEFAULT 'pending'
+    CHECK (match_status IN ('pending','auto','manual','unmatched','skipped')),
+  notes text,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS schedule_assessment_rows_assessment_idx
+  ON public.schedule_assessment_rows(assessment_id);
+CREATE INDEX IF NOT EXISTS schedule_assessment_rows_match_status_idx
+  ON public.schedule_assessment_rows(assessment_id, match_status);
+CREATE INDEX IF NOT EXISTS schedule_assessment_rows_sl_idx
+  ON public.schedule_assessment_rows(matched_service_location_id);
+
+-- Detected / accepted constraints. Populated by PR3's detection
+-- layer; status starts at 'detected', operator accepts/rejects.
+CREATE TABLE IF NOT EXISTS public.schedule_assessment_constraints (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  assessment_id uuid NOT NULL REFERENCES public.schedule_assessments(id) ON DELETE CASCADE,
+  detection_type text NOT NULL,
+  scope_type text NOT NULL CHECK (scope_type IN ('global','crew','property','pair')),
+  scope_ids uuid[],
+  pattern jsonb,
+  confidence numeric,
+  status text NOT NULL DEFAULT 'detected'
+    CHECK (status IN ('detected','accepted','rejected','edited')),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS schedule_assessment_constraints_assessment_idx
+  ON public.schedule_assessment_constraints(assessment_id);


### PR DESCRIPTION
## Summary
First of three PRs. This lands the data model, multi-file CSV upload, fuzzy address matching, and the wizard skeleton (list + detail pages with review tray). PR2 ships the optimized baseline + diff dashboard. PR3 ships constraint detection.

## Schema (already pushed)
- \`schedule_assessments\` — one per assessment job
- \`schedule_assessment_files\` — one row per uploaded CSV (multi-file from day one — needed for per-property pattern detection in PR3 since a 6-month cycle has 1 visit/property/cycle)
- \`schedule_assessment_rows\` — parsed CSV rows with raw + matched columns
- \`schedule_assessment_constraints\` — populated by PR3

## Backend
- \`/api/v1/schedule-assessments\` — list, create
- \`/api/v1/schedule-assessments/[id]\` — get, patch, archive
- \`/api/v1/schedule-assessments/[id]/upload\` — CSV parse + match
- \`/api/v1/schedule-assessments/[id]/rows\` — bulk-update match assignments

## Lib
- **parse-csv**: papaparse with header aliasing. Required: \`address\`, \`scheduled_date\`. Optional: \`crew_name\`. Returns parse errors per line.
- **match-addresses**: normalized-token Jaccard. AUTO ≥ 0.85, review tray for 0.55–0.85, unmatched below. Pages SL fetch and resolves combined clients via the existing helper.

## Frontend
- Sidebar link \"Schedule Assessment\" under Scheduler.
- List page with create dialog.
- Detail wizard with upload form, match summary stats, review tray for unmatched / low-confidence rows with per-row SL picker.

## Test plan
- [ ] Open AccountAnalysis sidebar → \"Schedule Assessment\" link visible
- [ ] Create assessment → land on detail page
- [ ] Upload a small CSV (3–5 rows) → file appears in Uploaded files; match summary populates
- [ ] Rows with low confidence appear in the review tray; \"Load SL list\" populates the dropdowns; pick an SL → row marked \`manual\`
- [ ] Skip a row → marked \`skipped\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)