### PR TITLE
Persist match results from upload + geocode-match

### DIFF
--- a/api/v1/schedule-assessments/[id]/geocode-match.ts
+++ b/api/v1/schedule-assessments/[id]/geocode-match.ts
@@ -243,16 +243,35 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     })
   }
 
-  // Persist in chunks.
-  for (let i = 0; i < updates.length; i += 200) {
-    const chunk = updates.slice(i, i + 200)
-    const { error } = await db
-      .from('schedule_assessment_rows')
-      .upsert(chunk, { onConflict: 'id' })
-    if (error) {
-      // eslint-disable-next-line no-console
-      console.warn(`geocode-match update batch failed: ${error.message}`)
+  // Persist results. Per-row UPDATE (not upsert) — schedule_assessment_rows
+  // has NOT NULL columns (assessment_id, file_id, raw_address) so an upsert
+  // with a partial payload silently fails the INSERT path and never reaches
+  // the ON CONFLICT update. Parallelize in modest batches; 645 rows
+  // finishes in well under a second.
+  const PARALLEL = 25
+  let writeFailures = 0
+  for (let i = 0; i < updates.length; i += PARALLEL) {
+    const batch = updates.slice(i, i + PARALLEL)
+    const results = await Promise.all(
+      batch.map((u) => {
+        const { id: rowId, ...patch } = u
+        return db.from('schedule_assessment_rows').update(patch).eq('id', rowId)
+      })
+    )
+    for (const r of results) {
+      if (r.error) {
+        writeFailures++
+        // eslint-disable-next-line no-console
+        console.warn(`geocode-match row update failed: ${r.error.message}`)
+      }
     }
+  }
+  if (writeFailures > 0) {
+    return res.status(500).json({
+      error: `Persisted some rows but ${writeFailures} of ${updates.length} updates failed. Check server logs.`,
+      processed: targets.length,
+      write_failures: writeFailures,
+    })
   }
 
   await db

--- a/api/v1/schedule-assessments/[id]/index.ts
+++ b/api/v1/schedule-assessments/[id]/index.ts
@@ -37,7 +37,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     for (let p = 0; p < 50; p++) {
       const { data: batch } = await db
         .from('schedule_assessment_rows')
-        .select('id, file_id, raw_address, raw_scheduled_date, raw_crew_name, raw_location_code, matched_service_location_id, match_confidence, match_status, match_candidates, notes')
+        .select('id, file_id, raw_address, raw_scheduled_date, raw_crew_name, raw_location_code, raw_city, raw_state, raw_postal_code, geocoded_lat, geocoded_lng, geocoded_status, matched_service_location_id, match_confidence, match_distance_feet, match_status, match_candidates, notes')
         .eq('assessment_id', id)
         .order('created_at', { ascending: true })
         .range(p * PAGE, p * PAGE + PAGE - 1)

--- a/api/v1/schedule-assessments/[id]/upload.ts
+++ b/api/v1/schedule-assessments/[id]/upload.ts
@@ -162,15 +162,30 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       match_status: 'pending',
     })
   }
-  for (let i = 0; i < updates.length; i += INSERT_CHUNK) {
-    const chunk = updates.slice(i, i + INSERT_CHUNK)
-    const { error: upErr } = await db
-      .from('schedule_assessment_rows')
-      .upsert(chunk, { onConflict: 'id' })
-    if (upErr) {
-      // eslint-disable-next-line no-console
-      console.warn(`match update batch failed: ${upErr.message}`)
+  // Per-row UPDATE (not upsert) — partial upserts trip NOT NULL on the
+  // INSERT path and silently no-op. Parallelize.
+  const PARALLEL = 25
+  let writeFailures = 0
+  for (let i = 0; i < updates.length; i += PARALLEL) {
+    const batch = updates.slice(i, i + PARALLEL)
+    const results = await Promise.all(
+      batch.map((u) => {
+        const { id: rowId, ...patch } = u
+        return db.from('schedule_assessment_rows').update(patch).eq('id', rowId)
+      })
+    )
+    for (const r of results) {
+      if (r.error) {
+        writeFailures++
+        // eslint-disable-next-line no-console
+        console.warn(`match update failed: ${r.error.message}`)
+      }
     }
+  }
+  if (writeFailures > 0) {
+    return res.status(500).json({
+      error: `Persisted some rows but ${writeFailures} of ${updates.length} match-status updates failed.`,
+    })
   }
 
   if (codeMatchedCount > 0) {


### PR DESCRIPTION
## Summary
- Both upload + geocode-match used \`.upsert(...)\` with partial payloads to persist match results. \`schedule_assessment_rows\` has NOT NULL on \`assessment_id\` / \`file_id\` / \`raw_address\`, so the INSERT path of the upsert was rejected by Postgres and the writes silently no-op'd. The error was \`console.warn\`'d but the route still returned its in-memory tally.
- User-visible: geocode-match reports "555 auto-matched, 90 not in portfolio" but the address-match summary keeps showing "0 auto, 645 need review" because the DB never moved off \`pending\`.
- Switch to per-row \`.update().eq('id', ...)\` parallelized at 25/batch in both endpoints. Surface write failures as a 500 instead of swallowing.
- Also fixes a related miss: GET \`[id]\` wasn't selecting \`raw_city\` / \`raw_state\` / \`raw_postal_code\` / \`geocoded_lat\` / \`geocoded_lng\` / \`geocoded_status\` / \`match_distance_feet\`, so the not-in-portfolio panel had no lat/lng to filter on and would render city/state/zip blank even after the writes were fixed.

## Test plan
- [ ] Upload a multi-file CSV that exercises location_code matches; confirm the matched rows show \`match_status='auto'\` (not \`pending\`)
- [ ] Run "Geocode & match"; confirm the address-match summary numbers agree with the geocode-match return payload
- [ ] Confirm the not-in-portfolio panel shows the unmatched rows grouped by address with visit counts
- [ ] Confirm the "Couldn't geocode" panel shows only ungeocodable rows (not all of them)

🤖 Generated with [Claude Code](https://claude.com/claude-code)