### PR TITLE
Dedup not-in-portfolio rows by address

### DIFF
--- a/api/v1/schedule-assessments/[id]/add-to-portfolio.ts
+++ b/api/v1/schedule-assessments/[id]/add-to-portfolio.ts
@@ -144,23 +144,41 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       propertyId = (newProp as any).id
     }
 
-    // Create the SL tying this property to the target client.
-    const { data: newSl, error: slErr } = await db
+    // Dedup the SL too — if a service_location already exists for
+    // (this property, this client), reuse it instead of creating a
+    // duplicate. Multi-visit uploads have one row per visit, so the
+    // same address shows up N times; without this dedup we'd create
+    // N SLs for the same building.
+    let slId: string
+    let reusedSl = false
+    const { data: existingSl } = await db
       .from('service_locations')
-      .insert({
-        property_id: propertyId,
-        client_id: targetClientId,
-        account_id: targetAccountId,
-        display_name: street,
-        status: 'active',
-      })
       .select('id')
-      .single()
-    if (slErr || !newSl) {
-      skipped.push({ row_id: row.id, reason: `service_location insert failed: ${slErr?.message ?? 'unknown'}` })
-      continue
+      .eq('property_id', propertyId)
+      .eq('client_id', targetClientId)
+      .maybeSingle()
+    if (existingSl) {
+      slId = (existingSl as any).id
+      reusedSl = true
+    } else {
+      const { data: newSl, error: slErr } = await db
+        .from('service_locations')
+        .insert({
+          property_id: propertyId,
+          client_id: targetClientId,
+          account_id: targetAccountId,
+          display_name: street,
+          status: 'active',
+        })
+        .select('id')
+        .single()
+      if (slErr || !newSl) {
+        skipped.push({ row_id: row.id, reason: `service_location insert failed: ${slErr?.message ?? 'unknown'}` })
+        continue
+      }
+      slId = (newSl as any).id
     }
-    const slId = (newSl as any).id
+    void reusedSl
 
     // Update the assessment row to point at the new SL.
     await db

--- a/src/pages/accounts/scheduler/ScheduleAssessmentDetail.tsx
+++ b/src/pages/accounts/scheduler/ScheduleAssessmentDetail.tsx
@@ -622,6 +622,48 @@ export default function ScheduleAssessmentDetailPage() {
       ),
     [rows]
   )
+  // Multi-visit uploads emit one row per visit, so the same building
+  // shows up N times. Group by address so the operator sees one entry
+  // per distinct property with a visit count, and so the bulk "Add"
+  // creates one SL per address (server-side dedup also enforces this).
+  const notInPortfolioGroups = useMemo(() => {
+    const norm = (s: string | null) => (s ?? '').trim().toLowerCase().replace(/\s+/g, ' ')
+    const m = new Map<
+      string,
+      {
+        key: string
+        address: string
+        city: string | null
+        state: string | null
+        zip: string | null
+        lat: number
+        lng: number
+        dates: string[]
+        rowIds: string[]
+      }
+    >()
+    for (const r of notInPortfolioRows) {
+      const key = `${norm(r.raw_address)}|${norm(r.raw_city)}|${norm(r.raw_state)}|${norm(r.raw_postal_code)}`
+      const existing = m.get(key)
+      if (existing) {
+        existing.rowIds.push(r.id)
+        if (r.raw_scheduled_date) existing.dates.push(r.raw_scheduled_date)
+      } else {
+        m.set(key, {
+          key,
+          address: r.raw_address,
+          city: r.raw_city,
+          state: r.raw_state,
+          zip: r.raw_postal_code,
+          lat: r.geocoded_lat as number,
+          lng: r.geocoded_lng as number,
+          dates: r.raw_scheduled_date ? [r.raw_scheduled_date] : [],
+          rowIds: [r.id],
+        })
+      }
+    }
+    return Array.from(m.values()).sort((a, b) => a.address.localeCompare(b.address))
+  }, [notInPortfolioRows])
   // Rows that couldn't be geocoded at all — bad address data.
   const ungeocodableRows = useMemo(
     () =>
@@ -1174,17 +1216,26 @@ export default function ScheduleAssessmentDetailPage() {
           </Card>
         )}
 
-        {/* Not in portfolio: rows that geocoded fine but no SL was nearby. */}
-        {notInPortfolioRows.length > 0 && (
+        {/* Not in portfolio: rows that geocoded fine but no SL was nearby.
+            Grouped by address so multi-visit duplicates collapse into one row. */}
+        {notInPortfolioGroups.length > 0 && (
           <Card padding="none">
             <div className="px-4 py-3 border-b border-border space-y-2">
-              <CardTitle>Not in portfolio ({notInPortfolioRows.length})</CardTitle>
+              <CardTitle>
+                Not in portfolio ({notInPortfolioGroups.length} address
+                {notInPortfolioGroups.length === 1 ? '' : 'es'}
+                {notInPortfolioRows.length !== notInPortfolioGroups.length
+                  ? ` · ${notInPortfolioRows.length} visits`
+                  : ''}
+                )
+              </CardTitle>
               <p className="text-xs text-fg-muted">
                 Google geocoded these addresses successfully, but no existing
                 service location is within 500ft. These look like real
-                properties not yet in your portfolio. Add them in one click —
-                we'll create the property + service location with the
-                already-resolved coordinates.
+                properties not yet in your portfolio. Multi-visit schedules
+                show one row per address with a visit count — adding will
+                create one property + service location for each distinct
+                address and link every visit row to it.
               </p>
               <div className="flex items-center gap-2 flex-wrap">
                 {memberClients.length > 0 && (
@@ -1202,11 +1253,13 @@ export default function ScheduleAssessmentDetailPage() {
                 )}
                 <Button
                   size="sm"
-                  onClick={() => addToPortfolio(notInPortfolioRows.map((r) => r.id))}
+                  onClick={() =>
+                    addToPortfolio(notInPortfolioGroups.flatMap((g) => g.rowIds))
+                  }
                   loading={addingToPortfolio}
                   disabled={!targetClientId}
                 >
-                  Add all {notInPortfolioRows.length} to portfolio
+                  Add all {notInPortfolioGroups.length} to portfolio
                 </Button>
               </div>
             </div>
@@ -1215,27 +1268,29 @@ export default function ScheduleAssessmentDetailPage() {
                 <TableRow>
                   <TableHead>Raw address</TableHead>
                   <TableHead>City / state / zip</TableHead>
-                  <TableHead>Date</TableHead>
+                  <TableHead className="text-right">Visits</TableHead>
                   <TableHead className="text-right">Lat / lng</TableHead>
                   <TableHead />
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {notInPortfolioRows.slice(0, 200).map((r) => (
-                  <TableRow key={r.id}>
-                    <TableCell className="text-xs">{r.raw_address}</TableCell>
+                {notInPortfolioGroups.slice(0, 200).map((g) => (
+                  <TableRow key={g.key}>
+                    <TableCell className="text-xs">{g.address}</TableCell>
                     <TableCell className="text-xs text-fg-muted">
-                      {[r.raw_city, r.raw_state, r.raw_postal_code].filter(Boolean).join(', ') || '—'}
+                      {[g.city, g.state, g.zip].filter(Boolean).join(', ') || '—'}
                     </TableCell>
-                    <TableCell className="text-xs font-tabular">{r.raw_scheduled_date ?? '—'}</TableCell>
+                    <TableCell numeric className="text-xs font-tabular">
+                      {g.rowIds.length}
+                    </TableCell>
                     <TableCell numeric className="text-xs font-tabular text-fg-muted">
-                      {r.geocoded_lat?.toFixed(4)}, {r.geocoded_lng?.toFixed(4)}
+                      {g.lat.toFixed(4)}, {g.lng.toFixed(4)}
                     </TableCell>
                     <TableCell className="text-right">
                       <div className="flex justify-end gap-1">
                         <Button
                           size="sm"
-                          onClick={() => addToPortfolio([r.id])}
+                          onClick={() => addToPortfolio(g.rowIds)}
                           loading={addingToPortfolio}
                           disabled={!targetClientId}
                         >
@@ -1244,7 +1299,11 @@ export default function ScheduleAssessmentDetailPage() {
                         <Button
                           size="sm"
                           variant="ghost"
-                          onClick={() => updateRow(r.id, { match_status: 'skipped' })}
+                          onClick={() =>
+                            Promise.all(
+                              g.rowIds.map((id) => updateRow(id, { match_status: 'skipped' }))
+                            )
+                          }
                         >
                           Skip
                         </Button>
@@ -1254,9 +1313,9 @@ export default function ScheduleAssessmentDetailPage() {
                 ))}
               </TableBody>
             </Table>
-            {notInPortfolioRows.length > 200 && (
+            {notInPortfolioGroups.length > 200 && (
               <p className="px-4 py-2 text-xs text-fg-subtle border-t border-border">
-                Showing 200 of {notInPortfolioRows.length} — resolve a batch and refresh.
+                Showing 200 of {notInPortfolioGroups.length} — resolve a batch and refresh.
               </p>
             )}
           </Card>


### PR DESCRIPTION
## Summary
- Group the not-in-portfolio list by raw `(address, city, state, zip)` so multi-visit duplicates collapse into one entry with a visit count
- Add a server-side service_location dedup in `add-to-portfolio` so two rows for the same building create one SL (matching the existing property-level dedup via `address_hash`)
- Header now reports "N addresses · M visits" when the two diverge

User report: "I ran the match and it auto matched 311, 2 near matches, and 231 not in the portfolio but looking at the list there are a lot of duplicates."

## Test plan
- [ ] Upload a multi-visit CSV (same address appearing multiple times)
- [ ] Run "Geocode & match"
- [ ] Confirm the not-in-portfolio panel shows one row per distinct address with the correct visit count
- [ ] Click "Add" on a group; verify one property + one service_location is created and all underlying assessment rows point at it
- [ ] Click "Add all"; verify N properties / N service_locations created (one per address, not per visit)
- [ ] Re-upload a row whose address already exists in the portfolio and confirm the existing property + SL are reused

🤖 Generated with [Claude Code](https://claude.com/claude-code)