### PR TITLE
Review tray UX: auto-load SLs, pre-select top candidate, bulk accept

### DIFF
--- a/api/_lib/schedule-assessment/match-addresses.ts
+++ b/api/_lib/schedule-assessment/match-addresses.ts
@@ -62,6 +62,12 @@ function jaccard(a: string[], b: string[]): number {
 export interface MatchInput {
   row_id: string
   raw_address: string
+  // Optional disambiguators. When present, they boost the match score
+  // for candidates whose property has the same city/state/zip — turning
+  // ambiguous "123 Main St" into a confident match.
+  raw_city?: string | null
+  raw_state?: string | null
+  raw_postal_code?: string | null
 }
 
 export interface MatchOutput {
@@ -109,13 +115,32 @@ export async function matchAddresses(
     cand: c,
     tokens: normalize(c.address_line1),
   }))
-  // Score each input against every candidate; keep top 3.
+  // Score each input against every candidate; keep top 3. When the
+  // input row has city / state / zip, boost the score for candidates
+  // whose property's city/state/zip matches — turns "123 Main St"
+  // into a confident match when 5 SLs share the street name but only
+  // one is in Phoenix.
   const out: MatchOutput[] = []
+  const norm = (s: string | null | undefined) => (s ?? '').trim().toLowerCase()
   for (const inp of inputs) {
     const inputTokens = normalize(inp.raw_address)
+    const inCity = norm(inp.raw_city)
+    const inState = norm(inp.raw_state)
+    const inZip = norm(inp.raw_postal_code).replace(/\D/g, '').slice(0, 5)
     const scored: Array<{ sl_id: string; address: string; score: number }> = []
     for (const ct of candTokens) {
-      const score = jaccard(inputTokens, ct.tokens)
+      let score = jaccard(inputTokens, ct.tokens)
+      // City exact match: +0.10. State match: +0.05. Zip match: +0.10.
+      // Mismatches penalize lightly so we don't over-confident on a
+      // street collision when city/state are wrong.
+      const cCity = norm(ct.cand.city)
+      const cState = norm(ct.cand.state)
+      const cZip = norm(ct.cand.postal_code).replace(/\D/g, '').slice(0, 5)
+      if (inCity && cCity) score += inCity === cCity ? 0.1 : -0.05
+      if (inState && cState) score += inState === cState ? 0.05 : -0.05
+      if (inZip && cZip) score += inZip === cZip ? 0.1 : -0.03
+      // Clamp to [0, 1].
+      score = Math.max(0, Math.min(1, score))
       if (score >= REVIEW_THRESHOLD) {
         scored.push({ sl_id: ct.cand.sl_id, address: ct.cand.address_line1, score })
       }

--- a/src/pages/accounts/scheduler/ScheduleAssessmentDetail.tsx
+++ b/src/pages/accounts/scheduler/ScheduleAssessmentDetail.tsx
@@ -486,6 +486,15 @@ export default function ScheduleAssessmentDetailPage() {
     [rows]
   )
 
+  // Auto-load the full SL list when there are rows that need review.
+  // Previously this required a manual button click — confusing because
+  // dropdowns appeared empty until the operator hit it.
+  useEffect(() => {
+    if (reviewRows.length > 0 && slOptions.length === 0) {
+      void loadSlOptions()
+    }
+  }, [reviewRows.length, slOptions.length, loadSlOptions])
+
   if (loading) {
     return (
       <AppShell><div className="p-10 text-fg-muted">Loading…</div></AppShell>
@@ -768,15 +777,82 @@ export default function ScheduleAssessmentDetailPage() {
         {reviewRows.length > 0 && (
           <Card padding="none">
             <div className="px-4 py-3 border-b border-border">
-              <CardTitle>Review unmatched / low-confidence rows</CardTitle>
+              <CardTitle>Review {reviewRows.length} unmatched / low-confidence rows</CardTitle>
               <p className="text-xs text-fg-muted mt-0.5">
-                Each row's top 3 candidates are pre-loaded from the matcher
-                — pick one or skip. The full SL list (all { (slOptions.length || '...') } locations) is available as a fallback.
+                The matcher's best guess is pre-selected in each dropdown. Just
+                confirm with <strong>Accept</strong> if the top suggestion is
+                right, change the selection, or <strong>Skip</strong> if the
+                row isn't part of this client's portfolio.
               </p>
-              <div className="mt-2">
-                <Button size="sm" variant="ghost" onClick={loadSlOptions}>
-                  {slOptions.length > 0 ? `Full list loaded (${slOptions.length})` : 'Load full SL list (fallback)'}
+              <div className="mt-2 flex items-center gap-2 flex-wrap">
+                <Button
+                  size="sm"
+                  onClick={async () => {
+                    // Bulk-accept the top candidate on every review row that
+                    // has one. The operator can still revisit individual rows
+                    // afterward.
+                    const accepts = reviewRows
+                      .filter((r) => Array.isArray(r.match_candidates) && r.match_candidates.length > 0)
+                      .map((r) => ({
+                        id: r.id,
+                        matched_service_location_id: r.match_candidates![0].sl_id,
+                        match_status: 'manual' as const,
+                      }))
+                    if (accepts.length === 0) return
+                    if (!confirm(`Auto-accept the top candidate for ${accepts.length} rows? You can still change individual rows after.`)) return
+                    try {
+                      const token = await getToken()
+                      // Chunk to keep payloads sane.
+                      for (let i = 0; i < accepts.length; i += 200) {
+                        const chunk = accepts.slice(i, i + 200)
+                        await fetch(`/api/v1/schedule-assessments/${id}/rows`, {
+                          method: 'PATCH',
+                          headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+                          body: JSON.stringify({ rows: chunk }),
+                        })
+                      }
+                      await load()
+                    } catch (err) {
+                      setError(err instanceof Error ? err.message : String(err))
+                    }
+                  }}
+                >
+                  Accept top suggestion for all (
+                  {reviewRows.filter((r) => Array.isArray(r.match_candidates) && r.match_candidates.length > 0).length}
+                  )
                 </Button>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={async () => {
+                    const skips = reviewRows
+                      .filter((r) => !Array.isArray(r.match_candidates) || r.match_candidates.length === 0)
+                      .map((r) => ({ id: r.id, match_status: 'skipped' as const }))
+                    if (skips.length === 0) return
+                    if (!confirm(`Skip ${skips.length} rows that have no candidates at all (almost certainly not in this portfolio)?`)) return
+                    try {
+                      const token = await getToken()
+                      for (let i = 0; i < skips.length; i += 200) {
+                        const chunk = skips.slice(i, i + 200)
+                        await fetch(`/api/v1/schedule-assessments/${id}/rows`, {
+                          method: 'PATCH',
+                          headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+                          body: JSON.stringify({ rows: chunk }),
+                        })
+                      }
+                      await load()
+                    } catch (err) {
+                      setError(err instanceof Error ? err.message : String(err))
+                    }
+                  }}
+                >
+                  Skip all unmatched ({reviewRows.filter((r) => !Array.isArray(r.match_candidates) || r.match_candidates.length === 0).length})
+                </Button>
+                {slOptions.length > 0 && (
+                  <span className="text-[11px] text-fg-subtle">
+                    Full SL list loaded ({slOptions.length})
+                  </span>
+                )}
               </div>
             </div>
             <Table>
@@ -794,6 +870,11 @@ export default function ScheduleAssessmentDetailPage() {
                 {reviewRows.slice(0, 200).map((r) => {
                   const candidates = Array.isArray(r.match_candidates) ? r.match_candidates : []
                   const usingCandidates = candidates.length > 0
+                  // Pre-select the best candidate so the dropdown isn't empty
+                  // and the operator can confirm with one click.
+                  const selectedValue =
+                    r.matched_service_location_id ??
+                    (candidates[0]?.sl_id ?? '')
                   return (
                     <TableRow key={r.id}>
                       <TableCell className="text-xs">
@@ -809,7 +890,7 @@ export default function ScheduleAssessmentDetailPage() {
                       </TableCell>
                       <TableCell>
                         <select
-                          value={r.matched_service_location_id ?? ''}
+                          value={selectedValue}
                           onChange={(e) =>
                             updateRow(r.id, {
                               matched_service_location_id: e.target.value || null,
@@ -840,13 +921,27 @@ export default function ScheduleAssessmentDetailPage() {
                         </select>
                       </TableCell>
                       <TableCell className="text-right">
-                        <Button
-                          size="sm"
-                          variant="ghost"
-                          onClick={() => updateRow(r.id, { match_status: 'skipped' })}
-                        >
-                          Skip
-                        </Button>
+                        <div className="flex items-center justify-end gap-1">
+                          <Button
+                            size="sm"
+                            onClick={() =>
+                              updateRow(r.id, {
+                                matched_service_location_id: selectedValue || null,
+                                match_status: selectedValue ? 'manual' : 'unmatched',
+                              })
+                            }
+                            disabled={!selectedValue || r.matched_service_location_id === selectedValue}
+                          >
+                            Accept
+                          </Button>
+                          <Button
+                            size="sm"
+                            variant="ghost"
+                            onClick={() => updateRow(r.id, { match_status: 'skipped' })}
+                          >
+                            Skip
+                          </Button>
+                        </div>
                       </TableCell>
                     </TableRow>
                   )


### PR DESCRIPTION
## Smaller fixes while the bigger geocode rewrite is in flight

1. **Auto-load SL list** when review rows exist. No more clicking \"Load full SL list\" before dropdowns work.
2. **Pre-select** the matcher's top candidate as the dropdown value. One-click Accept instead of opening the dropdown.
3. **Bulk header actions**: \"Accept top suggestion for all (N)\" and \"Skip all unmatched (M)\".
4. **Per-row Accept button** next to Skip.
5. **City/state/zip score boost** in match-addresses (boost +0.10/+0.05/+0.10 on match, light penalties on mismatch). Not yet wired through the upload — that comes with the geocode pivot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)