### PR TITLE
Guard implausible years + richer calendar property list

### DIFF
--- a/api/_lib/schedule-assessment/parse-csv.ts
+++ b/api/_lib/schedule-assessment/parse-csv.ts
@@ -129,12 +129,21 @@ function normalizeHeader(h: string): HeaderInfo {
   return { semantic: null, visit_index: null, raw }
 }
 
+// Guard against years outside what a real schedule could plausibly
+// hold. Year 1016 sneaking through (e.g. from a stray ISO-shaped
+// string in a non-date column) wrecks the calendar and coach.
+function plausibleYear(y: number): boolean {
+  return Number.isFinite(y) && y >= 1900 && y <= 2200
+}
+
 function parseDate(s: string): string | null {
   const trimmed = s.trim()
   if (!trimmed) return null
   // ISO YYYY-MM-DD.
   const iso = /^(\d{4})-(\d{1,2})-(\d{1,2})/.exec(trimmed)
   if (iso) {
+    const yNum = Number(iso[1])
+    if (!plausibleYear(yNum)) return null
     const y = iso[1]
     const m = iso[2].padStart(2, '0')
     const d = iso[3].padStart(2, '0')
@@ -145,6 +154,8 @@ function parseDate(s: string): string | null {
   if (us) {
     let y = us[3]
     if (y.length === 2) y = `20${y}` // 2-digit assume current millennium
+    const yNum = Number(y)
+    if (!plausibleYear(yNum)) return null
     const m = us[1].padStart(2, '0')
     const d = us[2].padStart(2, '0')
     return `${y}-${m}-${d}`

--- a/api/v1/schedule-assessments/[id]/calendar.ts
+++ b/api/v1/schedule-assessments/[id]/calendar.ts
@@ -47,6 +47,9 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   type RawRow = {
     id: string
     raw_address: string
+    raw_city: string | null
+    raw_state: string | null
+    raw_postal_code: string | null
     raw_scheduled_date: string | null
     raw_crew_name: string | null
     matched_service_location_id: string | null
@@ -57,6 +60,9 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           serviceable_sqft: number | null
           property: {
             address_line1: string | null
+            city: string | null
+            state: string | null
+            postal_code: string | null
             latitude: number | null
             longitude: number | null
           } | null
@@ -68,8 +74,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     const { data } = await db
       .from('schedule_assessment_rows')
       .select(
-        'id, raw_address, raw_scheduled_date, raw_crew_name, matched_service_location_id, ' +
-          'service_locations(id, display_name, serviceable_sqft, property:properties(address_line1, latitude, longitude))'
+        'id, raw_address, raw_city, raw_state, raw_postal_code, raw_scheduled_date, raw_crew_name, matched_service_location_id, ' +
+          'service_locations(id, display_name, serviceable_sqft, property:properties(address_line1, city, state, postal_code, latitude, longitude))'
       )
       .eq('assessment_id', id)
       .in('match_status', ['auto', 'manual'])
@@ -81,12 +87,32 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     if (arr.length < PAGE) break
   }
 
+  // Skip rows whose stored date is implausible (year < 1900 or > 2200).
+  // Older parse-csv versions let strings like "1016-05-22" through and
+  // those rows would lock the calendar onto a medieval month. Count
+  // them so we can surface a warning.
+  const filteredRows: RawRow[] = []
+  let implausibleDateCount = 0
+  for (const r of rows) {
+    const d = r.raw_scheduled_date
+    if (!d) continue
+    const year = Number(d.slice(0, 4))
+    if (!Number.isFinite(year) || year < 1900 || year > 2200) {
+      implausibleDateCount++
+      continue
+    }
+    filteredRows.push(r)
+  }
+
   // Group by date.
   type DayVisit = {
     row_id: string
     sl_id: string | null
     display_name: string | null
     address: string | null
+    city: string | null
+    state: string | null
+    postal_code: string | null
     crew_name: string | null
     sqft: number | null
     lat: number | null
@@ -102,7 +128,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   }
   const dowNames = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
   const byDate = new Map<string, Day>()
-  for (const r of rows) {
+  for (const r of filteredRows) {
     const date = r.raw_scheduled_date as string
     let day = byDate.get(date)
     if (!day) {
@@ -124,6 +150,9 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       sl_id: r.matched_service_location_id,
       display_name: sl?.display_name ?? null,
       address: sl?.property?.address_line1 ?? r.raw_address ?? null,
+      city: sl?.property?.city ?? r.raw_city ?? null,
+      state: sl?.property?.state ?? r.raw_state ?? null,
+      postal_code: sl?.property?.postal_code ?? r.raw_postal_code ?? null,
       crew_name: r.raw_crew_name ?? null,
       sqft,
       lat: sl?.property?.latitude ?? null,
@@ -148,7 +177,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       start_date: days[0]?.date ?? null,
       end_date: days[days.length - 1]?.date ?? null,
       day_count: days.length,
-      visit_count: rows.length,
+      visit_count: filteredRows.length,
+      implausible_date_count: implausibleDateCount,
       total_sqft: totalSqft,
       max_daily_sqft: maxDailySqft,
       max_daily_visits: maxDailyVisits,

--- a/api/v1/schedule-assessments/[id]/coach.ts
+++ b/api/v1/schedule-assessments/[id]/coach.ts
@@ -96,11 +96,23 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     }
     if (arr.length < PAGE) break
   }
-  if (rows.length === 0) {
+  // Drop rows whose stored date isn't a plausible year. Old parse-csv
+  // versions let strings like "1016-05-22" through; those would
+  // dominate the min/max envelope.
+  const plausibleRows = rows.filter((r) => {
+    if (!r.raw_scheduled_date) return false
+    const year = Number(r.raw_scheduled_date.slice(0, 4))
+    return Number.isFinite(year) && year >= 1900 && year <= 2200
+  })
+  const implausibleDateCount = rows.length - plausibleRows.length
+  if (plausibleRows.length === 0) {
     return res.status(400).json({
-      error: 'No rows with scheduled dates yet — upload a schedule first.',
+      error: 'No rows with plausible scheduled dates yet — upload a schedule first.',
     })
   }
+  // Use plausible rows everywhere downstream.
+  rows.length = 0
+  rows.push(...plausibleRows)
   // Matched-only subset for per-property stats that need the SL join.
   const matchedRows = rows.filter((r) => r.matched_service_location_id && r.property)
 

--- a/src/components/scheduler/ScheduleAssessmentCalendar.tsx
+++ b/src/components/scheduler/ScheduleAssessmentCalendar.tsx
@@ -17,6 +17,9 @@ export interface CalendarVisit {
   sl_id: string | null
   display_name: string | null
   address: string | null
+  city: string | null
+  state: string | null
+  postal_code: string | null
   crew_name: string | null
   sqft: number | null
   lat: number | null
@@ -35,6 +38,7 @@ export interface CalendarSummary {
   end_date: string | null
   day_count: number
   visit_count: number
+  implausible_date_count?: number
   total_sqft: number
   max_daily_sqft: number
   max_daily_visits: number
@@ -216,19 +220,27 @@ export default function ScheduleAssessmentCalendar({ days, summary }: Props) {
             </Button>
           </div>
           <ul className="divide-y divide-border">
-            {expanded.visits.map((v) => (
-              <li key={v.row_id} className="py-1.5 flex items-baseline gap-3 text-xs">
-                <span className="font-tabular text-fg-muted shrink-0 w-20 text-right">
-                  {v.sqft != null ? fmtSqft(v.sqft) + ' sqft' : '—'}
-                </span>
-                <span className="text-fg flex-1 truncate">
-                  {v.address ?? v.display_name ?? '(unnamed)'}
-                </span>
-                {v.crew_name && (
-                  <span className="text-fg-subtle shrink-0">{v.crew_name}</span>
-                )}
-              </li>
-            ))}
+            {expanded.visits.map((v) => {
+              const cityState = [v.city, v.state, v.postal_code].filter(Boolean).join(', ')
+              return (
+                <li key={v.row_id} className="py-2 flex items-start gap-3 text-xs">
+                  <span className="font-tabular text-fg-muted shrink-0 w-24 text-right pt-0.5">
+                    {v.sqft != null ? fmtSqft(v.sqft) + ' sqft' : '—'}
+                  </span>
+                  <div className="flex-1 min-w-0">
+                    <p className="text-fg truncate">
+                      {v.address ?? v.display_name ?? '(unnamed)'}
+                    </p>
+                    {cityState && (
+                      <p className="text-fg-muted truncate">{cityState}</p>
+                    )}
+                  </div>
+                  {v.crew_name && (
+                    <span className="text-fg-subtle shrink-0 pt-0.5">{v.crew_name}</span>
+                  )}
+                </li>
+              )
+            })}
           </ul>
         </div>
       )}

--- a/src/pages/accounts/scheduler/ScheduleAssessmentDetail.tsx
+++ b/src/pages/accounts/scheduler/ScheduleAssessmentDetail.tsx
@@ -1509,6 +1509,13 @@ export default function ScheduleAssessmentDetailPage() {
               )}
             </div>
             {calendarError && <p className="text-sm text-danger">{calendarError}</p>}
+            {calendarSummary && (calendarSummary.implausible_date_count ?? 0) > 0 && (
+              <p className="text-xs text-warning bg-warning-subtle/30 border border-warning/40 rounded-md px-3 py-2">
+                {calendarSummary.implausible_date_count} row
+                {calendarSummary.implausible_date_count === 1 ? '' : 's'} had an
+                unrealistic year (outside 1900–2200) and {calendarSummary.implausible_date_count === 1 ? 'was' : 'were'} hidden from the calendar. This usually means a non-date column was mapped as a date — re-upload with the correct mapping to recover them.
+              </p>
+            )}
             {calendarDays && calendarSummary && (
               <ScheduleAssessmentCalendar days={calendarDays} summary={calendarSummary} />
             )}


### PR DESCRIPTION
## Summary
Two issues from the deployed build:
1. **Calendar opened on "May 1016"** with a single visit on May 22. A row had \`raw_scheduled_date\` stored as something like \`1016-05-22\` because parse-csv's ISO regex didn't validate the year. A non-date column with an ISO-shaped value slipped through.
2. **Expanded property list** in the calendar showed only the street address — no city, state, or sqft.

## Fixes
- \`parse-csv\`: ISO and US-format date branches now require year ∈ \[1900, 2200\] (Excel-serial and Date-constructor branches already had this).
- \`calendar\` endpoint: filters rows with implausible years defensively so existing bad data doesn't break the UI; returns \`summary.implausible_date_count\` for the warning surface.
- \`coach\` endpoint: same year filter on the rows used for date envelope + daily-volume math.
- Expanded property list: shows address + city/state/zip + sqft + crew name. Pulls properties.city/state/postal_code via the SL join and falls back to the row's raw_city/state/postal_code for unmatched rows.
- UI: warning callout above the calendar when implausible_date_count > 0, pointing to a probable column-mapping mistake.

## Test plan
- [ ] Reload the assessment with the existing 1016 row — calendar should now open on the next plausible month, and the warning callout should show "1 row had an unrealistic year".
- [ ] Click any day with multiple visits — confirm address, city/state/zip, sqft, and crew name (if present) all render.
- [ ] Upload a fresh schedule with a clean date column — confirm parse still works and no rows are rejected.
- [ ] Try uploading a schedule that mistakenly maps a non-date column as date — confirm those rows are rejected with parse errors instead of silently persisting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)