### PR TITLE
Schedule Assessment PR3 — save as template + constraint detection

### DIFF
--- a/api/_lib/schedule-assessment/detect-constraints.ts
+++ b/api/_lib/schedule-assessment/detect-constraints.ts
@@ -1,0 +1,245 @@
+// Detect implicit constraints in uploaded schedule data.
+//
+// v1 detectors:
+//
+//   dow_avoidance        — across ALL visits, if a day-of-week has 0
+//                          occurrences while others are populated and
+//                          there are enough total visits to be
+//                          confident, suggest "Never on {DOW}".
+//
+//   workday_cap          — observed maximum buildings/day per crew.
+//                          Surfaces as a baseline for the engine's
+//                          pairing_max_buildings_per_day setting.
+//
+//   crew_branch_affinity — if a crew_name's visits cluster geographically
+//                          (low spatial spread), suggest a home-branch
+//                          assignment for that crew.
+//
+//   pair_recurring       — two SLs that appear on the same date
+//                          repeatedly. Even with N=2 visits per SL per
+//                          cycle, "twice in a row, same date" is a
+//                          signal.
+//
+//   dow_per_property     — single property always on the same DOW.
+//                          Requires 2+ files (multi-cycle uploads) to
+//                          have any confidence; surfaces as informational
+//                          on a single file.
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+export type DetectionType =
+  | 'dow_avoidance'
+  | 'workday_cap'
+  | 'crew_branch_affinity'
+  | 'pair_recurring'
+  | 'dow_per_property'
+
+export interface DetectedConstraint {
+  detection_type: DetectionType
+  scope_type: 'global' | 'crew' | 'property' | 'pair'
+  scope_ids: string[] // sl_ids when scope_type=property|pair, empty otherwise
+  pattern: Record<string, unknown> // detection-specific payload
+  confidence: number // 0..1
+}
+
+interface DetectInput {
+  assessment_id: string
+  // Flag to indicate whether we have multiple historical cycles
+  // (file count). Per-property detection is only meaningful with N>=2.
+  file_count: number
+}
+
+const DOW_NAMES = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
+
+export async function detectConstraints(
+  db: SupabaseClient,
+  input: DetectInput
+): Promise<DetectedConstraint[]> {
+  // Pull all matched rows with joined property coords (for branch
+  // affinity).
+  const PAGE = 1000
+  const rows: any[] = []
+  for (let p = 0; p < 50; p++) {
+    const { data } = await db
+      .from('schedule_assessment_rows')
+      .select('id, matched_service_location_id, raw_scheduled_date, raw_crew_name, file_id, service_locations(property:properties(latitude, longitude))')
+      .eq('assessment_id', input.assessment_id)
+      .in('match_status', ['auto', 'manual'])
+      .not('matched_service_location_id', 'is', null)
+      .not('raw_scheduled_date', 'is', null)
+      .range(p * PAGE, p * PAGE + PAGE - 1)
+    const batch = data ?? []
+    rows.push(...batch)
+    if (batch.length < PAGE) break
+  }
+  if (rows.length === 0) return []
+
+  const out: DetectedConstraint[] = []
+
+  // ── 1. DOW avoidance ───────────────────────────────────────────
+  const dowCounts = [0, 0, 0, 0, 0, 0, 0]
+  for (const r of rows) {
+    if (!r.raw_scheduled_date) continue
+    const d = new Date(`${r.raw_scheduled_date}T00:00:00Z`)
+    if (isNaN(d.getTime())) continue
+    dowCounts[d.getUTCDay()]++
+  }
+  const totalDated = dowCounts.reduce((s, n) => s + n, 0)
+  if (totalDated >= 20) {
+    for (let dow = 0; dow < 7; dow++) {
+      if (dowCounts[dow] === 0) {
+        // Higher confidence the more total visits we have.
+        const confidence = Math.min(0.95, 0.6 + (totalDated - 20) / 200)
+        out.push({
+          detection_type: 'dow_avoidance',
+          scope_type: 'global',
+          scope_ids: [],
+          pattern: {
+            day_of_week: dow,
+            day_of_week_name: DOW_NAMES[dow],
+            sample_size: totalDated,
+          },
+          confidence: Math.round(confidence * 100) / 100,
+        })
+      }
+    }
+  }
+
+  // ── 2. Workday cap ─────────────────────────────────────────────
+  // Count visits per (crew_name, date). Take the 95th percentile.
+  const visitsByCrewDate = new Map<string, number>()
+  for (const r of rows) {
+    if (!r.raw_crew_name || !r.raw_scheduled_date) continue
+    const k = `${r.raw_crew_name}|${r.raw_scheduled_date}`
+    visitsByCrewDate.set(k, (visitsByCrewDate.get(k) ?? 0) + 1)
+  }
+  if (visitsByCrewDate.size >= 10) {
+    const sorted = Array.from(visitsByCrewDate.values()).sort((a, b) => a - b)
+    const p95 = sorted[Math.min(sorted.length - 1, Math.floor(sorted.length * 0.95))]
+    const max = sorted[sorted.length - 1]
+    out.push({
+      detection_type: 'workday_cap',
+      scope_type: 'global',
+      scope_ids: [],
+      pattern: {
+        observed_max: max,
+        p95: p95,
+        sample_size: sorted.length,
+      },
+      confidence: Math.min(0.9, 0.5 + sorted.length / 200),
+    })
+  }
+
+  // ── 3. Crew → branch affinity (geographic centroid + spread) ────
+  const byCrewName = new Map<string, Array<{ lat: number; lng: number }>>()
+  for (const r of rows) {
+    const crew = (r.raw_crew_name ?? '').trim()
+    if (!crew) continue
+    const lat = r.service_locations?.property?.latitude
+    const lng = r.service_locations?.property?.longitude
+    if (typeof lat !== 'number' || typeof lng !== 'number') continue
+    const arr = byCrewName.get(crew) ?? []
+    arr.push({ lat, lng })
+    byCrewName.set(crew, arr)
+  }
+  for (const [crewName, coords] of byCrewName.entries()) {
+    if (coords.length < 5) continue
+    const centroid = {
+      lat: coords.reduce((s, c) => s + c.lat, 0) / coords.length,
+      lng: coords.reduce((s, c) => s + c.lng, 0) / coords.length,
+    }
+    const spreads = coords.map((c) => {
+      const dy = (c.lat - centroid.lat) * 69
+      const dx = (c.lng - centroid.lng) * 54.6
+      return Math.sqrt(dx * dx + dy * dy)
+    })
+    const meanSpread = spreads.reduce((s, n) => s + n, 0) / spreads.length
+    // If a crew's visits cluster within ~50mi of a centroid, that's a
+    // strong home-branch signal.
+    if (meanSpread < 50) {
+      out.push({
+        detection_type: 'crew_branch_affinity',
+        scope_type: 'crew',
+        scope_ids: [],
+        pattern: {
+          crew_name: crewName,
+          centroid_lat: Math.round(centroid.lat * 1000) / 1000,
+          centroid_lng: Math.round(centroid.lng * 1000) / 1000,
+          mean_spread_miles: Math.round(meanSpread * 10) / 10,
+          sample_size: coords.length,
+        },
+        confidence: Math.max(0.5, Math.min(0.95, 1 - meanSpread / 100)),
+      })
+    }
+  }
+
+  // ── 4. Recurring pairs (two SLs on the same date repeatedly) ────
+  // Build (date → sl_ids set), then pair counts.
+  const slsByDate = new Map<string, string[]>()
+  for (const r of rows) {
+    if (!r.raw_scheduled_date) continue
+    const arr = slsByDate.get(r.raw_scheduled_date) ?? []
+    arr.push(r.matched_service_location_id)
+    slsByDate.set(r.raw_scheduled_date, arr)
+  }
+  const pairCounts = new Map<string, number>()
+  for (const sls of slsByDate.values()) {
+    const unique = Array.from(new Set(sls))
+    if (unique.length < 2) continue
+    for (let i = 0; i < unique.length; i++) {
+      for (let j = i + 1; j < unique.length; j++) {
+        const k = unique[i] < unique[j] ? `${unique[i]}|${unique[j]}` : `${unique[j]}|${unique[i]}`
+        pairCounts.set(k, (pairCounts.get(k) ?? 0) + 1)
+      }
+    }
+  }
+  // Pairs that recur more than once are worth surfacing.
+  for (const [k, count] of pairCounts) {
+    if (count < 2) continue
+    const [a, b] = k.split('|')
+    out.push({
+      detection_type: 'pair_recurring',
+      scope_type: 'pair',
+      scope_ids: [a, b],
+      pattern: { same_date_occurrences: count },
+      confidence: count >= 3 ? 0.85 : 0.65,
+    })
+  }
+
+  // ── 5. Per-property DOW preference (multi-file only) ────────────
+  if (input.file_count >= 2) {
+    const dowsBySl = new Map<string, number[]>()
+    for (const r of rows) {
+      if (!r.raw_scheduled_date) continue
+      const d = new Date(`${r.raw_scheduled_date}T00:00:00Z`)
+      if (isNaN(d.getTime())) continue
+      const arr = dowsBySl.get(r.matched_service_location_id) ?? []
+      arr.push(d.getUTCDay())
+      dowsBySl.set(r.matched_service_location_id, arr)
+    }
+    for (const [slId, dows] of dowsBySl) {
+      if (dows.length < 2) continue
+      const counts = [0, 0, 0, 0, 0, 0, 0]
+      for (const d of dows) counts[d]++
+      const max = Math.max(...counts)
+      if (max < 2) continue
+      const dominant = counts.indexOf(max)
+      const ratio = max / dows.length
+      if (ratio >= 0.8) {
+        out.push({
+          detection_type: 'dow_per_property',
+          scope_type: 'property',
+          scope_ids: [slId],
+          pattern: {
+            day_of_week: dominant,
+            day_of_week_name: DOW_NAMES[dominant],
+            occurrences: max,
+            total_visits: dows.length,
+          },
+          confidence: Math.min(0.9, 0.5 + dows.length * 0.1),
+        })
+      }
+    }
+  }
+
+  return out
+}

--- a/api/v1/schedule-assessments/[id]/detect.ts
+++ b/api/v1/schedule-assessments/[id]/detect.ts
@@ -1,0 +1,98 @@
+// POST /api/v1/schedule-assessments/[id]/detect
+//   Runs the constraint detector against this assessment's matched
+//   rows. Persists findings to schedule_assessment_constraints with
+//   status='detected'. Replaces any existing 'detected' rows but
+//   preserves operator-accepted/rejected/edited choices.
+//
+// GET  /api/v1/schedule-assessments/[id]/detect
+//   Returns the latest set of detection findings (sorted highest
+//   confidence first).
+//
+// PATCH /api/v1/schedule-assessments/[id]/detect
+//   Body: { id, status: 'accepted'|'rejected'|'edited' }. Operator
+//   decision per finding.
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { createAdminClient } from '../../../_lib/supabase.js'
+import { authenticateRequest } from '../../../_lib/auth.js'
+import { detectConstraints } from '../../../_lib/schedule-assessment/detect-constraints.js'
+
+export const config = { maxDuration: 60 }
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  try { await authenticateRequest(req) } catch (err: any) {
+    return res.status(err.statusCode ?? 401).json({ error: err.message ?? 'Unauthorized' })
+  }
+  const id = req.query.id as string
+  const db = createAdminClient()
+
+  if (req.method === 'GET') {
+    const { data, error } = await db
+      .from('schedule_assessment_constraints')
+      .select('*')
+      .eq('assessment_id', id)
+      .order('confidence', { ascending: false })
+    if (error) return res.status(500).json({ error: error.message })
+    return res.status(200).json({ constraints: data ?? [] })
+  }
+
+  if (req.method === 'POST') {
+    const { count: fileCount } = await db
+      .from('schedule_assessment_files')
+      .select('id', { count: 'exact', head: true })
+      .eq('assessment_id', id)
+
+    // Run detection.
+    const findings = await detectConstraints(db, {
+      assessment_id: id,
+      file_count: fileCount ?? 1,
+    })
+
+    // Replace existing 'detected' rows with the fresh set; preserve
+    // any rows the operator has already accepted/rejected/edited.
+    await db
+      .from('schedule_assessment_constraints')
+      .delete()
+      .eq('assessment_id', id)
+      .eq('status', 'detected')
+
+    if (findings.length > 0) {
+      const insertRows = findings.map((f) => ({
+        assessment_id: id,
+        detection_type: f.detection_type,
+        scope_type: f.scope_type,
+        scope_ids: f.scope_ids,
+        pattern: f.pattern,
+        confidence: f.confidence,
+        status: 'detected' as const,
+      }))
+      const { error } = await db
+        .from('schedule_assessment_constraints')
+        .insert(insertRows)
+      if (error) return res.status(500).json({ error: error.message })
+    }
+
+    const { data: all } = await db
+      .from('schedule_assessment_constraints')
+      .select('*')
+      .eq('assessment_id', id)
+      .order('confidence', { ascending: false })
+
+    return res.status(200).json({ constraints: all ?? [], detected_count: findings.length })
+  }
+
+  if (req.method === 'PATCH') {
+    const body = (req.body ?? {}) as { id?: string; status?: string }
+    if (!body.id || !body.status) return res.status(400).json({ error: 'id + status required' })
+    const VALID = new Set(['detected', 'accepted', 'rejected', 'edited'])
+    if (!VALID.has(body.status)) return res.status(400).json({ error: 'invalid status' })
+    const { error } = await db
+      .from('schedule_assessment_constraints')
+      .update({ status: body.status, updated_at: new Date().toISOString() })
+      .eq('assessment_id', id)
+      .eq('id', body.id)
+    if (error) return res.status(500).json({ error: error.message })
+    return res.status(200).json({ ok: true })
+  }
+
+  return res.status(405).json({ error: 'Method not allowed' })
+}

--- a/api/v1/schedule-assessments/[id]/save-as-template.ts
+++ b/api/v1/schedule-assessments/[id]/save-as-template.ts
@@ -1,0 +1,167 @@
+// POST /api/v1/schedule-assessments/[id]/save-as-template
+//
+// Promotes the operator's hybrid choices into a real routing_template.
+// Body: { name, regenerate?: boolean }.
+//
+// What gets included:
+//   - SLs whose operator choice is 'current' or 'optimized' (or unset
+//     — default behavior is "include")
+//   - SLs whose choice is 'skip' are excluded from routed_service_location_ids
+//
+// Other settings (branches, crew_count, cycle config, etc.) copy from
+// the baseline template. The new template lives alongside the baseline
+// and the user can iterate from there via the normal template UI.
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { createAdminClient } from '../../../_lib/supabase.js'
+import { authenticateRequest, type AuthContext } from '../../../_lib/auth.js'
+
+export const config = { maxDuration: 300 }
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'POST') return res.status(405).json({ error: 'Method not allowed' })
+  let ctx: AuthContext
+  try { ctx = await authenticateRequest(req) } catch (err: any) {
+    return res.status(err.statusCode ?? 401).json({ error: err.message ?? 'Unauthorized' })
+  }
+  const id = req.query.id as string
+  const body = (req.body ?? {}) as { name?: string; regenerate?: boolean }
+  const name = (body.name ?? '').trim()
+  if (!name) return res.status(400).json({ error: 'name required' })
+  const db = createAdminClient()
+
+  const { data: assessment } = await db
+    .from('schedule_assessments')
+    .select('*')
+    .eq('id', id)
+    .maybeSingle()
+  if (!assessment) return res.status(404).json({ error: 'Assessment not found' })
+  const a = assessment as any
+  if (!a.baseline_template_id) {
+    return res.status(400).json({ error: 'No baseline_template_id — pick a template first.' })
+  }
+
+  // Fetch baseline template to copy branches / crew_count / config.
+  const { data: baseline } = await db
+    .from('routing_templates')
+    .select('*')
+    .eq('id', a.baseline_template_id)
+    .maybeSingle()
+  if (!baseline) return res.status(404).json({ error: 'Baseline template not found' })
+  const b = baseline as any
+
+  // Collect SLs to include. Skip rows where operator chose 'skip'.
+  const overrides = (a.hybrid_overrides ?? {}) as Record<string, { source?: string }>
+  const PAGE = 1000
+  const matched: any[] = []
+  for (let p = 0; p < 50; p++) {
+    const { data } = await db
+      .from('schedule_assessment_rows')
+      .select('id, matched_service_location_id, match_status')
+      .eq('assessment_id', id)
+      .in('match_status', ['auto', 'manual'])
+      .not('matched_service_location_id', 'is', null)
+      .range(p * PAGE, p * PAGE + PAGE - 1)
+    const arr = data ?? []
+    matched.push(...arr)
+    if (arr.length < PAGE) break
+  }
+  // Build per-SL skip set: if any of the operator's choices for this
+  // SL are 'skip' AND none are 'current'/'optimized', the SL is dropped
+  // from the new template.
+  const slIndexCounter = new Map<string, number>()
+  const skipBySl = new Map<string, boolean>()
+  for (const r of matched) {
+    const sl = r.matched_service_location_id as string
+    const idx = slIndexCounter.get(sl) ?? 0
+    slIndexCounter.set(sl, idx + 1)
+    const choice = overrides[`${sl}|${idx}`]?.source
+    if (choice === 'skip') {
+      // Mark unless we've already seen a non-skip choice for this SL.
+      if (!skipBySl.has(sl)) skipBySl.set(sl, true)
+    } else if (choice === 'current' || choice === 'optimized') {
+      skipBySl.set(sl, false)
+    }
+  }
+  // Also include SLs from the baseline template that aren't in the
+  // assessment at all — those are "only_optimized" and unless the
+  // operator explicitly skipped them via the diff (which we don't
+  // track separately), they belong in the new template.
+  const baselineSls = (b.routed_service_location_ids ?? []) as string[]
+  const finalSls = new Set<string>()
+  for (const slId of baselineSls) {
+    // Default include — operator can iterate on the new template.
+    if (skipBySl.get(slId) !== true) finalSls.add(slId)
+  }
+  for (const sl of slIndexCounter.keys()) {
+    if (skipBySl.get(sl) !== true) finalSls.add(sl)
+  }
+  if (finalSls.size === 0) {
+    return res.status(400).json({ error: 'No SLs to include — every row was skipped.' })
+  }
+
+  // Insert new template row, copying branches + crew_count + config
+  // from the baseline. Status starts at 'optimizing'; if regenerate is
+  // requested, we kick off the regenerate API to actually run the
+  // engine.
+  const { data: newTpl, error: insertErr } = await db
+    .from('routing_templates')
+    .insert({
+      account_id: b.account_id,
+      client_id: b.client_id,
+      name,
+      description: `Hybrid from assessment "${a.name}" (${a.id.slice(0, 8)})`,
+      routed_service_location_ids: Array.from(finalSls),
+      crew_count: b.crew_count,
+      branches: b.branches,
+      combined_client_ids: b.combined_client_ids ?? null,
+      config: b.config ?? null,
+      planning_mode: b.planning_mode ?? 'auto',
+      cycle_length_days: b.cycle_length_days ?? 0,
+      cycle_length_label: b.cycle_length_label ?? 'pending',
+      is_custom_cycle_length: b.is_custom_cycle_length ?? false,
+      status: 'pending',
+      created_by: ctx.email ?? ctx.userId ?? null,
+    })
+    .select('id')
+    .single()
+  if (insertErr || !newTpl) {
+    return res.status(500).json({ error: `template insert: ${insertErr?.message ?? 'unknown'}` })
+  }
+  const newTplId = (newTpl as any).id
+
+  // Update the assessment with the new template id + finalize status.
+  await db
+    .from('schedule_assessments')
+    .update({
+      status: 'finalized',
+      updated_at: new Date().toISOString(),
+    })
+    .eq('id', id)
+
+  // Optional: regenerate immediately so the user sees the engine's
+  // output for the new template.
+  if (body.regenerate) {
+    const baseUrl = `${req.headers['x-forwarded-proto'] ?? 'https'}://${req.headers.host}`
+    const auth = req.headers.authorization ?? ''
+    const r = await fetch(
+      `${baseUrl}/api/scheduler/templates/${newTplId}/regenerate`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: auth },
+        body: JSON.stringify({}),
+      }
+    )
+    if (!r.ok) {
+      // Non-fatal — the template is created; user can manually trigger
+      // regenerate from the template detail page.
+      // eslint-disable-next-line no-console
+      console.warn(`auto-regenerate failed: HTTP ${r.status}`)
+    }
+  }
+
+  return res.status(201).json({
+    template_id: newTplId,
+    sl_count: finalSls.size,
+    skipped_count: Array.from(skipBySl.entries()).filter(([, v]) => v).length,
+  })
+}

--- a/src/pages/accounts/scheduler/ScheduleAssessmentDetail.tsx
+++ b/src/pages/accounts/scheduler/ScheduleAssessmentDetail.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useMemo } from 'react'
-import { useParams } from 'react-router-dom'
+import { useParams, Link } from 'react-router-dom'
 import { Upload, AlertCircle, CheckCircle2 } from 'lucide-react'
 import { useAuth } from '../../../hooks/useAuth'
 import AppShell from '../../../components/layout/AppShell'
@@ -68,6 +68,16 @@ interface TemplateOption {
   status: string
 }
 
+interface DetectedConstraint {
+  id: string
+  detection_type: string
+  scope_type: string
+  scope_ids: string[] | null
+  pattern: Record<string, any>
+  confidence: number
+  status: 'detected' | 'accepted' | 'rejected' | 'edited'
+}
+
 const STATUS_VARIANT: Record<string, 'outline' | 'accent' | 'success' | 'warning' | 'danger'> = {
   auto: 'success',
   manual: 'success',
@@ -93,6 +103,11 @@ export default function ScheduleAssessmentDetailPage() {
   const [diff, setDiff] = useState<DiffPayload | null>(null)
   const [diffLoading, setDiffLoading] = useState(false)
   const [diffFilter, setDiffFilter] = useState<DiffStatus | 'all_actionable'>('all_actionable')
+  const [detections, setDetections] = useState<DetectedConstraint[]>([])
+  const [detecting, setDetecting] = useState(false)
+  const [savingTpl, setSavingTpl] = useState(false)
+  const [saveTplName, setSaveTplName] = useState('')
+  const [savedTplId, setSavedTplId] = useState<string | null>(null)
 
   const load = useCallback(async () => {
     if (!id) return
@@ -167,6 +182,81 @@ export default function ScheduleAssessmentDetailPage() {
       setError(err instanceof Error ? err.message : String(err))
     } finally {
       setDiffLoading(false)
+    }
+  }
+
+  async function loadDetections() {
+    if (!id) return
+    try {
+      const token = await getToken()
+      const res = await fetch(`/api/v1/schedule-assessments/${id}/detect`, {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      if (res.ok) {
+        const j = await res.json()
+        setDetections(j.constraints ?? [])
+      }
+    } catch {
+      // non-fatal
+    }
+  }
+
+  useEffect(() => { loadDetections() }, [id]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  async function runDetection() {
+    if (!id) return
+    setDetecting(true)
+    setError(null)
+    try {
+      const token = await getToken()
+      const res = await fetch(`/api/v1/schedule-assessments/${id}/detect`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      const j = await res.json()
+      if (!res.ok) throw new Error(j.error ?? `Detection failed (${res.status})`)
+      setDetections(j.constraints ?? [])
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setDetecting(false)
+    }
+  }
+
+  async function setDetectionStatus(detId: string, status: 'accepted' | 'rejected') {
+    if (!id) return
+    try {
+      const token = await getToken()
+      await fetch(`/api/v1/schedule-assessments/${id}/detect`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        body: JSON.stringify({ id: detId, status }),
+      })
+      setDetections((prev) => prev.map((d) => (d.id === detId ? { ...d, status } : d)))
+    } catch {
+      // ignore
+    }
+  }
+
+  async function saveAsTemplate() {
+    if (!id || !saveTplName.trim()) return
+    setSavingTpl(true)
+    setError(null)
+    try {
+      const token = await getToken()
+      const res = await fetch(`/api/v1/schedule-assessments/${id}/save-as-template`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        body: JSON.stringify({ name: saveTplName.trim(), regenerate: true }),
+      })
+      const j = await res.json()
+      if (!res.ok) throw new Error(j.error ?? `Save failed (${res.status})`)
+      setSavedTplId(j.template_id)
+      await load() // refresh status
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setSavingTpl(false)
     }
   }
 
@@ -560,9 +650,135 @@ export default function ScheduleAssessmentDetailPage() {
             />
           </Card>
         )}
+
+        {/* Step 5: Detected constraints */}
+        <Card className="space-y-3">
+          <div className="flex items-center justify-between gap-2 flex-wrap">
+            <CardTitle>Detected constraints</CardTitle>
+            <Button size="sm" variant="secondary" onClick={runDetection} loading={detecting}>
+              {detections.length === 0 ? 'Detect constraints' : 'Re-detect'}
+            </Button>
+          </div>
+          <p className="text-sm text-fg-muted">
+            Patterns the upload reveals — day-of-week avoidance, recurring
+            pairs, crew/branch geographic affinity. Per-property patterns
+            require 2+ files for confidence (a single 6-month or annual
+            cycle has too few samples).
+          </p>
+          {detections.length > 0 ? (
+            <ul className="space-y-2">
+              {detections.map((d) => (
+                <li
+                  key={d.id}
+                  className={
+                    'rounded-md border p-3 text-sm flex items-start justify-between gap-3 ' +
+                    (d.status === 'accepted'
+                      ? 'border-success/40 bg-success-subtle/30'
+                      : d.status === 'rejected'
+                        ? 'border-fg-subtle/30 bg-surface-subtle/40 opacity-60'
+                        : 'border-border bg-surface')
+                  }
+                >
+                  <div className="space-y-1 min-w-0">
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <Badge variant="accent" className="text-[10px]">
+                        {d.detection_type}
+                      </Badge>
+                      <Badge variant="outline" className="text-[10px]">
+                        confidence {Math.round(d.confidence * 100)}%
+                      </Badge>
+                      <Badge variant={d.status === 'accepted' ? 'success' : 'outline'} className="text-[10px]">
+                        {d.status}
+                      </Badge>
+                    </div>
+                    <p className="text-fg">{describeDetection(d)}</p>
+                  </div>
+                  {d.status !== 'accepted' && d.status !== 'rejected' && (
+                    <div className="flex gap-1 shrink-0">
+                      <Button size="sm" variant="ghost" onClick={() => setDetectionStatus(d.id, 'rejected')}>
+                        Reject
+                      </Button>
+                      <Button size="sm" onClick={() => setDetectionStatus(d.id, 'accepted')}>
+                        Accept
+                      </Button>
+                    </div>
+                  )}
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-xs text-fg-subtle italic">
+              No detections yet. Click "Detect constraints" once your matches
+              are resolved.
+            </p>
+          )}
+        </Card>
+
+        {/* Step 6: Save as template */}
+        {assessment.baseline_template_id && (
+          <Card className="space-y-3">
+            <CardTitle>Save hybrid as routing template</CardTitle>
+            <p className="text-sm text-fg-muted">
+              Promotes your accumulated diff choices into a new routing template
+              alongside the baseline. Skipped rows are excluded; the new template
+              regenerates immediately so you can see the engine's output for
+              the hybrid set.
+            </p>
+            {savedTplId ? (
+              <div className="rounded-md border border-success/40 bg-success-subtle/30 p-3">
+                <p className="text-sm text-fg">
+                  Saved as a new template.{' '}
+                  <Link
+                    to={`/accounts/${accountId}/clients/${clientId}/scheduler/templates/${savedTplId}`}
+                    className="text-accent hover:underline"
+                  >
+                    Open it →
+                  </Link>
+                </p>
+              </div>
+            ) : (
+              <div className="flex items-end gap-2 flex-wrap">
+                <FormField label="Template name" htmlFor="hybrid-name">
+                  <Input
+                    id="hybrid-name"
+                    value={saveTplName}
+                    onChange={(e) => setSaveTplName(e.target.value)}
+                    placeholder='e.g. "Hybrid 2025 — JLL"'
+                    className="min-w-[20rem]"
+                  />
+                </FormField>
+                <Button
+                  onClick={saveAsTemplate}
+                  loading={savingTpl}
+                  disabled={!saveTplName.trim()}
+                >
+                  Save & regenerate
+                </Button>
+              </div>
+            )}
+          </Card>
+        )}
       </div>
     </AppShell>
   )
+}
+
+function describeDetection(d: DetectedConstraint): string {
+  const p = d.pattern || {}
+  switch (d.detection_type) {
+    case 'dow_avoidance':
+      return `Schedule never uses ${p.day_of_week_name ?? 'this DOW'} (${p.sample_size ?? '?'} total visits sampled).`
+    case 'workday_cap':
+      return `Observed max ${p.observed_max ?? '?'} buildings/crew/day (95th percentile ${p.p95 ?? '?'}, sample ${p.sample_size ?? '?'}).`
+    case 'crew_branch_affinity':
+      return `${p.crew_name ?? 'Crew'} clusters within ${p.mean_spread_miles ?? '?'} mi of (${p.centroid_lat}, ${p.centroid_lng}) — looks home-based here.`
+    case 'pair_recurring':
+      return `Two properties scheduled together ${p.same_date_occurrences ?? '?'} times — possible co-location pairing.`
+    case 'dow_per_property':
+      return `Property always on ${p.day_of_week_name ?? '?'} (${p.occurrences ?? '?'} of ${p.total_visits ?? '?'} visits).`
+    default:
+      return JSON.stringify(p)
+  }
 }
 
 function Stat({ label, value, icon }: { label: string; value: number; icon?: React.ReactNode }) {


### PR DESCRIPTION
## Summary
Closes out the Schedule Assessment feature. Two layers on top of PR1 (upload/match) and PR2 (diff dashboard).

## Save hybrid as routing template
\`POST /api/v1/schedule-assessments/[id]/save-as-template\`
- New routing_template alongside the baseline. Routed-SL list = (baseline ∪ matched assessment SLs) minus any SL the operator marked \`skip\` in the diff.
- Branches, crew_count, config copy from baseline.
- \`regenerate: true\` triggers an immediate template build so the engine output is visible.
- Assessment status moves to \`finalized\`.

## Constraint detection
New lib \`detect-constraints.ts\` with five detectors:
- **dow_avoidance** — global day-of-week never used (e.g. \"Never on Fridays\")
- **workday_cap** — observed max + 95th percentile buildings/crew/day
- **crew_branch_affinity** — crew_name geographic clustering, suggests home branch
- **pair_recurring** — two SLs co-scheduled across multiple dates
- **dow_per_property** — single property always on the same DOW (multi-file only, single-cycle data has too few samples)

\`/detect\` GET / POST / PATCH endpoints. Persists findings; replaces prior \`detected\` rows on re-run; preserves operator's accept/reject choices.

## Frontend
- **Detected constraints card** with Detect button. Per-finding plain-English summary, confidence badge, Accept / Reject.
- **Save hybrid as routing template card** under the diff dashboard. Name input + Save & regenerate. After save, surfaces a deep link to the new template.

## Intentionally out of scope
Auto-applying accepted detections to \`service_location_constraints\` / \`scheduling_preferences\`. Detections are advisory in this PR; surface the analysis first, write through later once the signal proves reliable on real data. The operator gets the insight; the constraint write is a separate, later \"promote\" step.

## Test plan
- [ ] Upload a CSV (PR1), match rows, pick a baseline template (PR2), set diff choices
- [ ] Click \"Detect constraints\" → findings card populates
- [ ] Accept a few, reject a few → status persists
- [ ] Enter template name → \"Save & regenerate\" → new template appears, link works, regenerate runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)