### PR TITLE
Upload calendar with sqft + coach honors full date range

### DIFF
--- a/api/v1/schedule-assessments/[id]/calendar.ts
+++ b/api/v1/schedule-assessments/[id]/calendar.ts
@@ -1,0 +1,158 @@
+// GET /api/v1/schedule-assessments/[id]/calendar
+//
+// Returns the uploaded schedule organized by date, with each visit's
+// service location address + serviceable_sqft attached. The schedule
+// assessment UI uses this to render a month-grid calendar so the
+// operator can see, at a glance, which days are stacked with large
+// buildings vs days with many small ones — the difference between
+// "one crew can absorb this" and "we need a second crew."
+//
+// Output:
+//   {
+//     summary: {
+//       start_date, end_date, day_count, visit_count,
+//       total_sqft, max_daily_sqft, max_daily_visits
+//     },
+//     days: [
+//       {
+//         date: "2026-04-04",
+//         dow: "Mon",
+//         visits: [{ row_id, sl_id, display_name, address, crew_name, sqft, lat, lng }],
+//         total_sqft, visit_count, distinct_crews
+//       }
+//     ]
+//   }
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { createAdminClient } from '../../../_lib/supabase.js'
+import { authenticateRequest } from '../../../_lib/auth.js'
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'GET') return res.status(405).json({ error: 'Method not allowed' })
+  try { await authenticateRequest(req) } catch (err: any) {
+    return res.status(err.statusCode ?? 401).json({ error: err.message ?? 'Unauthorized' })
+  }
+  const id = req.query.id as string
+  const db = createAdminClient()
+
+  const { data: assessment } = await db
+    .from('schedule_assessments')
+    .select('id')
+    .eq('id', id)
+    .maybeSingle()
+  if (!assessment) return res.status(404).json({ error: 'Assessment not found' })
+
+  // Pull all matched rows. Join the SL → property so we can render
+  // address + lat/lng, and the SL itself for serviceable_sqft.
+  const PAGE = 1000
+  type RawRow = {
+    id: string
+    raw_address: string
+    raw_scheduled_date: string | null
+    raw_crew_name: string | null
+    matched_service_location_id: string | null
+    service_locations:
+      | {
+          id: string
+          display_name: string | null
+          serviceable_sqft: number | null
+          property: {
+            address_line1: string | null
+            latitude: number | null
+            longitude: number | null
+          } | null
+        }
+      | null
+  }
+  const rows: RawRow[] = []
+  for (let p = 0; p < 50; p++) {
+    const { data } = await db
+      .from('schedule_assessment_rows')
+      .select(
+        'id, raw_address, raw_scheduled_date, raw_crew_name, matched_service_location_id, ' +
+          'service_locations(id, display_name, serviceable_sqft, property:properties(address_line1, latitude, longitude))'
+      )
+      .eq('assessment_id', id)
+      .in('match_status', ['auto', 'manual'])
+      .not('matched_service_location_id', 'is', null)
+      .not('raw_scheduled_date', 'is', null)
+      .range(p * PAGE, p * PAGE + PAGE - 1)
+    const arr = (data ?? []) as any[]
+    rows.push(...(arr as RawRow[]))
+    if (arr.length < PAGE) break
+  }
+
+  // Group by date.
+  type DayVisit = {
+    row_id: string
+    sl_id: string | null
+    display_name: string | null
+    address: string | null
+    crew_name: string | null
+    sqft: number | null
+    lat: number | null
+    lng: number | null
+  }
+  type Day = {
+    date: string
+    dow: string
+    visits: DayVisit[]
+    total_sqft: number
+    visit_count: number
+    distinct_crews: number
+  }
+  const dowNames = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
+  const byDate = new Map<string, Day>()
+  for (const r of rows) {
+    const date = r.raw_scheduled_date as string
+    let day = byDate.get(date)
+    if (!day) {
+      const dt = new Date(date + 'T00:00:00Z')
+      day = {
+        date,
+        dow: !Number.isNaN(dt.getTime()) ? dowNames[dt.getUTCDay()] : '?',
+        visits: [],
+        total_sqft: 0,
+        visit_count: 0,
+        distinct_crews: 0,
+      }
+      byDate.set(date, day)
+    }
+    const sl = r.service_locations
+    const sqft = sl?.serviceable_sqft ?? null
+    day.visits.push({
+      row_id: r.id,
+      sl_id: r.matched_service_location_id,
+      display_name: sl?.display_name ?? null,
+      address: sl?.property?.address_line1 ?? r.raw_address ?? null,
+      crew_name: r.raw_crew_name ?? null,
+      sqft,
+      lat: sl?.property?.latitude ?? null,
+      lng: sl?.property?.longitude ?? null,
+    })
+    day.visit_count++
+    if (typeof sqft === 'number') day.total_sqft += sqft
+  }
+  for (const day of byDate.values()) {
+    const crews = new Set(day.visits.map((v) => (v.crew_name ?? '').trim().toLowerCase()).filter(Boolean))
+    day.distinct_crews = crews.size
+    day.visits.sort((a, b) => (b.sqft ?? 0) - (a.sqft ?? 0))
+  }
+
+  const days = Array.from(byDate.values()).sort((a, b) => a.date.localeCompare(b.date))
+  const totalSqft = days.reduce((s, d) => s + d.total_sqft, 0)
+  const maxDailySqft = days.reduce((m, d) => Math.max(m, d.total_sqft), 0)
+  const maxDailyVisits = days.reduce((m, d) => Math.max(m, d.visit_count), 0)
+
+  return res.status(200).json({
+    summary: {
+      start_date: days[0]?.date ?? null,
+      end_date: days[days.length - 1]?.date ?? null,
+      day_count: days.length,
+      visit_count: rows.length,
+      total_sqft: totalSqft,
+      max_daily_sqft: maxDailySqft,
+      max_daily_visits: maxDailyVisits,
+    },
+    days,
+  })
+}

--- a/api/v1/schedule-assessments/[id]/coach.ts
+++ b/api/v1/schedule-assessments/[id]/coach.ts
@@ -58,19 +58,26 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (!assessment) return res.status(404).json({ error: 'Assessment not found' })
   const a = assessment as any
 
-  // Pull all matched rows + property coords.
+  // Pull ALL rows that have a scheduled date. The previous filter
+  // (match_status IN auto/manual) excluded unmatched rows, which made
+  // the coach narrate the wrong date envelope when chunks of the
+  // upload were "not in portfolio" — e.g. an upload starting in
+  // January would appear to start in late May because January's
+  // properties weren't yet in the portfolio.
+  // For per-property stats (crew/geo) we still need the SL join, so
+  // matched rows carry the property; unmatched rows just contribute
+  // their date to the daily-volume math.
   const PAGE = 1000
   const rows: Row[] = []
   for (let p = 0; p < 50; p++) {
     const { data } = await db
       .from('schedule_assessment_rows')
       .select(
-        'raw_scheduled_date, raw_crew_name, matched_service_location_id, ' +
+        'raw_scheduled_date, raw_crew_name, matched_service_location_id, match_status, ' +
           'service_locations(property:properties(latitude, longitude, address_line1))'
       )
       .eq('assessment_id', id)
-      .in('match_status', ['auto', 'manual'])
-      .not('matched_service_location_id', 'is', null)
+      .not('raw_scheduled_date', 'is', null)
       .range(p * PAGE, p * PAGE + PAGE - 1)
     const arr = (data ?? []) as any[]
     for (const r of arr) {
@@ -91,20 +98,31 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   }
   if (rows.length === 0) {
     return res.status(400).json({
-      error: 'No matched rows yet — finish geocoding/matching before asking for coaching.',
+      error: 'No rows with scheduled dates yet — upload a schedule first.',
     })
   }
+  // Matched-only subset for per-property stats that need the SL join.
+  const matchedRows = rows.filter((r) => r.matched_service_location_id && r.property)
 
   // ---- Current schedule stats ----
+  // Date envelope + daily volumes use ALL rows with a date (matched
+  // and unmatched). The user uploaded the schedule; the entire date
+  // range is the schedule, regardless of which properties are in the
+  // portfolio yet.
   const dateValues = rows.map((r) => r.raw_scheduled_date).filter((d): d is string => !!d)
   const startDate = dateValues.length > 0 ? dateValues.reduce((a, b) => (a < b ? a : b)) : null
   const endDate = dateValues.length > 0 ? dateValues.reduce((a, b) => (a > b ? a : b)) : null
   const visitCount = rows.length
-  const distinctProperties = new Set(rows.map((r) => r.matched_service_location_id)).size
+  const matchedVisitCount = matchedRows.length
+  const distinctProperties = new Set(
+    matchedRows.map((r) => r.matched_service_location_id).filter(Boolean)
+  ).size
 
-  // Crew breakdown.
+  // Crew breakdown — matched rows only since unmatched rows often
+  // share the same Unassigned default and would skew the per-crew
+  // counts unhelpfully.
   const byCrew = new Map<string, Row[]>()
-  for (const r of rows) {
+  for (const r of matchedRows) {
     const k = (r.raw_crew_name ?? 'Unassigned').trim() || 'Unassigned'
     const arr = byCrew.get(k) ?? []
     arr.push(r)
@@ -117,9 +135,9 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     })
     .sort((a, b) => b.visits - a.visits)
 
-  // Workload per (crew, day).
+  // Workload per (crew, day) — matched rows only.
   const dayLoad = new Map<string, number>() // "crew|date" → visit count
-  for (const r of rows) {
+  for (const r of matchedRows) {
     if (!r.raw_scheduled_date) continue
     const k = `${r.raw_crew_name ?? 'Unassigned'}|${r.raw_scheduled_date}`
     dayLoad.set(k, (dayLoad.get(k) ?? 0) + 1)
@@ -181,9 +199,10 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
   // Geographic cohesion: for each (crew, day) with multiple visits,
   // compute the avg pairwise distance. Lower → tighter clustering.
+  // Matched rows only (need property coords).
   const clusterMiles: number[] = []
   const cdGroups = new Map<string, Row[]>()
-  for (const r of rows) {
+  for (const r of matchedRows) {
     if (!r.raw_scheduled_date) continue
     const k = `${r.raw_crew_name ?? 'Unassigned'}|${r.raw_scheduled_date}`
     const arr = cdGroups.get(k) ?? []
@@ -274,6 +293,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       cycle_start: startDate,
       cycle_end: endDate,
       visit_count: visitCount,
+      matched_visit_count: matchedVisitCount,
+      unmatched_visit_count: visitCount - matchedVisitCount,
       distinct_properties: distinctProperties,
       workday_count: workdayCount,
       // Crew column status — coach needs to know if it should infer

--- a/src/components/scheduler/ScheduleAssessmentCalendar.tsx
+++ b/src/components/scheduler/ScheduleAssessmentCalendar.tsx
@@ -1,0 +1,237 @@
+// Calendar view for an uploaded schedule assessment. Month grid where
+// each day cell shows visit count + total square footage so the
+// operator can tell at a glance which days are heavy by *footprint*
+// (one big building → maybe one crew can absorb it) vs heavy by
+// *count* (many small buildings → potentially needs a second crew).
+//
+// Click a day to expand a list of properties for that day with their
+// individual sqft. Sqft is also reflected as a color heat scale on
+// the cell itself relative to the busiest day in the upload.
+import { useMemo, useState } from 'react'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
+import Button from '../ui/Button'
+import { cn } from '../../lib/cn'
+
+export interface CalendarVisit {
+  row_id: string
+  sl_id: string | null
+  display_name: string | null
+  address: string | null
+  crew_name: string | null
+  sqft: number | null
+  lat: number | null
+  lng: number | null
+}
+export interface CalendarDay {
+  date: string
+  dow: string
+  visits: CalendarVisit[]
+  total_sqft: number
+  visit_count: number
+  distinct_crews: number
+}
+export interface CalendarSummary {
+  start_date: string | null
+  end_date: string | null
+  day_count: number
+  visit_count: number
+  total_sqft: number
+  max_daily_sqft: number
+  max_daily_visits: number
+}
+
+interface Props {
+  days: CalendarDay[]
+  summary: CalendarSummary
+}
+
+const MONTH_NAMES = [
+  'January', 'February', 'March', 'April', 'May', 'June',
+  'July', 'August', 'September', 'October', 'November', 'December',
+]
+const DOW_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
+
+function fmtSqft(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(2)}M`
+  if (n >= 1_000) return `${(n / 1_000).toFixed(0)}k`
+  return `${n}`
+}
+
+export default function ScheduleAssessmentCalendar({ days, summary }: Props) {
+  const dayByDate = useMemo(() => {
+    const m = new Map<string, CalendarDay>()
+    for (const d of days) m.set(d.date, d)
+    return m
+  }, [days])
+
+  const months = useMemo(() => {
+    const set = new Set<string>()
+    for (const d of days) set.add(d.date.slice(0, 7))
+    return Array.from(set).sort()
+  }, [days])
+
+  const [monthIndex, setMonthIndex] = useState(0)
+  const [expandedDate, setExpandedDate] = useState<string | null>(null)
+
+  if (months.length === 0) {
+    return (
+      <div className="rounded-md border border-border bg-surface p-6 text-sm text-fg-muted">
+        No matched rows with scheduled dates yet.
+      </div>
+    )
+  }
+
+  const currentMonthKey = months[Math.min(monthIndex, months.length - 1)]
+  const [year, month] = currentMonthKey.split('-').map(Number)
+  const firstDay = new Date(Date.UTC(year, month - 1, 1))
+  const padBefore = firstDay.getUTCDay()
+  const daysInMonth = new Date(Date.UTC(year, month, 0)).getUTCDate()
+  const cells: Array<{ date: string | null; dom: number | null }> = []
+  for (let i = 0; i < padBefore; i++) cells.push({ date: null, dom: null })
+  for (let d = 1; d <= daysInMonth; d++) {
+    const dt = new Date(Date.UTC(year, month - 1, d)).toISOString().slice(0, 10)
+    cells.push({ date: dt, dom: d })
+  }
+  while (cells.length % 7 !== 0) cells.push({ date: null, dom: null })
+
+  const expanded = expandedDate ? dayByDate.get(expandedDate) ?? null : null
+
+  // Heat scale based on sqft relative to the cycle's busiest day. Steps
+  // approximate quartiles so the worst day stands out.
+  const heatClass = (sqft: number): string => {
+    if (sqft <= 0 || summary.max_daily_sqft <= 0) return ''
+    const ratio = sqft / summary.max_daily_sqft
+    if (ratio >= 0.85) return 'bg-rose-500/15 border-rose-400/50'
+    if (ratio >= 0.6) return 'bg-amber-500/15 border-amber-400/50'
+    if (ratio >= 0.35) return 'bg-yellow-500/10 border-yellow-400/40'
+    return 'bg-emerald-500/10 border-emerald-400/30'
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 text-xs">
+        <div className="rounded-md border border-border bg-surface-subtle px-3 py-2">
+          <p className="text-fg-muted uppercase tracking-wide">Workdays</p>
+          <p className="text-base font-semibold text-fg font-tabular">{summary.day_count}</p>
+        </div>
+        <div className="rounded-md border border-border bg-surface-subtle px-3 py-2">
+          <p className="text-fg-muted uppercase tracking-wide">Total visits</p>
+          <p className="text-base font-semibold text-fg font-tabular">{summary.visit_count}</p>
+        </div>
+        <div className="rounded-md border border-border bg-surface-subtle px-3 py-2">
+          <p className="text-fg-muted uppercase tracking-wide">Total sqft</p>
+          <p className="text-base font-semibold text-fg font-tabular">{fmtSqft(summary.total_sqft)}</p>
+        </div>
+        <div className="rounded-md border border-border bg-surface-subtle px-3 py-2">
+          <p className="text-fg-muted uppercase tracking-wide">Peak day</p>
+          <p className="text-base font-semibold text-fg font-tabular">
+            {summary.max_daily_visits} visits · {fmtSqft(summary.max_daily_sqft)}
+          </p>
+        </div>
+      </div>
+
+      <div className="rounded-md border border-border bg-surface overflow-hidden">
+        <div className="flex items-center justify-between border-b border-border px-3 py-2 bg-surface-subtle">
+          <Button
+            size="sm"
+            variant="ghost"
+            disabled={monthIndex === 0}
+            onClick={() => setMonthIndex((i) => Math.max(0, i - 1))}
+          >
+            <ChevronLeft className="size-4" />
+          </Button>
+          <p className="text-sm font-medium text-fg">
+            {MONTH_NAMES[month - 1]} {year}
+          </p>
+          <Button
+            size="sm"
+            variant="ghost"
+            disabled={monthIndex >= months.length - 1}
+            onClick={() => setMonthIndex((i) => Math.min(months.length - 1, i + 1))}
+          >
+            <ChevronRight className="size-4" />
+          </Button>
+        </div>
+        <div className="grid grid-cols-7 border-b border-border bg-surface-subtle text-[10px] text-fg-muted uppercase tracking-wide">
+          {DOW_LABELS.map((d) => (
+            <div key={d} className="px-2 py-1 text-center">{d}</div>
+          ))}
+        </div>
+        <div className="grid grid-cols-7">
+          {cells.map((c, i) => {
+            const day = c.date ? dayByDate.get(c.date) : null
+            const isExpanded = !!day && expandedDate === c.date
+            return (
+              <button
+                key={i}
+                type="button"
+                disabled={!day}
+                onClick={() => day && setExpandedDate(isExpanded ? null : c.date)}
+                className={cn(
+                  'min-h-[78px] border-b border-r border-border p-1.5 text-left text-xs transition-colors',
+                  !c.date && 'bg-surface-subtle/40',
+                  day && heatClass(day.total_sqft),
+                  day && 'hover:bg-surface-muted/60 cursor-pointer',
+                  isExpanded && 'ring-2 ring-accent ring-inset'
+                )}
+              >
+                {c.dom && (
+                  <div className="text-fg-muted text-[10px] font-tabular">{c.dom}</div>
+                )}
+                {day && (
+                  <div className="space-y-0.5 mt-0.5">
+                    <p className="text-fg font-medium font-tabular">
+                      {day.visit_count} visit{day.visit_count === 1 ? '' : 's'}
+                    </p>
+                    <p className="text-fg-muted font-tabular">
+                      {day.total_sqft > 0 ? fmtSqft(day.total_sqft) + ' sqft' : '—'}
+                    </p>
+                    {day.distinct_crews > 0 && (
+                      <p className="text-fg-subtle text-[10px]">
+                        {day.distinct_crews} crew{day.distinct_crews === 1 ? '' : 's'}
+                      </p>
+                    )}
+                  </div>
+                )}
+              </button>
+            )
+          })}
+        </div>
+      </div>
+
+      {expanded && (
+        <div className="rounded-md border border-border bg-surface p-3">
+          <div className="flex items-center justify-between mb-2">
+            <p className="text-sm font-medium text-fg">
+              {expanded.dow} {expanded.date} — {expanded.visit_count} visit
+              {expanded.visit_count === 1 ? '' : 's'}
+              {expanded.total_sqft > 0 ? ` · ${fmtSqft(expanded.total_sqft)} sqft` : ''}
+            </p>
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={() => setExpandedDate(null)}
+            >
+              Close
+            </Button>
+          </div>
+          <ul className="divide-y divide-border">
+            {expanded.visits.map((v) => (
+              <li key={v.row_id} className="py-1.5 flex items-baseline gap-3 text-xs">
+                <span className="font-tabular text-fg-muted shrink-0 w-20 text-right">
+                  {v.sqft != null ? fmtSqft(v.sqft) + ' sqft' : '—'}
+                </span>
+                <span className="text-fg flex-1 truncate">
+                  {v.address ?? v.display_name ?? '(unnamed)'}
+                </span>
+                {v.crew_name && (
+                  <span className="text-fg-subtle shrink-0">{v.crew_name}</span>
+                )}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/pages/accounts/scheduler/ScheduleAssessmentDetail.tsx
+++ b/src/pages/accounts/scheduler/ScheduleAssessmentDetail.tsx
@@ -7,6 +7,10 @@ import { useAuth } from '../../../hooks/useAuth'
 import AppShell from '../../../components/layout/AppShell'
 import Button from '../../../components/ui/Button'
 import { Card, CardTitle } from '../../../components/ui/Card'
+import ScheduleAssessmentCalendar, {
+  type CalendarDay,
+  type CalendarSummary,
+} from '../../../components/scheduler/ScheduleAssessmentCalendar'
 import { Badge } from '../../../components/ui/Badge'
 import { Input, FormField, Textarea } from '../../../components/ui/Input'
 import {
@@ -170,6 +174,10 @@ export default function ScheduleAssessmentDetailPage() {
   const [coachNarrative, setCoachNarrative] = useState<string | null>(null)
   const [coachLoading, setCoachLoading] = useState(false)
   const [coachError, setCoachError] = useState<string | null>(null)
+  const [calendarDays, setCalendarDays] = useState<CalendarDay[] | null>(null)
+  const [calendarSummary, setCalendarSummary] = useState<CalendarSummary | null>(null)
+  const [calendarLoading, setCalendarLoading] = useState(false)
+  const [calendarError, setCalendarError] = useState<string | null>(null)
   const [diffFilter, setDiffFilter] = useState<DiffStatus | 'all_actionable'>('all_actionable')
   const [detections, setDetections] = useState<DetectedConstraint[]>([])
   const [detecting, setDetecting] = useState(false)
@@ -256,6 +264,38 @@ export default function ScheduleAssessmentDetailPage() {
       setDiffLoading(false)
     }
   }
+
+  // Calendar view of the upload — month grid with visit counts and
+  // total sqft per day so the operator can see at a glance whether a
+  // heavy day is one big building or many small ones.
+  const loadCalendar = useCallback(async () => {
+    if (!id) return
+    setCalendarLoading(true)
+    setCalendarError(null)
+    try {
+      const token = await getToken()
+      const res = await fetch(`/api/v1/schedule-assessments/${id}/calendar`, {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      const j = await res.json()
+      if (!res.ok) throw new Error(j.error ?? `Calendar failed (${res.status})`)
+      setCalendarDays(j.days as CalendarDay[])
+      setCalendarSummary(j.summary as CalendarSummary)
+    } catch (err) {
+      setCalendarError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setCalendarLoading(false)
+    }
+  }, [id, getToken])
+
+  // Auto-load the calendar when matched rows are present so the operator
+  // sees the upload visualization without an extra click.
+  useEffect(() => {
+    if (!id) return
+    if (rows.some((r) => r.match_status === 'auto' || r.match_status === 'manual')) {
+      void loadCalendar()
+    }
+  }, [id, rows, loadCalendar])
 
   // Ask the AI coach for a narrative review of the upload. Doesn't
   // require a baseline_template_id — coach gives schedule-on-its-own
@@ -1449,6 +1489,31 @@ export default function ScheduleAssessmentDetailPage() {
             </Button>
           </div>
         </Card>
+
+        {/* Step 4a: Calendar view of the upload — visit counts + sqft
+            per day, so the operator can tell at a glance whether a heavy
+            day is one big building or many small ones. */}
+        {(calendarDays && calendarSummary && calendarSummary.day_count > 0) || calendarLoading ? (
+          <Card className="space-y-3">
+            <div className="flex items-start justify-between gap-3 flex-wrap">
+              <div>
+                <CardTitle>Upload calendar</CardTitle>
+                <p className="text-xs text-fg-muted mt-0.5">
+                  Each cell shows visit count and total square footage for that day.
+                  Color heat reflects sqft relative to your busiest day. Click a
+                  day to see the property list.
+                </p>
+              </div>
+              {calendarLoading && (
+                <p className="text-xs text-fg-muted italic">Loading…</p>
+              )}
+            </div>
+            {calendarError && <p className="text-sm text-danger">{calendarError}</p>}
+            {calendarDays && calendarSummary && (
+              <ScheduleAssessmentCalendar days={calendarDays} summary={calendarSummary} />
+            )}
+          </Card>
+        ) : null}
 
         {/* Step 4: Coach narrative — AI-written feedback on the upload */}
         <Card className="space-y-3">


### PR DESCRIPTION
## Summary
Two issues:
1. Operator wanted a calendar visualization of the upload with square footage so they could distinguish "one big building" from "many small buildings" on heavy days — the difference between a single crew absorbing the load and needing to add a crew.
2. Coach was narrating a truncated date range (e.g. late May → Dec when the upload starts in January). Cause: coach filtered to \`match_status IN ('auto','manual')\` and dropped rows whose properties weren't yet in the portfolio.

## Changes
**Calendar endpoint** — \`GET /api/v1/schedule-assessments/[id]/calendar\` returns the upload organized by date with each visit's address + \`serviceable_sqft\` joined through \`service_location → properties\`. Per-day totals (sqft, visits, distinct crews) and a summary block (workdays, total sqft, peak day, max-daily-visits).

**Calendar component** — month grid with cells showing visit count + total sqft, color heat scaled to peak day, expand-on-click property list with individual sqft. Auto-loads when matched rows exist; sits above the coach card on the assessment detail page.

**Coach fix** — pull ALL rows with a \`scheduled_date\` (regardless of match_status) for the date envelope and daily-volume math. Reserve the matched-only filter for stats that need the SL/property join (crew breakdown, geo cohesion). Surface \`matched_visit_count\` and \`unmatched_visit_count\` in stats so the LLM can describe how much of the schedule is matched vs still awaiting portfolio additions.

## Test plan
- [ ] After matching, confirm the calendar card appears with the correct workday count and date range
- [ ] Click a day to confirm the property list expands with sqft per property
- [ ] Confirm color heat reflects the busiest day
- [ ] Run "Generate diff" → the coach narrative should now reflect the full upload date range, not just the matched-row subset
- [ ] If some rows are still unmatched, confirm the coach can still narrate the full date envelope (and ideally calls out the matched-vs-unmatched split)

🤖 Generated with [Claude Code](https://claude.com/claude-code)