### PR TITLE
Schedule Assessment: delete uploaded file (purges rows)

### DIFF
--- a/api/v1/schedule-assessments/[id]/files/[fileId].ts
+++ b/api/v1/schedule-assessments/[id]/files/[fileId].ts
@@ -1,0 +1,33 @@
+// DELETE /api/v1/schedule-assessments/[id]/files/[fileId]
+//
+// Removes one uploaded file. The schedule_assessment_rows ON DELETE
+// CASCADE FK takes its rows with it. Used by the wizard to wipe a
+// bad upload and start over without recreating the whole assessment.
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { createAdminClient } from '../../../../_lib/supabase.js'
+import { authenticateRequest } from '../../../../_lib/auth.js'
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'DELETE') return res.status(405).json({ error: 'Method not allowed' })
+  try { await authenticateRequest(req) } catch (err: any) {
+    return res.status(err.statusCode ?? 401).json({ error: err.message ?? 'Unauthorized' })
+  }
+  const assessmentId = req.query.id as string
+  const fileId = req.query.fileId as string
+  const db = createAdminClient()
+
+  // Scoped delete — file must belong to the assessment to be removed.
+  const { error } = await db
+    .from('schedule_assessment_files')
+    .delete()
+    .eq('id', fileId)
+    .eq('assessment_id', assessmentId)
+  if (error) return res.status(500).json({ error: error.message })
+
+  await db
+    .from('schedule_assessments')
+    .update({ updated_at: new Date().toISOString() })
+    .eq('id', assessmentId)
+
+  return res.status(204).end()
+}

--- a/src/pages/accounts/scheduler/ScheduleAssessmentDetail.tsx
+++ b/src/pages/accounts/scheduler/ScheduleAssessmentDetail.tsx
@@ -678,6 +678,7 @@ export default function ScheduleAssessmentDetailPage() {
                   <TableHead>Cycle label</TableHead>
                   <TableHead className="text-right">Rows</TableHead>
                   <TableHead>Uploaded</TableHead>
+                  <TableHead />
                 </TableRow>
               </TableHeader>
               <TableBody>
@@ -688,6 +689,31 @@ export default function ScheduleAssessmentDetailPage() {
                     <TableCell numeric>{f.row_count.toLocaleString()}</TableCell>
                     <TableCell className="text-xs text-fg-muted">
                       {new Date(f.uploaded_at).toLocaleString()}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        onClick={async () => {
+                          if (!confirm(`Delete "${f.filename}" and all ${f.row_count} parsed rows?`)) return
+                          try {
+                            const token = await getToken()
+                            const res = await fetch(
+                              `/api/v1/schedule-assessments/${id}/files/${f.id}`,
+                              { method: 'DELETE', headers: { Authorization: `Bearer ${token}` } }
+                            )
+                            if (!res.ok) {
+                              const j = await res.json().catch(() => ({}))
+                              throw new Error(j.error ?? `Delete failed (${res.status})`)
+                            }
+                            await load()
+                          } catch (err) {
+                            setError(err instanceof Error ? err.message : String(err))
+                          }
+                        }}
+                      >
+                        Delete
+                      </Button>
                     </TableCell>
                   </TableRow>
                 ))}


### PR DESCRIPTION
## Summary
Adds a Delete button per uploaded file so the operator can wipe a bad upload and start over without recreating the assessment.

\`DELETE /api/v1/schedule-assessments/[id]/files/[fileId]\` — removes the file row; FK \`ON DELETE CASCADE\` takes its parsed rows with it. Scoped to (assessment_id, file_id).

UI: trailing column on the Uploaded files table with a confirm-before-delete button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)