### PR TITLE
Schedule-assessment health card + recommendations

### DIFF
--- a/api/v1/schedule-assessments/[id]/diff.ts
+++ b/api/v1/schedule-assessments/[id]/diff.ts
@@ -15,6 +15,7 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
 import { createAdminClient } from '../../../_lib/supabase.js'
 import { authenticateRequest } from '../../../_lib/auth.js'
+import { computeCrewUtilization } from '../../../_lib/scheduler/crew-utilization.js'
 
 type DiffStatus = 'only_current' | 'only_optimized' | 'moved_date' | 'matched_same'
 
@@ -26,8 +27,25 @@ interface DiffRow {
   current_crew: string | null
   optimized_date: string | null
   optimized_crew: string | null
+  // Hybrid key the user's per-row choice is stored under (sl_id|idx).
+  // Surfacing it lets the frontend's recommendation buttons patch
+  // multiple rows in one PATCH without re-deriving the key.
+  hybrid_key?: string
   // Per-row hybrid override choice (set by the user via the wizard).
   hybrid_choice?: 'current' | 'optimized' | 'skip' | null
+}
+
+type RecommendationKind = 'move_date' | 'add_visits' | 'remove_visits'
+interface Recommendation {
+  id: string
+  kind: RecommendationKind
+  title: string
+  description: string
+  visit_count: number
+  // hybrid keys to patch when the user accepts this recommendation.
+  affected_keys: string[]
+  // What hybrid_choice to set on the affected rows.
+  apply_choice: 'current' | 'optimized' | 'skip'
 }
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
@@ -172,6 +190,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           current_crew: null,
           optimized_date: o.date,
           optimized_crew: o.crew,
+          hybrid_key: hybridKey,
           hybrid_choice: choice,
         })
       } else if (c && !o) {
@@ -183,6 +202,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           current_crew: c.raw_crew_name,
           optimized_date: null,
           optimized_crew: null,
+          hybrid_key: hybridKey,
           hybrid_choice: choice,
         })
       } else if (c && o) {
@@ -195,6 +215,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           current_crew: c.raw_crew_name,
           optimized_date: o.date,
           optimized_crew: o.crew,
+          hybrid_key: hybridKey,
           hybrid_choice: choice,
         })
       }
@@ -209,6 +230,104 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     matched_same: diff.filter((d) => d.status === 'matched_same').length,
   }
 
+  // Schedule health summary — three numbers the operator should see
+  // before any row-level data: how aligned is the current schedule
+  // already, and what does the optimized cycle look like overall.
+  const totalEvaluated = counts.only_current + counts.only_optimized + counts.moved_date + counts.matched_same
+  const matchRatePct = totalEvaluated > 0 ? Math.round((counts.matched_same / totalEvaluated) * 100) : 0
+
+  let optimizedTotalHours = 0
+  let optimizedUtilizationPct = 0
+  let optimizedIdleDays = 0
+  let optimizedWorkdayCount = 0
+  try {
+    const utilDays = await computeCrewUtilization(db, cycleId)
+    let usedDays = 0
+    for (const d of utilDays) {
+      optimizedTotalHours += d.work_hours_scheduled
+      if (d.state.kind === 'idle') optimizedIdleDays++
+      if (d.utilization_pct > 0) usedDays++
+    }
+    optimizedWorkdayCount = utilDays.length
+    optimizedUtilizationPct =
+      optimizedWorkdayCount > 0 ? Math.round((usedDays / optimizedWorkdayCount) * 100) : 0
+  } catch {
+    // Util compute is best-effort — diff still loads if it fails.
+  }
+
+  const health = {
+    match_rate_pct: matchRatePct,
+    visits_already_optimal: counts.matched_same,
+    visits_to_move: counts.moved_date,
+    visits_to_add: counts.only_optimized,
+    visits_to_remove: counts.only_current,
+    total_evaluated: totalEvaluated,
+    optimized_total_hours: Math.round(optimizedTotalHours * 10) / 10,
+    optimized_utilization_pct: optimizedUtilizationPct,
+    optimized_idle_days: optimizedIdleDays,
+    optimized_workday_count: optimizedWorkdayCount,
+  }
+
+  // Recommendations — the actionable summary. Group date moves by
+  // (from_date → to_date) so "move 6 visits from Mon → Thu" reads as
+  // one operation, then add catch-all entries for adds/removes.
+  const recommendations: Recommendation[] = []
+  const moveGroups = new Map<string, DiffRow[]>()
+  for (const d of diff) {
+    if (d.status !== 'moved_date') continue
+    const k = `${d.current_date ?? '?'}→${d.optimized_date ?? '?'}`
+    const arr = moveGroups.get(k) ?? []
+    arr.push(d)
+    moveGroups.set(k, arr)
+  }
+  const fmtDate = (s: string | null) => {
+    if (!s) return '?'
+    const dt = new Date(s + 'T00:00:00Z')
+    if (Number.isNaN(dt.getTime())) return s
+    const dow = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'][dt.getUTCDay()]
+    const mon = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'][dt.getUTCMonth()]
+    return `${dow} ${mon} ${dt.getUTCDate()}`
+  }
+  const sortedMoveGroups = Array.from(moveGroups.entries()).sort(
+    (a, b) => b[1].length - a[1].length
+  )
+  for (const [key, rows] of sortedMoveGroups) {
+    const [from, to] = key.split('→')
+    recommendations.push({
+      id: `move_${key}`,
+      kind: 'move_date',
+      title: `Move ${rows.length} visit${rows.length === 1 ? '' : 's'} from ${fmtDate(from)} → ${fmtDate(to)}`,
+      description: `The optimized cycle puts these properties on ${fmtDate(to)} instead of ${fmtDate(from)}. Accepting moves them to the engine's date.`,
+      visit_count: rows.length,
+      affected_keys: rows.map((r) => r.hybrid_key!).filter(Boolean),
+      apply_choice: 'optimized',
+    })
+  }
+  if (counts.only_optimized > 0) {
+    const rows = diff.filter((d) => d.status === 'only_optimized')
+    recommendations.push({
+      id: 'add_visits',
+      kind: 'add_visits',
+      title: `Add ${rows.length} visit${rows.length === 1 ? '' : 's'} the engine schedules but the upload skips`,
+      description: `These properties appear in the optimized cycle but not in the uploaded schedule. Accepting adds them to the hybrid template.`,
+      visit_count: rows.length,
+      affected_keys: rows.map((r) => r.hybrid_key!).filter(Boolean),
+      apply_choice: 'optimized',
+    })
+  }
+  if (counts.only_current > 0) {
+    const rows = diff.filter((d) => d.status === 'only_current')
+    recommendations.push({
+      id: 'remove_visits',
+      kind: 'remove_visits',
+      title: `Skip ${rows.length} visit${rows.length === 1 ? '' : 's'} the optimized cycle drops`,
+      description: `These properties are in the upload but the engine's optimized plan doesn't visit them this cycle. Accepting marks them as skipped.`,
+      visit_count: rows.length,
+      affected_keys: rows.map((r) => r.hybrid_key!).filter(Boolean),
+      apply_choice: 'skip',
+    })
+  }
+
   return res.status(200).json({
     cycle: {
       id: cycleId,
@@ -216,6 +335,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       end_date: (cycleRow as any).end_date,
     },
     counts,
+    health,
+    recommendations,
     diff,
   })
 }

--- a/src/pages/accounts/scheduler/ScheduleAssessmentDetail.tsx
+++ b/src/pages/accounts/scheduler/ScheduleAssessmentDetail.tsx
@@ -73,11 +73,35 @@ interface DiffRow {
   current_crew: string | null
   optimized_date: string | null
   optimized_crew: string | null
+  hybrid_key?: string
   hybrid_choice?: 'current' | 'optimized' | 'skip' | null
+}
+interface DiffHealth {
+  match_rate_pct: number
+  visits_already_optimal: number
+  visits_to_move: number
+  visits_to_add: number
+  visits_to_remove: number
+  total_evaluated: number
+  optimized_total_hours: number
+  optimized_utilization_pct: number
+  optimized_idle_days: number
+  optimized_workday_count: number
+}
+interface DiffRecommendation {
+  id: string
+  kind: 'move_date' | 'add_visits' | 'remove_visits'
+  title: string
+  description: string
+  visit_count: number
+  affected_keys: string[]
+  apply_choice: 'current' | 'optimized' | 'skip'
 }
 interface DiffPayload {
   cycle: { id: string; start_date: string; end_date: string }
   counts: { only_current: number; only_optimized: number; moved_date: number; matched_same: number }
+  health?: DiffHealth
+  recommendations?: DiffRecommendation[]
   diff: DiffRow[]
 }
 interface TemplateOption {
@@ -141,6 +165,8 @@ export default function ScheduleAssessmentDetailPage() {
   const [templates, setTemplates] = useState<TemplateOption[]>([])
   const [diff, setDiff] = useState<DiffPayload | null>(null)
   const [diffLoading, setDiffLoading] = useState(false)
+  const [showAllDiffRows, setShowAllDiffRows] = useState(false)
+  const [showConstraintsList, setShowConstraintsList] = useState(false)
   const [diffFilter, setDiffFilter] = useState<DiffStatus | 'all_actionable'>('all_actionable')
   const [detections, setDetections] = useState<DetectedConstraint[]>([])
   const [detecting, setDetecting] = useState(false)
@@ -296,6 +322,36 @@ export default function ScheduleAssessmentDetailPage() {
       setError(err instanceof Error ? err.message : String(err))
     } finally {
       setSavingTpl(false)
+    }
+  }
+
+  // Apply a recommendation: PATCH the hybrid endpoint with all of the
+  // recommendation's row keys at once, then optimistically update the
+  // cached diff so the UI reflects the new choices without a refetch.
+  async function applyRecommendation(rec: DiffRecommendation) {
+    if (!id || rec.affected_keys.length === 0) return
+    const choice = rec.apply_choice
+    try {
+      const token = await getToken()
+      await fetch(`/api/v1/schedule-assessments/${id}/hybrid`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        body: JSON.stringify({
+          rows: rec.affected_keys.map((key) => ({ key, source: choice })),
+        }),
+      })
+      const keySet = new Set(rec.affected_keys)
+      setDiff((prev) => {
+        if (!prev) return prev
+        return {
+          ...prev,
+          diff: prev.diff.map((r) =>
+            r.hybrid_key && keySet.has(r.hybrid_key) ? { ...r, hybrid_choice: choice } : r
+          ),
+        }
+      })
+    } catch {
+      // ignore — user can retry
     }
   }
 
@@ -1364,70 +1420,199 @@ export default function ScheduleAssessmentDetailPage() {
           </div>
         </Card>
 
-        {/* Step 4: Diff dashboard */}
-        {diff && (
-          <Card padding="none" className="overflow-hidden">
-            <div className="px-4 py-3 border-b border-border space-y-2">
-              <CardTitle>Current vs optimized</CardTitle>
+        {/* Step 4: Schedule health summary */}
+        {diff?.health && (
+          <Card className="space-y-3">
+            <div className="flex items-baseline justify-between gap-3 flex-wrap">
+              <CardTitle>Schedule health</CardTitle>
               <p className="text-xs text-fg-muted">
-                Optimized cycle: {diff.cycle.start_date} → {diff.cycle.end_date}
+                vs cycle {diff.cycle.start_date} → {diff.cycle.end_date}
               </p>
-              <div className="flex flex-wrap gap-2">
-                <FilterChip
-                  label={`All actionable (${diff.counts.only_current + diff.counts.only_optimized + diff.counts.moved_date})`}
-                  active={diffFilter === 'all_actionable'}
-                  onClick={() => setDiffFilter('all_actionable')}
-                />
-                <FilterChip
-                  label={`Only on current (${diff.counts.only_current})`}
-                  active={diffFilter === 'only_current'}
-                  onClick={() => setDiffFilter('only_current')}
-                />
-                <FilterChip
-                  label={`Only on optimized (${diff.counts.only_optimized})`}
-                  active={diffFilter === 'only_optimized'}
-                  onClick={() => setDiffFilter('only_optimized')}
-                />
-                <FilterChip
-                  label={`Moved date (${diff.counts.moved_date})`}
-                  active={diffFilter === 'moved_date'}
-                  onClick={() => setDiffFilter('moved_date')}
-                />
-                <FilterChip
-                  label={`Same (${diff.counts.matched_same})`}
-                  active={diffFilter === 'matched_same'}
-                  onClick={() => setDiffFilter('matched_same')}
-                />
+            </div>
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+              <div className="rounded-md border border-border bg-surface-subtle p-3">
+                <p className="text-xs text-fg-muted uppercase tracking-wide">
+                  Already optimal
+                </p>
+                <p className="text-3xl font-semibold text-fg font-tabular mt-1">
+                  {diff.health.match_rate_pct}%
+                </p>
+                <p className="text-xs text-fg-muted mt-1">
+                  {diff.health.visits_already_optimal} of {diff.health.total_evaluated} visits
+                  match the engine's date.
+                </p>
+              </div>
+              <div className="rounded-md border border-border bg-surface-subtle p-3">
+                <p className="text-xs text-fg-muted uppercase tracking-wide">
+                  Optimized utilization
+                </p>
+                <p className="text-3xl font-semibold text-fg font-tabular mt-1">
+                  {diff.health.optimized_utilization_pct}%
+                </p>
+                <p className="text-xs text-fg-muted mt-1">
+                  {diff.health.optimized_total_hours.toFixed(1)} work hours scheduled across{' '}
+                  {diff.health.optimized_workday_count} crew-days
+                  {diff.health.optimized_idle_days > 0
+                    ? ` (${diff.health.optimized_idle_days} idle)`
+                    : ''}
+                  .
+                </p>
+              </div>
+              <div className="rounded-md border border-border bg-surface-subtle p-3">
+                <p className="text-xs text-fg-muted uppercase tracking-wide">
+                  Changes proposed
+                </p>
+                <p className="text-3xl font-semibold text-fg font-tabular mt-1">
+                  {diff.health.visits_to_move +
+                    diff.health.visits_to_add +
+                    diff.health.visits_to_remove}
+                </p>
+                <p className="text-xs text-fg-muted mt-1">
+                  {diff.health.visits_to_move} move · {diff.health.visits_to_add} add ·{' '}
+                  {diff.health.visits_to_remove} skip
+                </p>
               </div>
             </div>
-            <DiffTable
-              rows={(() => {
-                if (diffFilter === 'all_actionable') {
-                  return diff.diff.filter((r) => r.status !== 'matched_same')
-                }
-                return diff.diff.filter((r) => r.status === diffFilter)
-              })()}
-              onChoice={setHybridChoice}
-            />
           </Card>
         )}
 
-        {/* Step 5: Detected constraints */}
-        <Card className="space-y-3">
-          <div className="flex items-center justify-between gap-2 flex-wrap">
-            <CardTitle>Detected constraints</CardTitle>
-            <Button size="sm" variant="secondary" onClick={runDetection} loading={detecting}>
-              {detections.length === 0 ? 'Detect constraints' : 'Re-detect'}
-            </Button>
-          </div>
-          <p className="text-sm text-fg-muted">
-            Patterns the upload reveals — day-of-week avoidance, recurring
-            pairs, crew/branch geographic affinity. Per-property patterns
-            require 2+ files for confidence (a single 6-month or annual
-            cycle has too few samples).
-          </p>
-          {detections.length > 0 ? (
+        {/* Step 4b: Recommendations — actionable, ranked, one-click apply */}
+        {diff?.recommendations && diff.recommendations.length > 0 && (
+          <Card className="space-y-3">
+            <CardTitle>Recommendations</CardTitle>
+            <p className="text-xs text-fg-muted">
+              Each entry batches a group of moves the engine wants to make.
+              "Apply" sets the per-row hybrid choice for every visit in the
+              group; you can still tweak individual rows in the detail table
+              below.
+            </p>
             <ul className="space-y-2">
+              {diff.recommendations.map((rec) => {
+                const allRowsHaveChoice = rec.affected_keys.every((key) =>
+                  diff.diff.some(
+                    (r) => r.hybrid_key === key && r.hybrid_choice === rec.apply_choice
+                  )
+                )
+                return (
+                  <li
+                    key={rec.id}
+                    className="rounded-md border border-border bg-surface p-3 flex items-start justify-between gap-3"
+                  >
+                    <div className="space-y-1 min-w-0">
+                      <p className="text-sm font-medium text-fg">{rec.title}</p>
+                      <p className="text-xs text-fg-muted">{rec.description}</p>
+                    </div>
+                    <Button
+                      size="sm"
+                      variant={allRowsHaveChoice ? 'secondary' : 'primary'}
+                      onClick={() => applyRecommendation(rec)}
+                    >
+                      {allRowsHaveChoice ? 'Applied' : 'Apply'}
+                    </Button>
+                  </li>
+                )
+              })}
+            </ul>
+          </Card>
+        )}
+
+        {/* Step 4c: Detail diff table — collapsed by default. */}
+        {diff && (
+          <Card padding="none" className="overflow-hidden">
+            <button
+              type="button"
+              onClick={() => setShowAllDiffRows((v) => !v)}
+              className="w-full px-4 py-3 border-b border-border flex items-center justify-between text-left hover:bg-surface-subtle transition-colors"
+            >
+              <div>
+                <p className="font-medium text-fg">
+                  {showAllDiffRows ? 'Hide' : 'Show'} per-visit detail (
+                  {diff.counts.only_current +
+                    diff.counts.only_optimized +
+                    diff.counts.moved_date +
+                    diff.counts.matched_same}{' '}
+                  rows)
+                </p>
+                <p className="text-xs text-fg-muted mt-0.5">
+                  Edit individual visit choices instead of applying a whole
+                  recommendation.
+                </p>
+              </div>
+              <span className="text-fg-muted text-sm">{showAllDiffRows ? '▾' : '▸'}</span>
+            </button>
+            {showAllDiffRows && (
+              <>
+                <div className="px-4 py-3 border-b border-border">
+                  <div className="flex flex-wrap gap-2">
+                    <FilterChip
+                      label={`All actionable (${diff.counts.only_current + diff.counts.only_optimized + diff.counts.moved_date})`}
+                      active={diffFilter === 'all_actionable'}
+                      onClick={() => setDiffFilter('all_actionable')}
+                    />
+                    <FilterChip
+                      label={`Only on current (${diff.counts.only_current})`}
+                      active={diffFilter === 'only_current'}
+                      onClick={() => setDiffFilter('only_current')}
+                    />
+                    <FilterChip
+                      label={`Only on optimized (${diff.counts.only_optimized})`}
+                      active={diffFilter === 'only_optimized'}
+                      onClick={() => setDiffFilter('only_optimized')}
+                    />
+                    <FilterChip
+                      label={`Moved date (${diff.counts.moved_date})`}
+                      active={diffFilter === 'moved_date'}
+                      onClick={() => setDiffFilter('moved_date')}
+                    />
+                    <FilterChip
+                      label={`Same (${diff.counts.matched_same})`}
+                      active={diffFilter === 'matched_same'}
+                      onClick={() => setDiffFilter('matched_same')}
+                    />
+                  </div>
+                </div>
+                <DiffTable
+                  rows={(() => {
+                    if (diffFilter === 'all_actionable') {
+                      return diff.diff.filter((r) => r.status !== 'matched_same')
+                    }
+                    return diff.diff.filter((r) => r.status === diffFilter)
+                  })()}
+                  onChoice={setHybridChoice}
+                />
+              </>
+            )}
+          </Card>
+        )}
+
+        {/* Step 5: Detected constraints — collapsed callout */}
+        <Card className="space-y-2">
+          <div className="flex items-center justify-between gap-2 flex-wrap">
+            <div>
+              <CardTitle>Detected constraints</CardTitle>
+              <p className="text-xs text-fg-muted mt-0.5">
+                {detections.length > 0
+                  ? `${detections.length} pattern${detections.length === 1 ? '' : 's'} detected — ${detections.filter((d) => d.status === 'accepted').length} accepted, ${detections.filter((d) => d.status === 'rejected').length} rejected, ${detections.filter((d) => d.status === 'detected' || d.status === 'edited').length} pending review.`
+                  : 'Day-of-week patterns, recurring pairs, crew/branch affinity. Click to detect.'}
+              </p>
+            </div>
+            <div className="flex items-center gap-2">
+              <Button size="sm" variant="secondary" onClick={runDetection} loading={detecting}>
+                {detections.length === 0 ? 'Detect' : 'Re-detect'}
+              </Button>
+              {detections.length > 0 && (
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={() => setShowConstraintsList((v) => !v)}
+                >
+                  {showConstraintsList ? 'Hide' : 'Review'}
+                </Button>
+              )}
+            </div>
+          </div>
+          {showConstraintsList && detections.length > 0 && (
+            <ul className="space-y-2 pt-1">
               {detections.map((d) => (
                 <li
                   key={d.id}
@@ -1467,11 +1652,6 @@ export default function ScheduleAssessmentDetailPage() {
                 </li>
               ))}
             </ul>
-          ) : (
-            <p className="text-xs text-fg-subtle italic">
-              No detections yet. Click "Detect constraints" once your matches
-              are resolved.
-            </p>
           )}
         </Card>
 


### PR DESCRIPTION
## Summary
The diff page led with a row-level "Current vs Optimized" table and never answered "is my schedule any good?" or "what should I actually do?". Operator had to scan hundreds of rows to extract the pattern.

Reframe the layout around three surfaces, in order:

1. **Schedule health card** — three KPIs at the top:
   - Already optimal: % of evaluated visits already on the engine's date
   - Optimized utilization: building-day utilization across the cycle's crew-days, with total work hours + idle days
   - Changes proposed: total visits to move/add/skip

2. **Recommendations list** — actionable, ranked, one-click apply. Date moves are grouped by (from → to) so "move 6 visits Mon → Thu" is one entry, not 6 rows. "Apply" PATCHes the hybrid endpoint for every affected row at once; the button flips to "Applied" once every row in the group has the recommended choice.

3. **Per-visit diff table** — collapsed behind a toggle. Filter chips + DiffTable preserved for power users who want per-row edits.

4. **Detected constraints** — small callout with count + status breakdown; accept/reject list lives behind a "Review" toggle.

Backend: GET /diff returns \`health\` (counts + utilization via \`computeCrewUtilization\`) and \`recommendations\` (grouped move-date / add / remove buckets with \`hybrid_keys\` ready for bulk PATCH). Each diff row now carries its own \`hybrid_key\` so the frontend doesn't have to re-derive it.

## Test plan
- [ ] Run "Generate diff" on an assessment with a baseline template
- [ ] Confirm health card shows match-rate %, optimized utilization %, and changes-proposed total
- [ ] Confirm recommendations list shows grouped moves with sensible date labels (e.g. "Mon Apr 4 → Thu Apr 8")
- [ ] Click "Apply" on a recommendation; confirm all affected rows get the choice and the button flips to "Applied"
- [ ] Toggle "Show per-visit detail"; confirm the old DiffTable + filter chips still work and individual row choices still update
- [ ] Toggle "Review" on detected constraints; confirm accept/reject still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)