### PR TITLE
Schedule Assessment PR2 — diff dashboard + hybrid choices

### DIFF
--- a/api/v1/schedule-assessments/[id]/diff.ts
+++ b/api/v1/schedule-assessments/[id]/diff.ts
@@ -1,0 +1,221 @@
+// GET /api/v1/schedule-assessments/[id]/diff
+//
+// Compares the assessment's matched rows ("current schedule" — what the
+// operator uploaded) against the optimized baseline ("what the engine
+// produced"). The baseline is the most recent cycle of the assessment's
+// linked baseline_template_id.
+//
+// Output: 4 categorized buckets the wizard renders:
+//   only_current  — uploaded for an SL the optimized cycle doesn't visit
+//   only_optimized — engine schedules an SL the upload doesn't include
+//   moved_date    — same SL, different scheduled_date (and possibly crew)
+//   matched_same  — SL on the same date in both (no action needed)
+// Plus aggregate stats so the operator can see drive-time / day-count
+// deltas at a glance.
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { createAdminClient } from '../../../_lib/supabase.js'
+import { authenticateRequest } from '../../../_lib/auth.js'
+
+type DiffStatus = 'only_current' | 'only_optimized' | 'moved_date' | 'matched_same'
+
+interface DiffRow {
+  status: DiffStatus
+  service_location_id: string | null
+  display_name: string | null
+  current_date: string | null
+  current_crew: string | null
+  optimized_date: string | null
+  optimized_crew: string | null
+  // Per-row hybrid override choice (set by the user via the wizard).
+  hybrid_choice?: 'current' | 'optimized' | 'skip' | null
+}
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'GET') return res.status(405).json({ error: 'Method not allowed' })
+  try { await authenticateRequest(req) } catch (err: any) {
+    return res.status(err.statusCode ?? 401).json({ error: err.message ?? 'Unauthorized' })
+  }
+  const id = req.query.id as string
+  const db = createAdminClient()
+
+  const { data: assessment } = await db
+    .from('schedule_assessments')
+    .select('id, baseline_template_id, hybrid_overrides')
+    .eq('id', id)
+    .maybeSingle()
+  if (!assessment) return res.status(404).json({ error: 'Assessment not found' })
+  const a = assessment as any
+  const overrides = (a.hybrid_overrides ?? {}) as Record<
+    string,
+    { source?: 'current' | 'optimized' | 'skip' }
+  >
+
+  if (!a.baseline_template_id) {
+    return res.status(400).json({
+      error: 'No baseline_template_id set on this assessment. Pick a routing template to compare against.',
+      code: 'NO_BASELINE',
+    })
+  }
+
+  // Pull this template's most recent cycle.
+  const { data: cycleRow } = await db
+    .from('cycle_instances')
+    .select('id, start_date, end_date, generated_at')
+    .eq('template_id', a.baseline_template_id)
+    .order('generated_at', { ascending: false })
+    .limit(1)
+    .maybeSingle()
+  if (!cycleRow) {
+    return res.status(400).json({
+      error: 'Linked template has no generated cycle yet. Generate a cycle on the template first, then come back.',
+      code: 'NO_CYCLE',
+    })
+  }
+  const cycleId = (cycleRow as any).id
+
+  // Page through scheduled_visits for the cycle (1000-cap protection).
+  const PAGE = 1000
+  const optimizedVisits: Array<{ sl_id: string; date: string | null; crew: string | null; address: string | null; status: string }> = []
+  for (let p = 0; p < 50; p++) {
+    const { data } = await db
+      .from('scheduled_visits')
+      .select('id, status, service_location_id, scheduled_date, crew_index, service_locations(display_name, property:properties(address_line1))')
+      .eq('cycle_instance_id', cycleId)
+      .range(p * PAGE, p * PAGE + PAGE - 1)
+    const arr = data ?? []
+    for (const v of arr as any[]) {
+      optimizedVisits.push({
+        sl_id: v.service_location_id,
+        date: v.scheduled_date,
+        crew: v.crew_index != null ? `Crew ${Number(v.crew_index) + 1}` : null,
+        address: v.service_locations?.property?.address_line1 ?? v.service_locations?.display_name ?? null,
+        status: v.status,
+      })
+    }
+    if (arr.length < PAGE) break
+  }
+  // Resolve crew_label per crew_index by sampling crew_day_routes.
+  const { data: cdRows } = await db
+    .from('crew_day_routes')
+    .select('crew_index, crew_label')
+    .eq('cycle_instance_id', cycleId)
+    .limit(500)
+  const crewLabelByIdx = new Map<number, string>()
+  for (const r of (cdRows ?? []) as any[]) {
+    if (typeof r.crew_index === 'number' && !crewLabelByIdx.has(r.crew_index)) {
+      crewLabelByIdx.set(r.crew_index, r.crew_label ?? `Crew ${r.crew_index + 1}`)
+    }
+  }
+  // Repopulate crew labels with the canonical name.
+  for (const v of optimizedVisits) {
+    if (v.crew) {
+      const idx = parseInt(v.crew.replace(/\D+/g, ''), 10) - 1
+      if (Number.isFinite(idx) && crewLabelByIdx.has(idx)) {
+        v.crew = crewLabelByIdx.get(idx)!
+      }
+    }
+  }
+
+  // Pull all matched assessment rows.
+  const matchedRows: any[] = []
+  for (let p = 0; p < 50; p++) {
+    const { data } = await db
+      .from('schedule_assessment_rows')
+      .select('id, raw_address, raw_scheduled_date, raw_crew_name, matched_service_location_id, match_status, service_locations(display_name, property:properties(address_line1))')
+      .eq('assessment_id', id)
+      .in('match_status', ['auto', 'manual'])
+      .not('matched_service_location_id', 'is', null)
+      .range(p * PAGE, p * PAGE + PAGE - 1)
+    const arr = data ?? []
+    matchedRows.push(...arr)
+    if (arr.length < PAGE) break
+  }
+
+  // Build diff. An SL may have multiple rows in either side (multi-visit
+  // per cycle). For v1 we treat each as an independent visit slot —
+  // pair them by date proximity.
+  const optimizedBySl = new Map<string, typeof optimizedVisits>()
+  for (const v of optimizedVisits) {
+    const arr = optimizedBySl.get(v.sl_id) ?? []
+    arr.push(v)
+    optimizedBySl.set(v.sl_id, arr)
+  }
+  const currentBySl = new Map<string, any[]>()
+  for (const r of matchedRows as any[]) {
+    const sl = r.matched_service_location_id
+    const arr = currentBySl.get(sl) ?? []
+    arr.push(r)
+    currentBySl.set(sl, arr)
+  }
+
+  const diff: DiffRow[] = []
+  const allSlIds = new Set([...optimizedBySl.keys(), ...currentBySl.keys()])
+  for (const slId of allSlIds) {
+    const opts = optimizedBySl.get(slId) ?? []
+    const curs = currentBySl.get(slId) ?? []
+    const optsSorted = [...opts].sort((a, b) => (a.date ?? '').localeCompare(b.date ?? ''))
+    const cursSorted = [...curs].sort((a, b) =>
+      (a.raw_scheduled_date ?? '').localeCompare(b.raw_scheduled_date ?? '')
+    )
+    const len = Math.max(optsSorted.length, cursSorted.length)
+    for (let i = 0; i < len; i++) {
+      const o = optsSorted[i]
+      const c = cursSorted[i]
+      const hybridKey = `${slId}|${i}`
+      const choice = (overrides[hybridKey]?.source ?? null) as DiffRow['hybrid_choice']
+      if (o && !c) {
+        diff.push({
+          status: 'only_optimized',
+          service_location_id: slId,
+          display_name: o.address ?? null,
+          current_date: null,
+          current_crew: null,
+          optimized_date: o.date,
+          optimized_crew: o.crew,
+          hybrid_choice: choice,
+        })
+      } else if (c && !o) {
+        diff.push({
+          status: 'only_current',
+          service_location_id: slId,
+          display_name: c.service_locations?.property?.address_line1 ?? c.raw_address,
+          current_date: c.raw_scheduled_date,
+          current_crew: c.raw_crew_name,
+          optimized_date: null,
+          optimized_crew: null,
+          hybrid_choice: choice,
+        })
+      } else if (c && o) {
+        const sameDate = c.raw_scheduled_date === o.date
+        diff.push({
+          status: sameDate ? 'matched_same' : 'moved_date',
+          service_location_id: slId,
+          display_name: o.address ?? c.service_locations?.property?.address_line1 ?? c.raw_address,
+          current_date: c.raw_scheduled_date,
+          current_crew: c.raw_crew_name,
+          optimized_date: o.date,
+          optimized_crew: o.crew,
+          hybrid_choice: choice,
+        })
+      }
+    }
+  }
+
+  // Aggregates.
+  const counts = {
+    only_current: diff.filter((d) => d.status === 'only_current').length,
+    only_optimized: diff.filter((d) => d.status === 'only_optimized').length,
+    moved_date: diff.filter((d) => d.status === 'moved_date').length,
+    matched_same: diff.filter((d) => d.status === 'matched_same').length,
+  }
+
+  return res.status(200).json({
+    cycle: {
+      id: cycleId,
+      start_date: (cycleRow as any).start_date,
+      end_date: (cycleRow as any).end_date,
+    },
+    counts,
+    diff,
+  })
+}

--- a/api/v1/schedule-assessments/[id]/hybrid.ts
+++ b/api/v1/schedule-assessments/[id]/hybrid.ts
@@ -1,0 +1,48 @@
+// PATCH /api/v1/schedule-assessments/[id]/hybrid
+//
+// Update the operator's per-row choice on the diff. Body:
+//   { rows: [{ key: "<sl_id>|<idx>", source: "current"|"optimized"|"skip" }] }
+// Stored on the assessment's hybrid_overrides jsonb. The save-as-template
+// endpoint reads this map to decide which dates/crews to lock when
+// promoting the hybrid to a new routing template.
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { createAdminClient } from '../../../_lib/supabase.js'
+import { authenticateRequest } from '../../../_lib/auth.js'
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'PATCH') return res.status(405).json({ error: 'Method not allowed' })
+  try { await authenticateRequest(req) } catch (err: any) {
+    return res.status(err.statusCode ?? 401).json({ error: err.message ?? 'Unauthorized' })
+  }
+  const id = req.query.id as string
+  const body = (req.body ?? {}) as {
+    rows?: Array<{ key: string; source: 'current' | 'optimized' | 'skip' | null }>
+  }
+  if (!Array.isArray(body.rows)) return res.status(400).json({ error: 'rows array required' })
+  const db = createAdminClient()
+
+  const { data: row } = await db
+    .from('schedule_assessments')
+    .select('hybrid_overrides')
+    .eq('id', id)
+    .maybeSingle()
+  if (!row) return res.status(404).json({ error: 'Assessment not found' })
+
+  const next = { ...((row as any).hybrid_overrides ?? {}) } as Record<string, { source: string }>
+  const VALID = new Set(['current', 'optimized', 'skip'])
+  for (const r of body.rows) {
+    if (!r.key) continue
+    if (r.source == null) {
+      delete next[r.key]
+    } else if (VALID.has(r.source)) {
+      next[r.key] = { source: r.source }
+    }
+  }
+  const { error } = await db
+    .from('schedule_assessments')
+    .update({ hybrid_overrides: next, updated_at: new Date().toISOString() })
+    .eq('id', id)
+  if (error) return res.status(500).json({ error: error.message })
+
+  return res.status(200).json({ hybrid_overrides: next })
+}

--- a/src/pages/accounts/scheduler/ScheduleAssessmentDetail.tsx
+++ b/src/pages/accounts/scheduler/ScheduleAssessmentDetail.tsx
@@ -46,6 +46,28 @@ interface SLOption {
   property: { address_line1: string | null } | null
 }
 
+type DiffStatus = 'only_current' | 'only_optimized' | 'moved_date' | 'matched_same'
+interface DiffRow {
+  status: DiffStatus
+  service_location_id: string | null
+  display_name: string | null
+  current_date: string | null
+  current_crew: string | null
+  optimized_date: string | null
+  optimized_crew: string | null
+  hybrid_choice?: 'current' | 'optimized' | 'skip' | null
+}
+interface DiffPayload {
+  cycle: { id: string; start_date: string; end_date: string }
+  counts: { only_current: number; only_optimized: number; moved_date: number; matched_same: number }
+  diff: DiffRow[]
+}
+interface TemplateOption {
+  id: string
+  name: string
+  status: string
+}
+
 const STATUS_VARIANT: Record<string, 'outline' | 'accent' | 'success' | 'warning' | 'danger'> = {
   auto: 'success',
   manual: 'success',
@@ -67,6 +89,10 @@ export default function ScheduleAssessmentDetailPage() {
   const [uploadName, setUploadName] = useState('')
   const [uploadCycleLabel, setUploadCycleLabel] = useState('')
   const [slOptions, setSlOptions] = useState<SLOption[]>([])
+  const [templates, setTemplates] = useState<TemplateOption[]>([])
+  const [diff, setDiff] = useState<DiffPayload | null>(null)
+  const [diffLoading, setDiffLoading] = useState(false)
+  const [diffFilter, setDiffFilter] = useState<DiffStatus | 'all_actionable'>('all_actionable')
 
   const load = useCallback(async () => {
     if (!id) return
@@ -89,6 +115,89 @@ export default function ScheduleAssessmentDetailPage() {
   }, [id, getToken])
 
   useEffect(() => { load() }, [load])
+
+  // Load this client's available templates so the user can pick a
+  // baseline. Combined-aware via the existing GET endpoint.
+  useEffect(() => {
+    if (!accountId || !clientId) return
+    let cancelled = false
+    ;(async () => {
+      try {
+        const token = await getToken()
+        const res = await fetch(
+          `/api/scheduler/templates?account_id=${accountId}&client_id=${clientId}`,
+          { headers: { Authorization: `Bearer ${token}` } }
+        )
+        if (res.ok) {
+          const j = await res.json()
+          if (!cancelled) setTemplates((j.templates ?? []).filter((t: any) => t.status !== 'archived'))
+        }
+      } catch {
+        // non-fatal
+      }
+    })()
+    return () => { cancelled = true }
+  }, [accountId, clientId, getToken])
+
+  async function setBaselineTemplate(templateId: string | null) {
+    if (!id) return
+    const token = await getToken()
+    await fetch(`/api/v1/schedule-assessments/${id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+      body: JSON.stringify({ baseline_template_id: templateId }),
+    })
+    setAssessment((prev) => (prev ? { ...prev, baseline_template_id: templateId } : prev))
+    setDiff(null) // stale
+  }
+
+  async function loadDiff() {
+    if (!id) return
+    setDiffLoading(true)
+    setError(null)
+    try {
+      const token = await getToken()
+      const res = await fetch(`/api/v1/schedule-assessments/${id}/diff`, {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      const j = await res.json()
+      if (!res.ok) throw new Error(j.error ?? `Diff failed (${res.status})`)
+      setDiff(j as DiffPayload)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setDiffLoading(false)
+    }
+  }
+
+  async function setHybridChoice(slId: string | null, indexAtSl: number, source: 'current' | 'optimized' | 'skip' | null) {
+    if (!id || !slId) return
+    const key = `${slId}|${indexAtSl}`
+    try {
+      const token = await getToken()
+      await fetch(`/api/v1/schedule-assessments/${id}/hybrid`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        body: JSON.stringify({ rows: [{ key, source }] }),
+      })
+      // Optimistically patch the diff in state.
+      setDiff((prev) => {
+        if (!prev) return prev
+        const next = { ...prev, diff: prev.diff.map((r) => r) }
+        // Update each matching row by sl_id + position. Simple linear.
+        let seen = 0
+        next.diff = next.diff.map((r) => {
+          if (r.service_location_id !== slId) return r
+          const isMatch = seen === indexAtSl
+          seen++
+          return isMatch ? { ...r, hybrid_choice: source } : r
+        })
+        return next
+      })
+    } catch {
+      // ignore
+    }
+  }
 
   // Lazy-load SL options for the manual-match dropdowns when the
   // operator opens the review tray.
@@ -374,15 +483,83 @@ export default function ScheduleAssessmentDetailPage() {
           </Card>
         )}
 
-        {/* Placeholder for next-PR work */}
-        <Card>
-          <CardTitle>Next steps (PR2 / PR3)</CardTitle>
-          <p className="text-sm text-fg-muted mt-2">
-            Once your matches are resolved, the next iteration ships the
-            optimized baseline + diff dashboard (PR2) and constraint
-            detection (PR3). For now, the upload + match flow is live.
+        {/* Step 3: Baseline picker — required before diff */}
+        <Card className="space-y-3">
+          <CardTitle>Baseline routing template</CardTitle>
+          <p className="text-sm text-fg-muted">
+            Pick a routing template to compare against. The diff uses that
+            template's most recent generated cycle as the "optimized" side.
           </p>
+          <div className="flex items-center gap-2 flex-wrap">
+            <select
+              value={assessment.baseline_template_id ?? ''}
+              onChange={(e) => setBaselineTemplate(e.target.value || null)}
+              className="h-9 rounded-md border border-border bg-surface px-3 text-sm text-fg max-w-md"
+            >
+              <option value="">— pick template —</option>
+              {templates.map((t) => (
+                <option key={t.id} value={t.id}>
+                  {t.name} ({t.status})
+                </option>
+              ))}
+            </select>
+            <Button
+              onClick={loadDiff}
+              disabled={!assessment.baseline_template_id || diffLoading}
+              loading={diffLoading}
+            >
+              Compare against optimized
+            </Button>
+          </div>
         </Card>
+
+        {/* Step 4: Diff dashboard */}
+        {diff && (
+          <Card padding="none" className="overflow-hidden">
+            <div className="px-4 py-3 border-b border-border space-y-2">
+              <CardTitle>Current vs optimized</CardTitle>
+              <p className="text-xs text-fg-muted">
+                Optimized cycle: {diff.cycle.start_date} → {diff.cycle.end_date}
+              </p>
+              <div className="flex flex-wrap gap-2">
+                <FilterChip
+                  label={`All actionable (${diff.counts.only_current + diff.counts.only_optimized + diff.counts.moved_date})`}
+                  active={diffFilter === 'all_actionable'}
+                  onClick={() => setDiffFilter('all_actionable')}
+                />
+                <FilterChip
+                  label={`Only on current (${diff.counts.only_current})`}
+                  active={diffFilter === 'only_current'}
+                  onClick={() => setDiffFilter('only_current')}
+                />
+                <FilterChip
+                  label={`Only on optimized (${diff.counts.only_optimized})`}
+                  active={diffFilter === 'only_optimized'}
+                  onClick={() => setDiffFilter('only_optimized')}
+                />
+                <FilterChip
+                  label={`Moved date (${diff.counts.moved_date})`}
+                  active={diffFilter === 'moved_date'}
+                  onClick={() => setDiffFilter('moved_date')}
+                />
+                <FilterChip
+                  label={`Same (${diff.counts.matched_same})`}
+                  active={diffFilter === 'matched_same'}
+                  onClick={() => setDiffFilter('matched_same')}
+                />
+              </div>
+            </div>
+            <DiffTable
+              rows={(() => {
+                if (diffFilter === 'all_actionable') {
+                  return diff.diff.filter((r) => r.status !== 'matched_same')
+                }
+                return diff.diff.filter((r) => r.status === diffFilter)
+              })()}
+              onChoice={setHybridChoice}
+            />
+          </Card>
+        )}
       </div>
     </AppShell>
   )
@@ -396,6 +573,123 @@ function Stat({ label, value, icon }: { label: string; value: number; icon?: Rea
         {label}
       </p>
       <p className="font-mono text-lg font-semibold text-fg tabular-nums">{value}</p>
+    </div>
+  )
+}
+
+function FilterChip({
+  label,
+  active,
+  onClick,
+}: {
+  label: string
+  active: boolean
+  onClick: () => void
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={
+        'rounded-md border px-2 py-0.5 text-[11px] transition-colors ' +
+        (active
+          ? 'border-accent bg-accent/10 text-accent'
+          : 'border-border bg-surface text-fg-muted hover:text-fg')
+      }
+    >
+      {label}
+    </button>
+  )
+}
+
+const STATUS_BADGE: Record<DiffStatus, { label: string; variant: 'outline' | 'accent' | 'success' | 'warning' | 'danger' }> = {
+  only_current: { label: 'Only current', variant: 'danger' },
+  only_optimized: { label: 'Only optimized', variant: 'accent' },
+  moved_date: { label: 'Moved', variant: 'warning' },
+  matched_same: { label: 'Same', variant: 'success' },
+}
+
+function DiffTable({
+  rows,
+  onChoice,
+}: {
+  rows: DiffRow[]
+  onChoice: (slId: string | null, indexAtSl: number, source: 'current' | 'optimized' | 'skip' | null) => void
+}) {
+  // Track per-(sl_id) running index so the click handler can identify
+  // which slot a row represents (multiple visits per SL are paired by
+  // chronological position in the diff endpoint).
+  const slCounts = new Map<string, number>()
+  return (
+    <div className="max-h-[600px] overflow-y-auto">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Status</TableHead>
+            <TableHead>Property</TableHead>
+            <TableHead>Current</TableHead>
+            <TableHead>Optimized</TableHead>
+            <TableHead>Choice</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {rows.length === 0 ? (
+            <TableRow>
+              <TableCell colSpan={5} className="text-fg-subtle text-xs italic">
+                Nothing in this category.
+              </TableCell>
+            </TableRow>
+          ) : (
+            rows.map((r, i) => {
+              const slKey = r.service_location_id ?? `_unmatched_${i}`
+              const idxAtSl = slCounts.get(slKey) ?? 0
+              slCounts.set(slKey, idxAtSl + 1)
+              const meta = STATUS_BADGE[r.status]
+              return (
+                <TableRow key={`${slKey}-${idxAtSl}`}>
+                  <TableCell>
+                    <Badge variant={meta.variant} className="text-[10px]">
+                      {meta.label}
+                    </Badge>
+                  </TableCell>
+                  <TableCell className="text-xs max-w-xs truncate">{r.display_name ?? '—'}</TableCell>
+                  <TableCell className="text-xs font-tabular">
+                    {r.current_date ?? '—'}
+                    {r.current_crew && (
+                      <p className="text-[10px] text-fg-subtle">{r.current_crew}</p>
+                    )}
+                  </TableCell>
+                  <TableCell className="text-xs font-tabular">
+                    {r.optimized_date ?? '—'}
+                    {r.optimized_crew && (
+                      <p className="text-[10px] text-fg-subtle">{r.optimized_crew}</p>
+                    )}
+                  </TableCell>
+                  <TableCell>
+                    <select
+                      value={r.hybrid_choice ?? ''}
+                      onChange={(e) => {
+                        const v = e.target.value
+                        onChoice(
+                          r.service_location_id,
+                          idxAtSl,
+                          v === '' ? null : (v as 'current' | 'optimized' | 'skip')
+                        )
+                      }}
+                      className="h-7 rounded-md border border-border bg-surface px-2 text-xs"
+                    >
+                      <option value="">—</option>
+                      {r.current_date && <option value="current">Keep current</option>}
+                      {r.optimized_date && <option value="optimized">Use optimized</option>}
+                      <option value="skip">Skip</option>
+                    </select>
+                  </TableCell>
+                </TableRow>
+              )
+            })
+          )}
+        </TableBody>
+      </Table>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
Second of three PRs. Adds the comparison + iteration layer: pick a baseline routing template, compare your uploaded schedule against its most recent cycle, and per-row decide \"keep current\" / \"use optimized\" / \"skip.\"

## Backend
\`GET /api/v1/schedule-assessments/[id]/diff\`
- No inline engine run — the linked template's most recent cycle IS the optimized view.
- Pages \`scheduled_visits\` + \`crew_day_routes\` for the cycle.
- Joins to matched assessment rows, categorizes:
  - \`only_current\` — uploaded but optimizer doesn't visit
  - \`only_optimized\` — optimizer adds vs upload
  - \`moved_date\` — same SL, different date
  - \`matched_same\` — already aligned

\`PATCH /api/v1/schedule-assessments/[id]/hybrid\`
- Operator's per-row choice persists to \`hybrid_overrides\` jsonb keyed \`<sl_id>|<idx>\`.
- PR3 \"Save as template\" reads this map.

## Frontend
- **Baseline picker** — select from this client's templates (combined-aware).
- **Compare button** — fires diff fetch.
- **Diff dashboard** — filter chips for each bucket + count, table with status badge / property / current vs optimized date+crew / per-row choice select.
- Choices update optimistically.

## Test plan
- [ ] Upload a CSV (PR1 flow) → matched
- [ ] Pick a routing template that has a generated cycle → \"Compare against optimized\"
- [ ] See counts populate, filter chips work
- [ ] Per-row choices save (refresh and they persist)

## Up next (PR3)
- \"Save hybrid as routing template\" — turns the operator's accumulated picks into a real template.
- Constraint detection from upload patterns (cross-property + per-property when 2+ files uploaded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)