### PR TITLE
Schedule assessment: inline match candidates + location_code + lower threshold

### DIFF
--- a/api/_lib/schedule-assessment/match-addresses.ts
+++ b/api/_lib/schedule-assessment/match-addresses.ts
@@ -8,8 +8,12 @@
 
 import type { SupabaseClient } from '@supabase/supabase-js'
 
-const AUTO_THRESHOLD = 0.85
-const REVIEW_THRESHOLD = 0.55 // below this we don't even suggest
+const AUTO_THRESHOLD = 0.7 // lowered from 0.85 — abbreviated addresses
+                            // ("123 Main St" vs "123 Main Street, Phoenix")
+                            // routinely scored ~0.7 and got dumped into the
+                            // review tray for no good reason.
+const REVIEW_THRESHOLD = 0.45 // below this we don't bother surfacing as a
+                              // candidate — too noisy.
 
 interface Candidate {
   sl_id: string

--- a/api/_lib/schedule-assessment/parse-csv.ts
+++ b/api/_lib/schedule-assessment/parse-csv.ts
@@ -9,6 +9,7 @@ export interface ParsedRow {
   raw_address: string
   raw_scheduled_date: string | null // ISO YYYY-MM-DD
   raw_crew_name: string | null
+  raw_location_code: string | null
 }
 
 export interface ParseError {
@@ -32,12 +33,18 @@ export interface ColumnMapping {
   // [first_visit_col, second_visit_col, ...] or [single_date_col].
   date_columns?: string[]
   crew?: string | null
+  // Optional location_code column. When present, the matcher uses an
+  // exact lookup against service_locations.location_code BEFORE
+  // fuzzy address matching — exact-match wins are far more reliable
+  // than Jaccard scoring on abbreviated addresses.
+  location_code?: string | null
 }
 
 export interface ResolvedMapping {
   address: string
   date_columns: string[]
   crew: string | null
+  location_code: string | null
 }
 
 // Substrings that, when found in a normalized header, mark it as an
@@ -183,6 +190,7 @@ export function parseScheduleCsv(csv: string, mapping?: ColumnMapping): ParseRes
   let resolvedAddress: string | null = null
   let resolvedDateCols: string[] = []
   let resolvedCrew: string | null = null
+  let resolvedLocationCode: string | null = null
   if (mapping) {
     if (mapping.address && fields.includes(mapping.address)) {
       resolvedAddress = mapping.address
@@ -192,6 +200,9 @@ export function parseScheduleCsv(csv: string, mapping?: ColumnMapping): ParseRes
     }
     if (mapping.crew && fields.includes(mapping.crew)) {
       resolvedCrew = mapping.crew
+    }
+    if (mapping.location_code && fields.includes(mapping.location_code)) {
+      resolvedLocationCode = mapping.location_code
     }
   }
   if (!resolvedAddress || resolvedDateCols.length === 0) {
@@ -237,8 +248,11 @@ export function parseScheduleCsv(csv: string, mapping?: ColumnMapping): ParseRes
     const row = result.data[i] as Record<string, string>
     const address = addressCols.map((c) => (row[c] ?? '').toString().trim()).find(Boolean) ?? ''
     const crew = crewCols.map((c) => (row[c] ?? '').toString().trim()).find(Boolean) ?? ''
-    if (!address) {
-      errors.push({ line: i + 2, reason: 'missing address' })
+    const locationCode = resolvedLocationCode
+      ? (row[resolvedLocationCode] ?? '').toString().trim()
+      : ''
+    if (!address && !locationCode) {
+      errors.push({ line: i + 2, reason: 'missing address (and no location_code)' })
       continue
     }
     // Emit one ParsedRow per non-empty date column.
@@ -258,6 +272,7 @@ export function parseScheduleCsv(csv: string, mapping?: ColumnMapping): ParseRes
         raw_address: address,
         raw_scheduled_date: parsed,
         raw_crew_name: crew || null,
+        raw_location_code: locationCode || null,
       })
       emittedAny = true
     }
@@ -272,6 +287,7 @@ export function parseScheduleCsv(csv: string, mapping?: ColumnMapping): ParseRes
       address: resolvedAddress,
       date_columns: resolvedDateCols,
       crew: resolvedCrew,
+      location_code: resolvedLocationCode,
     },
   }
 }
@@ -303,6 +319,7 @@ export function previewCsvHeaders(csv: string, sampleRows = 5): {
       address: addressCol,
       date_columns: dateCols,
       crew: crewCol,
+      location_code: null,
     },
   }
 }

--- a/api/v1/schedule-assessments/[id]/index.ts
+++ b/api/v1/schedule-assessments/[id]/index.ts
@@ -37,7 +37,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     for (let p = 0; p < 50; p++) {
       const { data: batch } = await db
         .from('schedule_assessment_rows')
-        .select('id, file_id, raw_address, raw_scheduled_date, raw_crew_name, matched_service_location_id, match_confidence, match_status, notes')
+        .select('id, file_id, raw_address, raw_scheduled_date, raw_crew_name, raw_location_code, matched_service_location_id, match_confidence, match_status, match_candidates, notes')
         .eq('assessment_id', id)
         .order('created_at', { ascending: true })
         .range(p * PAGE, p * PAGE + PAGE - 1)

--- a/api/v1/schedule-assessments/[id]/upload.ts
+++ b/api/v1/schedule-assessments/[id]/upload.ts
@@ -33,6 +33,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       address?: string
       date_columns?: string[]
       crew?: string | null
+      location_code?: string | null
     }
   }
   if (!body.csv) return res.status(400).json({ error: 'csv required' })
@@ -82,7 +83,11 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
   // Bulk-insert parsed rows. Chunk to keep payload sizes sane.
   const INSERT_CHUNK = 500
-  const insertedRows: Array<{ id: string; raw_address: string }> = []
+  const insertedRows: Array<{
+    id: string
+    raw_address: string
+    raw_location_code: string | null
+  }> = []
   for (let i = 0; i < rows.length; i += INSERT_CHUNK) {
     const chunk = rows.slice(i, i + INSERT_CHUNK).map((r) => ({
       assessment_id: assessmentId,
@@ -90,44 +95,97 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       raw_address: r.raw_address,
       raw_scheduled_date: r.raw_scheduled_date,
       raw_crew_name: r.raw_crew_name,
+      raw_location_code: r.raw_location_code,
     }))
     const { data: inserted, error: insErr } = await db
       .from('schedule_assessment_rows')
       .insert(chunk)
-      .select('id, raw_address')
+      .select('id, raw_address, raw_location_code')
     if (insErr) {
       return res.status(500).json({ error: `rows insert: ${insErr.message}` })
     }
     if (inserted) insertedRows.push(...(inserted as any[]))
   }
 
-  // Resolve client_ids (combined → members) and run fuzzy matching.
+  // Resolve client_ids (combined → members) for SL lookups.
   const memberIds = await resolveClientIds(db, clientId)
+
+  // Step A — exact location_code matches first (no fuzzy). Build a
+  // code-keyed lookup of this client's SLs.
+  const codeMap = new Map<string, string>()
+  if (insertedRows.some((r) => r.raw_location_code)) {
+    const PAGE = 1000
+    for (let p = 0; p < 50; p++) {
+      const { data } = await db
+        .from('service_locations')
+        .select('id, location_code')
+        .in('client_id', memberIds)
+        .not('location_code', 'is', null)
+        .range(p * PAGE, p * PAGE + PAGE - 1)
+      const arr = data ?? []
+      for (const r of arr as any[]) {
+        if (r.location_code) codeMap.set(String(r.location_code).trim().toLowerCase(), r.id)
+      }
+      if (arr.length < PAGE) break
+    }
+  }
+  const codeMatched = new Map<string, string>() // row_id → sl_id
+  const remainingForFuzzy = insertedRows.filter((r) => {
+    if (!r.raw_location_code) return true
+    const slId = codeMap.get(r.raw_location_code.trim().toLowerCase())
+    if (slId) {
+      codeMatched.set(r.id, slId)
+      return false
+    }
+    return true
+  })
+
+  // Step B — fuzzy match the rest by address.
   const matches = await matchAddresses(
     db,
     memberIds,
-    insertedRows.map((r) => ({ row_id: r.id, raw_address: r.raw_address }))
+    remainingForFuzzy.map((r) => ({ row_id: r.id, raw_address: r.raw_address }))
   )
 
-  // Persist match results. Group updates by status to minimize round-trips.
-  const updates: Array<{ id: string; matched_service_location_id: string | null; match_confidence: number | null; match_status: string }> = []
+  // Persist all results. Each row gets matched_service_location_id +
+  // confidence + status + match_candidates (top 3 SL options for
+  // inline review tray rendering).
+  const updates: Array<{
+    id: string
+    matched_service_location_id: string | null
+    match_confidence: number | null
+    match_status: string
+    match_candidates: any
+  }> = []
+  for (const [rowId, slId] of codeMatched) {
+    updates.push({
+      id: rowId,
+      matched_service_location_id: slId,
+      match_confidence: 1.0,
+      match_status: 'auto',
+      match_candidates: null,
+    })
+  }
   for (const m of matches) {
     updates.push({
       id: m.row_id,
       matched_service_location_id: m.matched_sl_id,
       match_confidence: m.confidence,
-      match_status: m.match_status === 'auto' ? 'auto' : (m.match_status === 'unmatched' ? 'unmatched' : 'pending'),
+      match_status:
+        m.match_status === 'auto'
+          ? 'auto'
+          : m.match_status === 'unmatched'
+            ? 'unmatched'
+            : 'pending',
+      match_candidates: m.candidates,
     })
   }
-  // Batch the row-by-row updates. Supabase doesn't support a single
-  // bulk UPDATE without a CTE; use upsert-by-id which is fine here.
   for (let i = 0; i < updates.length; i += INSERT_CHUNK) {
     const chunk = updates.slice(i, i + INSERT_CHUNK)
     const { error: upErr } = await db
       .from('schedule_assessment_rows')
       .upsert(chunk, { onConflict: 'id' })
     if (upErr) {
-      // Non-fatal — surface but don't fail the whole upload.
       // eslint-disable-next-line no-console
       console.warn(`match update batch failed: ${upErr.message}`)
     }
@@ -143,7 +201,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
   const summary = {
     rows_parsed: rows.length,
-    auto_matched: matches.filter((m) => m.match_status === 'auto').length,
+    auto_matched: codeMatched.size + matches.filter((m) => m.match_status === 'auto').length,
+    code_matched: codeMatched.size,
     review_needed: matches.filter((m) => m.match_status === 'pending').length,
     unmatched: matches.filter((m) => m.match_status === 'unmatched').length,
     parse_errors: errors,

--- a/src/pages/accounts/scheduler/ScheduleAssessmentDetail.tsx
+++ b/src/pages/accounts/scheduler/ScheduleAssessmentDetail.tsx
@@ -30,15 +30,23 @@ interface FileRow {
   uploaded_at: string
 }
 
+interface MatchCandidate {
+  sl_id: string
+  address_line1: string
+  score: number
+}
+
 interface AssessmentRowData {
   id: string
   file_id: string
   raw_address: string
   raw_scheduled_date: string | null
   raw_crew_name: string | null
+  raw_location_code: string | null
   matched_service_location_id: string | null
   match_confidence: number | null
   match_status: string
+  match_candidates: MatchCandidate[] | null
   notes: string | null
 }
 
@@ -106,6 +114,7 @@ export default function ScheduleAssessmentDetailPage() {
   const [mapAddress, setMapAddress] = useState<string>('')
   const [mapDates, setMapDates] = useState<string[]>([])
   const [mapCrew, setMapCrew] = useState<string>('')
+  const [mapLocationCode, setMapLocationCode] = useState<string>('')
   const [uploadName, setUploadName] = useState('')
   const [uploadCycleLabel, setUploadCycleLabel] = useState('')
   const [slOptions, setSlOptions] = useState<SLOption[]>([])
@@ -350,6 +359,7 @@ export default function ScheduleAssessmentDetailPage() {
     setMapAddress('')
     setMapDates([])
     setMapCrew('')
+    setMapLocationCode('')
 
     let csv = ''
     const lower = file.name.toLowerCase()
@@ -418,6 +428,7 @@ export default function ScheduleAssessmentDetailPage() {
             address: mapAddress,
             date_columns: mapDates,
             crew: mapCrew || null,
+            location_code: mapLocationCode || null,
           },
         }),
       })
@@ -431,6 +442,7 @@ export default function ScheduleAssessmentDetailPage() {
       setMapAddress('')
       setMapDates([])
       setMapCrew('')
+      setMapLocationCode('')
       await load()
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err))
@@ -544,7 +556,7 @@ export default function ScheduleAssessmentDetailPage() {
                 add additional visit-date columns if your spreadsheet has
                 them, then click Upload.
               </p>
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
                 <FormField label="Address column *">
                   <select
                     value={mapAddress}
@@ -552,6 +564,21 @@ export default function ScheduleAssessmentDetailPage() {
                     className="h-9 w-full rounded-md border border-border bg-surface px-2 text-sm"
                   >
                     <option value="">— pick column —</option>
+                    {csvHeaders.map((h) => (
+                      <option key={h} value={h}>{h}</option>
+                    ))}
+                  </select>
+                </FormField>
+                <FormField
+                  label="Location code (optional)"
+                  helper="If your spreadsheet has an SL code that matches the SL row's location_code, it skips fuzzy matching and resolves exactly."
+                >
+                  <select
+                    value={mapLocationCode}
+                    onChange={(e) => setMapLocationCode(e.target.value)}
+                    className="h-9 w-full rounded-md border border-border bg-surface px-2 text-sm"
+                  >
+                    <option value="">— none —</option>
                     {csvHeaders.map((h) => (
                       <option key={h} value={h}>{h}</option>
                     ))}
@@ -634,6 +661,7 @@ export default function ScheduleAssessmentDetailPage() {
                               <span className="ml-1 text-warning">[v{mapDates.indexOf(h) + 1}]</span>
                             )}
                             {h === mapCrew && <span className="ml-1 text-success">[crew]</span>}
+                            {h === mapLocationCode && <span className="ml-1 text-fg-subtle">[code]</span>}
                           </th>
                         ))}
                       </tr>
@@ -739,16 +767,17 @@ export default function ScheduleAssessmentDetailPage() {
         {/* Review tray */}
         {reviewRows.length > 0 && (
           <Card padding="none">
-            <div className="px-4 py-3 border-b border-border flex items-center justify-between">
-              <div>
-                <CardTitle>Review unmatched / low-confidence rows</CardTitle>
-                <p className="text-xs text-fg-muted mt-0.5">
-                  Pick the right service location, or skip rows that aren't part of this client's portfolio.
-                </p>
+            <div className="px-4 py-3 border-b border-border">
+              <CardTitle>Review unmatched / low-confidence rows</CardTitle>
+              <p className="text-xs text-fg-muted mt-0.5">
+                Each row's top 3 candidates are pre-loaded from the matcher
+                — pick one or skip. The full SL list (all { (slOptions.length || '...') } locations) is available as a fallback.
+              </p>
+              <div className="mt-2">
+                <Button size="sm" variant="ghost" onClick={loadSlOptions}>
+                  {slOptions.length > 0 ? `Full list loaded (${slOptions.length})` : 'Load full SL list (fallback)'}
+                </Button>
               </div>
-              <Button size="sm" variant="ghost" onClick={loadSlOptions}>
-                Load SL list
-              </Button>
             </div>
             <Table>
               <TableHeader>
@@ -756,22 +785,29 @@ export default function ScheduleAssessmentDetailPage() {
                   <TableHead>Raw address</TableHead>
                   <TableHead>Date</TableHead>
                   <TableHead>Crew</TableHead>
-                  <TableHead className="text-right">Confidence</TableHead>
+                  <TableHead className="text-right">Conf</TableHead>
                   <TableHead>Match</TableHead>
                   <TableHead />
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {reviewRows.slice(0, 200).map((r) => (
-                  <TableRow key={r.id}>
-                    <TableCell className="text-xs">{r.raw_address}</TableCell>
-                    <TableCell className="text-xs font-tabular">{r.raw_scheduled_date ?? '—'}</TableCell>
-                    <TableCell className="text-xs">{r.raw_crew_name ?? '—'}</TableCell>
-                    <TableCell numeric className="text-xs">
-                      {r.match_confidence != null ? `${Math.round(r.match_confidence * 100)}%` : '—'}
-                    </TableCell>
-                    <TableCell>
-                      {slOptions.length > 0 ? (
+                {reviewRows.slice(0, 200).map((r) => {
+                  const candidates = Array.isArray(r.match_candidates) ? r.match_candidates : []
+                  const usingCandidates = candidates.length > 0
+                  return (
+                    <TableRow key={r.id}>
+                      <TableCell className="text-xs">
+                        {r.raw_address}
+                        {r.raw_location_code && (
+                          <span className="ml-1 text-fg-subtle">[code: {r.raw_location_code}]</span>
+                        )}
+                      </TableCell>
+                      <TableCell className="text-xs font-tabular">{r.raw_scheduled_date ?? '—'}</TableCell>
+                      <TableCell className="text-xs">{r.raw_crew_name ?? '—'}</TableCell>
+                      <TableCell numeric className="text-xs">
+                        {r.match_confidence != null ? `${Math.round(r.match_confidence * 100)}%` : '—'}
+                      </TableCell>
+                      <TableCell>
                         <select
                           value={r.matched_service_location_id ?? ''}
                           onChange={(e) =>
@@ -783,29 +819,38 @@ export default function ScheduleAssessmentDetailPage() {
                           className="h-8 max-w-xs rounded-md border border-border bg-surface px-2 text-xs"
                         >
                           <option value="">— pick SL —</option>
-                          {slOptions.map((s) => (
-                            <option key={s.id} value={s.id}>
-                              {s.display_name ?? s.property?.address_line1 ?? s.id.slice(0, 8)}
-                            </option>
-                          ))}
+                          {usingCandidates && (
+                            <optgroup label="Suggested matches">
+                              {candidates.map((c) => (
+                                <option key={c.sl_id} value={c.sl_id}>
+                                  {c.address_line1} ({Math.round(c.score * 100)}%)
+                                </option>
+                              ))}
+                            </optgroup>
+                          )}
+                          {slOptions.length > 0 && (
+                            <optgroup label="All service locations">
+                              {slOptions.map((s) => (
+                                <option key={s.id} value={s.id}>
+                                  {s.display_name ?? s.property?.address_line1 ?? s.id.slice(0, 8)}
+                                </option>
+                              ))}
+                            </optgroup>
+                          )}
                         </select>
-                      ) : (
-                        <span className="text-xs text-fg-subtle">click "Load SL list"</span>
-                      )}
-                    </TableCell>
-                    <TableCell className="text-right">
-                      <Button
-                        size="sm"
-                        variant="ghost"
-                        onClick={() =>
-                          updateRow(r.id, { match_status: 'skipped' })
-                        }
-                      >
-                        Skip
-                      </Button>
-                    </TableCell>
-                  </TableRow>
-                ))}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          onClick={() => updateRow(r.id, { match_status: 'skipped' })}
+                        >
+                          Skip
+                        </Button>
+                      </TableCell>
+                    </TableRow>
+                  )
+                })}
               </TableBody>
             </Table>
             {reviewRows.length > 200 && (

--- a/supabase/migrations/20260503034228_schedule_assessment_match_candidates.sql
+++ b/supabase/migrations/20260503034228_schedule_assessment_match_candidates.sql
@@ -1,0 +1,11 @@
+-- Persist top-3 fuzzy match candidates per assessment row so the
+-- review tray can render them inline without a separate "Load SL
+-- list" click. Each candidate: { sl_id, address_line1, score }.
+ALTER TABLE public.schedule_assessment_rows
+  ADD COLUMN IF NOT EXISTS match_candidates jsonb;
+
+-- Optional raw-CSV column for explicit location-code lookups (bypasses
+-- fuzzy address matching when present). Stored separately from
+-- raw_address so we can show both in the review UI when needed.
+ALTER TABLE public.schedule_assessment_rows
+  ADD COLUMN IF NOT EXISTS raw_location_code text;


### PR DESCRIPTION
## Three improvements to shrink the review tray

### 1. Inline candidates (no \"Load SL list\" required)
- New \`schedule_assessment_rows.match_candidates\` jsonb persists the matcher's top-3 results per row at upload time.
- Review tray dropdown shows a \"Suggested matches\" optgroup pre-loaded with candidate addresses + match score. Full SL list still available as fallback.

### 2. Location-code exact match
- New \`raw_location_code\` column + \`location_code\` field in \`ColumnMapping\`.
- When mapped, upload first does case-insensitive exact match against \`service_locations.location_code\`. Hits get auto-matched with confidence=1.0, no fuzzy comparison. Misses fall through to address fuzzy match.

### 3. Auto threshold 0.85 → 0.7
- Abbreviated addresses (\"123 Main St\" vs \"123 Main Street, Phoenix, AZ\") scored ~0.7 and got dumped to review for no good reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)