### PR TITLE
Explicit column-mapping wizard for schedule-assessment uploads

### DIFF
--- a/api/_lib/schedule-assessment/parse-csv.ts
+++ b/api/_lib/schedule-assessment/parse-csv.ts
@@ -19,6 +19,25 @@ export interface ParseError {
 export interface ParseResult {
   rows: ParsedRow[]
   errors: ParseError[]
+  // Echoed for debugging / UI display.
+  resolved_mapping?: ResolvedMapping
+}
+
+// Operator-supplied explicit mapping. When passed, overrides the
+// header auto-classifier entirely. Each mapping field references a
+// raw column header from the CSV.
+export interface ColumnMapping {
+  address?: string
+  // Visit-date columns in order (each emits one row per non-empty cell).
+  // [first_visit_col, second_visit_col, ...] or [single_date_col].
+  date_columns?: string[]
+  crew?: string | null
+}
+
+export interface ResolvedMapping {
+  address: string
+  date_columns: string[]
+  crew: string | null
 }
 
 // Substrings that, when found in a normalized header, mark it as an
@@ -145,7 +164,7 @@ function parseDate(s: string): string | null {
   return null
 }
 
-export function parseScheduleCsv(csv: string): ParseResult {
+export function parseScheduleCsv(csv: string, mapping?: ColumnMapping): ParseResult {
   const result = Papa.parse<Record<string, string>>(csv, {
     header: true,
     skipEmptyLines: 'greedy',
@@ -157,26 +176,40 @@ export function parseScheduleCsv(csv: string): ParseResult {
       errors.push({ line: (e.row ?? 0) + 2, reason: e.message })
     }
   }
-  // Classify every column.
   const fields = result.meta.fields ?? []
-  const headers = fields.map((f) => normalizeHeader(f))
 
-  // Single-date columns and per-visit-index date columns.
-  const addressCols = headers.filter((h) => h.semantic === 'address').map((h) => h.raw)
-  const crewCols = headers.filter((h) => h.semantic === 'crew').map((h) => h.raw)
-  const dateCols = headers.filter((h) => h.semantic === 'date')
-  // Sort numbered visit dates by visit_index so visit 1 comes before
-  // visit 2 in the output.
-  const orderedDateCols = [...dateCols].sort((a, b) => {
-    const ai = a.visit_index ?? 0
-    const bi = b.visit_index ?? 0
-    if (ai !== bi) return ai - bi
-    return 0
-  })
+  // Resolve mapping. Explicit mapping (operator-provided) takes
+  // precedence. Otherwise auto-detect via the header classifier.
+  let resolvedAddress: string | null = null
+  let resolvedDateCols: string[] = []
+  let resolvedCrew: string | null = null
+  if (mapping) {
+    if (mapping.address && fields.includes(mapping.address)) {
+      resolvedAddress = mapping.address
+    }
+    if (Array.isArray(mapping.date_columns)) {
+      resolvedDateCols = mapping.date_columns.filter((c) => fields.includes(c))
+    }
+    if (mapping.crew && fields.includes(mapping.crew)) {
+      resolvedCrew = mapping.crew
+    }
+  }
+  if (!resolvedAddress || resolvedDateCols.length === 0) {
+    const headers = fields.map((f) => normalizeHeader(f))
+    const addressCols = headers.filter((h) => h.semantic === 'address').map((h) => h.raw)
+    const crewCols = headers.filter((h) => h.semantic === 'crew').map((h) => h.raw)
+    const dateCols = headers.filter((h) => h.semantic === 'date')
+    // Sort numbered visit dates by visit_index so visit 1 < visit 2.
+    const orderedDateCols = [...dateCols]
+      .sort((a, b) => (a.visit_index ?? 0) - (b.visit_index ?? 0))
+      .map((h) => h.raw)
+    if (!resolvedAddress) resolvedAddress = addressCols[0] ?? null
+    if (resolvedDateCols.length === 0) resolvedDateCols = orderedDateCols
+    if (!resolvedCrew) resolvedCrew = crewCols[0] ?? null
+  }
 
-  if (addressCols.length === 0 || orderedDateCols.length === 0) {
-    // Build a per-header diagnostic so the operator can see what we
-    // classified each column as (and why it didn't match).
+  if (!resolvedAddress || resolvedDateCols.length === 0) {
+    const headers = fields.map((f) => normalizeHeader(f))
     const classified = headers
       .map(
         (h) =>
@@ -191,11 +224,14 @@ export function parseScheduleCsv(csv: string): ParseResult {
           reason:
             'CSV must include an "address"-like column AND at least one date column ' +
             '(scheduled_date, first_visit_date, second_visit_date, etc.). ' +
-            `Headers seen: ${classified}.`,
+            `Headers seen: ${classified}. Tip: pass an explicit column_mapping to skip auto-detection.`,
         },
       ],
     }
   }
+  const orderedDateCols: Array<{ raw: string }> = resolvedDateCols.map((raw) => ({ raw }))
+  const addressCols = [resolvedAddress]
+  const crewCols = resolvedCrew ? [resolvedCrew] : []
 
   for (let i = 0; i < (result.data ?? []).length; i++) {
     const row = result.data[i] as Record<string, string>
@@ -229,5 +265,44 @@ export function parseScheduleCsv(csv: string): ParseResult {
       errors.push({ line: i + 2, reason: 'no scheduled date columns populated' })
     }
   }
-  return { rows, errors }
+  return {
+    rows,
+    errors,
+    resolved_mapping: {
+      address: resolvedAddress,
+      date_columns: resolvedDateCols,
+      crew: resolvedCrew,
+    },
+  }
+}
+
+// Lightweight header preview — used by the upload wizard to populate
+// the column-mapping dropdowns without parsing every row first.
+export function previewCsvHeaders(csv: string, sampleRows = 5): {
+  headers: string[]
+  sample: Array<Record<string, string>>
+  auto_mapping: ResolvedMapping
+} {
+  const result = Papa.parse<Record<string, string>>(csv, {
+    header: true,
+    skipEmptyLines: 'greedy',
+    preview: sampleRows + 1,
+  })
+  const fields = result.meta.fields ?? []
+  const headers = fields.map((f) => normalizeHeader(f))
+  const addressCol = headers.find((h) => h.semantic === 'address')?.raw ?? ''
+  const dateCols = headers
+    .filter((h) => h.semantic === 'date')
+    .sort((a, b) => (a.visit_index ?? 0) - (b.visit_index ?? 0))
+    .map((h) => h.raw)
+  const crewCol = headers.find((h) => h.semantic === 'crew')?.raw ?? null
+  return {
+    headers: fields,
+    sample: (result.data ?? []).slice(0, sampleRows) as Array<Record<string, string>>,
+    auto_mapping: {
+      address: addressCol,
+      date_columns: dateCols,
+      crew: crewCol,
+    },
+  }
 }

--- a/api/v1/schedule-assessments/[id]/upload.ts
+++ b/api/v1/schedule-assessments/[id]/upload.ts
@@ -25,7 +25,16 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     return res.status(err.statusCode ?? 401).json({ error: err.message ?? 'Unauthorized' })
   }
   const assessmentId = req.query.id as string
-  const body = (req.body ?? {}) as { filename?: string; cycle_label?: string; csv?: string }
+  const body = (req.body ?? {}) as {
+    filename?: string
+    cycle_label?: string
+    csv?: string
+    column_mapping?: {
+      address?: string
+      date_columns?: string[]
+      crew?: string | null
+    }
+  }
   if (!body.csv) return res.status(400).json({ error: 'csv required' })
   const filename = (body.filename ?? 'upload.csv').trim() || 'upload.csv'
   const cycleLabel = body.cycle_label ?? null
@@ -39,8 +48,10 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (!assessment) return res.status(404).json({ error: 'Assessment not found' })
   const clientId = (assessment as any).client_id as string
 
-  // Parse CSV.
-  const { rows, errors } = parseScheduleCsv(body.csv)
+  // Parse CSV. Operator may pass an explicit column_mapping to
+  // bypass the heuristic header classifier — the wizard uses this
+  // after the user confirms columns in the preview step.
+  const { rows, errors } = parseScheduleCsv(body.csv, body.column_mapping)
   if (rows.length === 0) {
     // Surface the FULL parse-error detail in the response so the UI
     // can show the operator exactly which column was misclassified.

--- a/src/pages/accounts/scheduler/ScheduleAssessmentDetail.tsx
+++ b/src/pages/accounts/scheduler/ScheduleAssessmentDetail.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useMemo } from 'react'
 import { useParams, Link } from 'react-router-dom'
 import { Upload, AlertCircle, CheckCircle2 } from 'lucide-react'
 import * as XLSX from 'xlsx'
+import Papa from 'papaparse'
 import { useAuth } from '../../../hooks/useAuth'
 import AppShell from '../../../components/layout/AppShell'
 import Button from '../../../components/ui/Button'
@@ -97,6 +98,14 @@ export default function ScheduleAssessmentDetailPage() {
   const [error, setError] = useState<string | null>(null)
   const [uploading, setUploading] = useState(false)
   const [uploadCsv, setUploadCsv] = useState('')
+  // Column-mapping preview state. After file selection, we parse just
+  // the headers + a few sample rows in the browser, show a mapping
+  // table the operator can adjust, then submit on confirm.
+  const [csvHeaders, setCsvHeaders] = useState<string[]>([])
+  const [csvSample, setCsvSample] = useState<Array<Record<string, string>>>([])
+  const [mapAddress, setMapAddress] = useState<string>('')
+  const [mapDates, setMapDates] = useState<string[]>([])
+  const [mapCrew, setMapCrew] = useState<string>('')
   const [uploadName, setUploadName] = useState('')
   const [uploadCycleLabel, setUploadCycleLabel] = useState('')
   const [slOptions, setSlOptions] = useState<SLOption[]>([])
@@ -308,39 +317,92 @@ export default function ScheduleAssessmentDetailPage() {
     }
   }, [clientId, slOptions.length, getToken])
 
+  function autoClassify(header: string): 'address' | 'date' | 'crew' | null {
+    const k = header
+      .replace(/^﻿/, '')
+      .trim()
+      .toLowerCase()
+      .replace(/\s+/g, '_')
+      .replace(/[^a-z0-9_]/g, '')
+    if (!k) return null
+    if (
+      ['address', 'property', 'building', 'location'].some((s) => k.includes(s)) ||
+      k.includes('site_name') || k.includes('site_address') || k === 'site'
+    ) return 'address'
+    if (['date', 'visit', 'scheduled', 'service'].some((s) => k.includes(s))) return 'date'
+    if (['crew', 'team', 'tech', 'worker'].some((s) => k.includes(s))) return 'crew'
+    return null
+  }
+
+  function visitIndexFromHeader(header: string): number {
+    const k = header.trim().toLowerCase().replace(/\s+/g, '_').replace(/[^a-z0-9_]/g, '')
+    const ords: Record<string, number> = { first: 1, second: 2, third: 3, fourth: 4, fifth: 5 }
+    for (const [w, i] of Object.entries(ords)) if (k.startsWith(w)) return i
+    const num = k.match(/(?:^|_)(\d+)(?:st|nd|rd|th)?(?:_|$)/)?.[1]
+    return num ? parseInt(num, 10) : 0
+  }
+
   async function handleFileUpload(file: File) {
     if (!id) return
     setError(null)
+    setCsvHeaders([])
+    setCsvSample([])
+    setMapAddress('')
+    setMapDates([])
+    setMapCrew('')
+
+    let csv = ''
     const lower = file.name.toLowerCase()
     if (lower.endsWith('.xlsx') || lower.endsWith('.xls')) {
-      // Parse xlsx in the browser, convert the first sheet to CSV,
-      // and feed the existing CSV pipeline. xlsx is already a
-      // dependency for the upload-review flow elsewhere in the app.
       try {
         const buf = await file.arrayBuffer()
         const wb = XLSX.read(buf, { type: 'array' })
         const sheetName = wb.SheetNames[0]
         if (!sheetName) throw new Error('Workbook has no sheets.')
         const sheet = wb.Sheets[sheetName]
-        // raw: false formats values (dates as strings); we still re-parse
-        // dates server-side for normalization. blankrows: false drops
-        // empty rows the spreadsheet may have at the bottom.
-        const csv = XLSX.utils.sheet_to_csv(sheet, { blankrows: false })
-        setUploadCsv(csv)
-        setUploadName(file.name)
+        csv = XLSX.utils.sheet_to_csv(sheet, { blankrows: false })
       } catch (e) {
         setError(e instanceof Error ? `xlsx parse failed: ${e.message}` : String(e))
+        return
       }
-      return
+    } else {
+      csv = await file.text()
     }
-    // CSV: read as text directly.
-    const text = await file.text()
-    setUploadCsv(text)
+    setUploadCsv(csv)
     setUploadName(file.name)
+
+    // Parse just the headers + a few sample rows for the mapping wizard.
+    const parsed = Papa.parse<Record<string, string>>(csv, {
+      header: true,
+      skipEmptyLines: 'greedy',
+      preview: 6,
+    })
+    const headers = parsed.meta.fields ?? []
+    setCsvHeaders(headers)
+    setCsvSample(((parsed.data ?? []) as Record<string, string>[]).slice(0, 5))
+
+    // Pre-fill mapping via the same heuristics the server uses, so the
+    // common case is one click. The user can override anything.
+    const addressGuess = headers.find((h) => autoClassify(h) === 'address') ?? ''
+    const crewGuess = headers.find((h) => autoClassify(h) === 'crew') ?? ''
+    const dateGuesses = headers
+      .filter((h) => autoClassify(h) === 'date')
+      .sort((a, b) => visitIndexFromHeader(a) - visitIndexFromHeader(b))
+    setMapAddress(addressGuess)
+    setMapCrew(crewGuess)
+    setMapDates(dateGuesses)
   }
 
   async function submitUpload() {
     if (!uploadCsv || !id) return
+    if (!mapAddress) {
+      setError('Pick an Address column before uploading.')
+      return
+    }
+    if (mapDates.length === 0) {
+      setError('Pick at least one Visit-date column before uploading.')
+      return
+    }
     setUploading(true)
     setError(null)
     try {
@@ -352,6 +414,11 @@ export default function ScheduleAssessmentDetailPage() {
           filename: uploadName || 'upload.csv',
           cycle_label: uploadCycleLabel || null,
           csv: uploadCsv,
+          column_mapping: {
+            address: mapAddress,
+            date_columns: mapDates,
+            crew: mapCrew || null,
+          },
         }),
       })
       const j = await res.json()
@@ -359,6 +426,11 @@ export default function ScheduleAssessmentDetailPage() {
       setUploadCsv('')
       setUploadName('')
       setUploadCycleLabel('')
+      setCsvHeaders([])
+      setCsvSample([])
+      setMapAddress('')
+      setMapDates([])
+      setMapCrew('')
       await load()
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err))
@@ -462,17 +534,132 @@ export default function ScheduleAssessmentDetailPage() {
               />
             </FormField>
           </div>
-          {uploadCsv && (
-            <FormField label="Preview (first 200 chars)">
-              <Textarea
-                rows={3}
-                readOnly
-                value={uploadCsv.slice(0, 200) + (uploadCsv.length > 200 ? '…' : '')}
-              />
-            </FormField>
+          {csvHeaders.length > 0 && (
+            <div className="space-y-3 rounded-md border border-border bg-surface-subtle/40 p-3">
+              <p className="text-[10px] uppercase tracking-wide text-fg-subtle">
+                Map columns
+              </p>
+              <p className="text-xs text-fg-muted">
+                Auto-detected best guesses below. Adjust any that are wrong,
+                add additional visit-date columns if your spreadsheet has
+                them, then click Upload.
+              </p>
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                <FormField label="Address column *">
+                  <select
+                    value={mapAddress}
+                    onChange={(e) => setMapAddress(e.target.value)}
+                    className="h-9 w-full rounded-md border border-border bg-surface px-2 text-sm"
+                  >
+                    <option value="">— pick column —</option>
+                    {csvHeaders.map((h) => (
+                      <option key={h} value={h}>{h}</option>
+                    ))}
+                  </select>
+                </FormField>
+                <FormField label="Crew column (optional)">
+                  <select
+                    value={mapCrew}
+                    onChange={(e) => setMapCrew(e.target.value)}
+                    className="h-9 w-full rounded-md border border-border bg-surface px-2 text-sm"
+                  >
+                    <option value="">— none —</option>
+                    {csvHeaders.map((h) => (
+                      <option key={h} value={h}>{h}</option>
+                    ))}
+                  </select>
+                </FormField>
+              </div>
+              <div>
+                <p className="text-xs font-medium text-fg mb-1.5">Visit-date columns *</p>
+                <p className="text-[11px] text-fg-subtle mb-2">
+                  Each non-empty cell in these columns becomes one visit row.
+                  Order matters (visit 1 first, visit 2 second, etc.).
+                </p>
+                <div className="space-y-1.5">
+                  {mapDates.map((col, i) => (
+                    <div key={`${col}-${i}`} className="flex items-center gap-2">
+                      <span className="text-[11px] text-fg-subtle w-12 shrink-0">Visit {i + 1}</span>
+                      <select
+                        value={col}
+                        onChange={(e) => {
+                          const v = e.target.value
+                          setMapDates((prev) => {
+                            if (!v) return prev.filter((_, j) => j !== i)
+                            const next = [...prev]
+                            next[i] = v
+                            return next
+                          })
+                        }}
+                        className="h-8 flex-1 rounded-md border border-border bg-surface px-2 text-xs"
+                      >
+                        <option value="">— remove —</option>
+                        {csvHeaders.map((h) => (
+                          <option key={h} value={h}>{h}</option>
+                        ))}
+                      </select>
+                    </div>
+                  ))}
+                  <div className="flex items-center gap-2">
+                    <span className="text-[11px] text-fg-subtle w-12 shrink-0">Visit {mapDates.length + 1}</span>
+                    <select
+                      value=""
+                      onChange={(e) => {
+                        const v = e.target.value
+                        if (v) setMapDates((prev) => [...prev, v])
+                      }}
+                      className="h-8 flex-1 rounded-md border border-border bg-surface px-2 text-xs"
+                    >
+                      <option value="">— add column —</option>
+                      {csvHeaders
+                        .filter((h) => !mapDates.includes(h))
+                        .map((h) => (
+                          <option key={h} value={h}>{h}</option>
+                        ))}
+                    </select>
+                  </div>
+                </div>
+              </div>
+              {csvSample.length > 0 && (
+                <div className="overflow-x-auto">
+                  <p className="text-[11px] text-fg-subtle mb-1">Sample rows:</p>
+                  <table className="text-[11px] border-collapse">
+                    <thead>
+                      <tr>
+                        {csvHeaders.map((h) => (
+                          <th key={h} className="border border-border px-1.5 py-0.5 bg-surface text-left whitespace-nowrap">
+                            {h}
+                            {h === mapAddress && <span className="ml-1 text-accent">[addr]</span>}
+                            {mapDates.includes(h) && (
+                              <span className="ml-1 text-warning">[v{mapDates.indexOf(h) + 1}]</span>
+                            )}
+                            {h === mapCrew && <span className="ml-1 text-success">[crew]</span>}
+                          </th>
+                        ))}
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {csvSample.map((r, i) => (
+                        <tr key={i}>
+                          {csvHeaders.map((h) => (
+                            <td key={h} className="border border-border px-1.5 py-0.5 text-fg-muted whitespace-nowrap">
+                              {r[h] ?? ''}
+                            </td>
+                          ))}
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </div>
           )}
           <div>
-            <Button onClick={submitUpload} disabled={!uploadCsv || uploading} loading={uploading}>
+            <Button
+              onClick={submitUpload}
+              disabled={!uploadCsv || !mapAddress || mapDates.length === 0 || uploading}
+              loading={uploading}
+            >
               <Upload className="h-4 w-4" />
               Upload
             </Button>


### PR DESCRIPTION
## Why
Auto-detection isn't enough for real-world spreadsheets. Now the operator confirms or overrides the address / visit-date / crew columns before the upload submits.

## Frontend
After file pick (CSV or xlsx), client-side parses headers + first 5 rows. A \"Map columns\" panel appears with:
- **Address column** dropdown (required)
- **Crew column** dropdown (optional)
- **Visit-date columns** — add/remove ordered list. Visit 1 first, visit 2 second. Each non-empty cell in those columns becomes one visit row.
- **Sample rows** table with \`[addr]\` / \`[v1]\` / \`[v2]\` / \`[crew]\` tags above each column header for visual confirmation.

Auto-classifier pre-fills picks via the same heuristics the server uses, so the common case is one click. Operator can override.

## Backend
- \`parseScheduleCsv\` accepts optional \`ColumnMapping\`. When supplied, bypasses heuristic auto-classify entirely.
- Upload endpoint accepts \`column_mapping\` in the body.
- \`previewCsvHeaders()\` helper for the wizard (currently used client-side; available server-side for future use).

## Test plan
- [ ] Upload xlsx with custom headers (e.g. \"Customer Site\", \"Round 1\", \"Round 2\", \"Crew Lead\") → mapping panel appears, dropdowns let you map them, sample rows tag the right columns, upload succeeds
- [ ] Auto-detected headers (Address, Visit 1, Visit 2, Crew) pre-fill correctly — one-click upload still works
- [ ] Required validation: upload disabled when address or all date columns are unselected

🤖 Generated with [Claude Code](https://claude.com/claude-code)