### PR TITLE
Schedule Assessment: CSV parser handles multi-visit-date columns

### DIFF
--- a/api/_lib/schedule-assessment/parse-csv.ts
+++ b/api/_lib/schedule-assessment/parse-csv.ts
@@ -21,24 +21,66 @@ export interface ParseResult {
   errors: ParseError[]
 }
 
-const ALIASES: Record<string, 'address' | 'date' | 'crew'> = {
-  address: 'address',
-  property: 'address',
-  property_address: 'address',
-  location: 'address',
-  site: 'address',
-  scheduled_date: 'date',
-  date: 'date',
-  visit_date: 'date',
-  service_date: 'date',
-  crew_name: 'crew',
-  crew: 'crew',
-  team: 'crew',
+// Headers that always mean "address."
+const ADDRESS_ALIASES = new Set([
+  'address',
+  'property',
+  'property_address',
+  'location',
+  'site',
+])
+// Headers that always mean "crew."
+const CREW_ALIASES = new Set(['crew_name', 'crew', 'team'])
+
+// Single-visit date headers.
+const SINGLE_DATE_ALIASES = new Set([
+  'scheduled_date',
+  'date',
+  'visit_date',
+  'service_date',
+])
+
+// Multi-visit date column patterns. Each property row may have N
+// separate date columns (first_visit_date, second_visit_date,
+// visit_1_date, visit_2, etc.). When detected, the parser emits
+// ONE row per non-empty date column instead of one row per CSV
+// line. This is how 2-visits-per-cycle schedules show up.
+const ORDINAL_WORDS: Record<string, number> = {
+  first: 1,
+  second: 2,
+  third: 3,
+  fourth: 4,
+  fifth: 5,
+  sixth: 6,
 }
 
-function normalizeHeader(h: string): 'address' | 'date' | 'crew' | null {
+interface HeaderInfo {
+  semantic: 'address' | 'date' | 'crew' | null
+  visit_index: number | null // 1-based; null for single-date headers
+  raw: string
+}
+
+function normalizeHeader(h: string): HeaderInfo {
+  const raw = h
   const k = h.trim().toLowerCase().replace(/\s+/g, '_').replace(/[^a-z0-9_]/g, '')
-  return ALIASES[k] ?? null
+  if (ADDRESS_ALIASES.has(k)) return { semantic: 'address', visit_index: null, raw }
+  if (CREW_ALIASES.has(k)) return { semantic: 'crew', visit_index: null, raw }
+  if (SINGLE_DATE_ALIASES.has(k)) return { semantic: 'date', visit_index: null, raw }
+  // Multi-visit pattern: "first_visit_date", "visit_1_date", "1st_visit",
+  // "visit2", "second_date", etc.
+  // Try ordinal-word + date: "first_visit_date" → visit 1
+  for (const [word, idx] of Object.entries(ORDINAL_WORDS)) {
+    if (k.startsWith(word) && (k.includes('visit') || k.includes('date'))) {
+      return { semantic: 'date', visit_index: idx, raw }
+    }
+  }
+  // Try numeric pattern: "visit_1_date", "visit_2", "1st_visit_date",
+  // "date_1", "second_visit_date" already covered above.
+  const num = k.match(/(?:^|_)(\d+)(?:st|nd|rd|th)?(?:_|$)/)?.[1]
+  if (num && (k.includes('visit') || k.includes('date'))) {
+    return { semantic: 'date', visit_index: parseInt(num, 10), raw }
+  }
+  return { semantic: null, visit_index: null, raw }
 }
 
 function parseDate(s: string): string | null {
@@ -81,58 +123,68 @@ export function parseScheduleCsv(csv: string): ParseResult {
       errors.push({ line: (e.row ?? 0) + 2, reason: e.message })
     }
   }
-  // Build a column-name map (raw header → semantic).
+  // Classify every column.
   const fields = result.meta.fields ?? []
-  const colMap = new Map<string, 'address' | 'date' | 'crew'>()
-  for (const f of fields) {
-    const sem = normalizeHeader(f)
-    if (sem) colMap.set(f, sem)
-  }
-  // Require at least address + date columns.
-  const hasAddress = Array.from(colMap.values()).includes('address')
-  const hasDate = Array.from(colMap.values()).includes('date')
-  if (!hasAddress || !hasDate) {
+  const headers = fields.map((f) => normalizeHeader(f))
+
+  // Single-date columns and per-visit-index date columns.
+  const addressCols = headers.filter((h) => h.semantic === 'address').map((h) => h.raw)
+  const crewCols = headers.filter((h) => h.semantic === 'crew').map((h) => h.raw)
+  const dateCols = headers.filter((h) => h.semantic === 'date')
+  // Sort numbered visit dates by visit_index so visit 1 comes before
+  // visit 2 in the output.
+  const orderedDateCols = [...dateCols].sort((a, b) => {
+    const ai = a.visit_index ?? 0
+    const bi = b.visit_index ?? 0
+    if (ai !== bi) return ai - bi
+    return 0
+  })
+
+  if (addressCols.length === 0 || orderedDateCols.length === 0) {
     return {
       rows: [],
       errors: [
         {
           line: 1,
           reason:
-            'CSV must include an "address" column and a "scheduled_date" column. ' +
+            'CSV must include an "address" column and at least one "scheduled_date" / "first_visit_date" / "second_visit_date" column. ' +
             `Got: ${fields.join(', ')}`,
         },
       ],
     }
   }
+
   for (let i = 0; i < (result.data ?? []).length; i++) {
     const row = result.data[i] as Record<string, string>
-    let address = ''
-    let dateStr = ''
-    let crew = ''
-    for (const [col, sem] of colMap) {
-      const v = (row[col] ?? '').toString().trim()
-      if (sem === 'address' && !address) address = v
-      else if (sem === 'date' && !dateStr) dateStr = v
-      else if (sem === 'crew' && !crew) crew = v
-    }
+    const address = addressCols.map((c) => (row[c] ?? '').toString().trim()).find(Boolean) ?? ''
+    const crew = crewCols.map((c) => (row[c] ?? '').toString().trim()).find(Boolean) ?? ''
     if (!address) {
       errors.push({ line: i + 2, reason: 'missing address' })
       continue
     }
-    if (!dateStr) {
-      errors.push({ line: i + 2, reason: 'missing scheduled_date' })
-      continue
+    // Emit one ParsedRow per non-empty date column.
+    let emittedAny = false
+    for (const dateCol of orderedDateCols) {
+      const raw = (row[dateCol.raw] ?? '').toString().trim()
+      if (!raw) continue
+      const parsed = parseDate(raw)
+      if (!parsed) {
+        errors.push({
+          line: i + 2,
+          reason: `unparseable date in "${dateCol.raw}": "${raw}"`,
+        })
+        continue
+      }
+      rows.push({
+        raw_address: address,
+        raw_scheduled_date: parsed,
+        raw_crew_name: crew || null,
+      })
+      emittedAny = true
     }
-    const parsed = parseDate(dateStr)
-    if (!parsed) {
-      errors.push({ line: i + 2, reason: `unparseable date: "${dateStr}"` })
-      continue
+    if (!emittedAny) {
+      errors.push({ line: i + 2, reason: 'no scheduled date columns populated' })
     }
-    rows.push({
-      raw_address: address,
-      raw_scheduled_date: parsed,
-      raw_crew_name: crew || null,
-    })
   }
   return { rows, errors }
 }

--- a/src/pages/accounts/scheduler/ScheduleAssessmentDetail.tsx
+++ b/src/pages/accounts/scheduler/ScheduleAssessmentDetail.tsx
@@ -409,8 +409,12 @@ export default function ScheduleAssessmentDetailPage() {
         <Card className="space-y-3">
           <CardTitle>Upload schedule files</CardTitle>
           <p className="text-sm text-fg-muted">
-            CSV with columns <code>address</code>, <code>scheduled_date</code>, optional <code>crew_name</code>.
-            Upload one file per historical cycle to enable per-property pattern detection (PR3).
+            CSV with columns <code>address</code>, plus one or more visit-date
+            columns (<code>scheduled_date</code>, or <code>first_visit_date</code> /{' '}
+            <code>second_visit_date</code> / etc. for multi-visit-per-cycle
+            schedules). Optional <code>crew_name</code>. Each non-empty date
+            column emits its own row, so a property with both first + second
+            visit dates becomes two rows automatically.
           </p>
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
             <FormField label="Cycle label (optional)">


### PR DESCRIPTION
## Why
Real-world schedule spreadsheets often put each visit in its own column — \"first visit date,\" \"second visit date,\" etc. — instead of one row per visit. The previous parser required a single date column.

## Behavior
Header classifier now recognizes:
- Single-date headers as before
- **Ordinal words**: \`first_visit_date\`, \`second_visit_date\`, \`third_visit_date\`, …
- **Numeric patterns**: \`visit_1_date\`, \`visit_2\`, \`1st_visit_date\`, \`date_2\`

Each non-empty date column emits its own row with the same address + crew. Empty cells are silently skipped (a property may be visited once or twice in a cycle). Columns are sorted by visit index so visit 1 appears before visit 2 in the output.

## Test
Verified against:
\`\`\`
address,first visit date,second visit date,crew
123 Main St,3/15/2025,9/12/2025,Tempe Crew 1
456 Oak Ave,4/2/2025,10/8/2025,Tempe Crew 2
789 Elm,2025-05-10,,Phoenix Crew 1
\`\`\`
→ produces 5 rows (2+2+1), correctly skipping the empty second-visit cell on the third property.

🤖 Generated with [Claude Code](https://claude.com/claude-code)