### PR TITLE
Edit scheduled_date on a row from the calendar

### DIFF
--- a/api/v1/schedule-assessments/[id]/rows.ts
+++ b/api/v1/schedule-assessments/[id]/rows.ts
@@ -20,6 +20,9 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       matched_service_location_id?: string | null
       match_status?: string
       notes?: string | null
+      // Allow correcting a parse error after the fact — e.g. when the
+      // upload spreadsheet had a wrong year on a handful of rows.
+      raw_scheduled_date?: string | null
     }>
   }
   if (!Array.isArray(body.rows) || body.rows.length === 0) {
@@ -43,6 +46,21 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       update.match_status = r.match_status
     }
     if ('notes' in r) update.notes = r.notes ?? null
+    if ('raw_scheduled_date' in r) {
+      // Accept null (clear the date) or an ISO YYYY-MM-DD with a
+      // plausible year. Anything else gets dropped silently — the
+      // caller can re-submit with a clean value.
+      const v = r.raw_scheduled_date
+      if (v === null) {
+        update.raw_scheduled_date = null
+      } else if (typeof v === 'string') {
+        const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(v.trim())
+        if (m) {
+          const y = Number(m[1])
+          if (y >= 1900 && y <= 2200) update.raw_scheduled_date = v.trim()
+        }
+      }
+    }
     if (Object.keys(update).length === 0) continue
     await db
       .from('schedule_assessment_rows')

--- a/src/components/scheduler/ScheduleAssessmentCalendar.tsx
+++ b/src/components/scheduler/ScheduleAssessmentCalendar.tsx
@@ -47,6 +47,11 @@ export interface CalendarSummary {
 interface Props {
   days: CalendarDay[]
   summary: CalendarSummary
+  // Save a corrected date on a single row. Parent wires this to the
+  // rows PATCH endpoint; the component handles UI state. Returns
+  // whatever the server returned so the caller can decide whether to
+  // refetch the calendar.
+  onEditDate?: (rowId: string, newDate: string) => Promise<void>
 }
 
 const MONTH_NAMES = [
@@ -61,7 +66,11 @@ function fmtSqft(n: number): string {
   return `${n}`
 }
 
-export default function ScheduleAssessmentCalendar({ days, summary }: Props) {
+export default function ScheduleAssessmentCalendar({ days, summary, onEditDate }: Props) {
+  const [editingRowId, setEditingRowId] = useState<string | null>(null)
+  const [editingDate, setEditingDate] = useState<string>('')
+  const [savingDate, setSavingDate] = useState(false)
+  const [editError, setEditError] = useState<string | null>(null)
   const dayByDate = useMemo(() => {
     const m = new Map<string, CalendarDay>()
     for (const d of days) m.set(d.date, d)
@@ -222,6 +231,7 @@ export default function ScheduleAssessmentCalendar({ days, summary }: Props) {
           <ul className="divide-y divide-border">
             {expanded.visits.map((v) => {
               const cityState = [v.city, v.state, v.postal_code].filter(Boolean).join(', ')
+              const isEditing = editingRowId === v.row_id
               return (
                 <li key={v.row_id} className="py-2 flex items-start gap-3 text-xs">
                   <span className="font-tabular text-fg-muted shrink-0 w-24 text-right pt-0.5">
@@ -234,9 +244,66 @@ export default function ScheduleAssessmentCalendar({ days, summary }: Props) {
                     {cityState && (
                       <p className="text-fg-muted truncate">{cityState}</p>
                     )}
+                    {isEditing && (
+                      <div className="mt-1.5 flex items-center gap-2">
+                        <input
+                          type="date"
+                          value={editingDate}
+                          onChange={(e) => setEditingDate(e.target.value)}
+                          className="h-7 rounded border border-border bg-surface px-2 text-xs"
+                          autoFocus
+                        />
+                        <Button
+                          size="sm"
+                          loading={savingDate}
+                          disabled={!editingDate || savingDate}
+                          onClick={async () => {
+                            if (!onEditDate) return
+                            setEditError(null)
+                            setSavingDate(true)
+                            try {
+                              await onEditDate(v.row_id, editingDate)
+                              setEditingRowId(null)
+                            } catch (e) {
+                              setEditError(e instanceof Error ? e.message : String(e))
+                            } finally {
+                              setSavingDate(false)
+                            }
+                          }}
+                        >
+                          Save
+                        </Button>
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          disabled={savingDate}
+                          onClick={() => {
+                            setEditingRowId(null)
+                            setEditError(null)
+                          }}
+                        >
+                          Cancel
+                        </Button>
+                        {editError && <span className="text-danger">{editError}</span>}
+                      </div>
+                    )}
                   </div>
-                  {v.crew_name && (
+                  {v.crew_name && !isEditing && (
                     <span className="text-fg-subtle shrink-0 pt-0.5">{v.crew_name}</span>
+                  )}
+                  {onEditDate && !isEditing && (
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      onClick={() => {
+                        setEditingRowId(v.row_id)
+                        setEditingDate(expanded.date)
+                        setEditError(null)
+                      }}
+                      className="shrink-0"
+                    >
+                      Edit date
+                    </Button>
                   )}
                 </li>
               )

--- a/src/pages/accounts/scheduler/ScheduleAssessmentDetail.tsx
+++ b/src/pages/accounts/scheduler/ScheduleAssessmentDetail.tsx
@@ -298,6 +298,33 @@ export default function ScheduleAssessmentDetailPage() {
     }
   }, [id, rows, loadCalendar])
 
+  // Edit a single row's scheduled_date — used to fix wrong-year rows
+  // (spreadsheet errors). Refresh the calendar after so the visit
+  // moves to its corrected day.
+  const editRowDate = useCallback(
+    async (rowId: string, newDate: string) => {
+      if (!id) return
+      const token = await getToken()
+      const res = await fetch(`/api/v1/schedule-assessments/${id}/rows`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        body: JSON.stringify({
+          rows: [{ id: rowId, raw_scheduled_date: newDate }],
+        }),
+      })
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}))
+        throw new Error((j as any)?.error ?? `Update failed (${res.status})`)
+      }
+      // Mirror the change locally and refresh the calendar.
+      setRows((prev) =>
+        prev.map((r) => (r.id === rowId ? { ...r, raw_scheduled_date: newDate } : r))
+      )
+      await loadCalendar()
+    },
+    [id, getToken, loadCalendar]
+  )
+
   // Ask the AI coach for a narrative review of the upload. Doesn't
   // require a baseline_template_id — coach gives schedule-on-its-own
   // feedback, with optimized-cycle contrast added if available.
@@ -1519,7 +1546,11 @@ export default function ScheduleAssessmentDetailPage() {
               </p>
             )}
             {calendarDays && calendarSummary && (
-              <ScheduleAssessmentCalendar days={calendarDays} summary={calendarSummary} />
+              <ScheduleAssessmentCalendar
+                days={calendarDays}
+                summary={calendarSummary}
+                onEditDate={editRowDate}
+              />
             )}
           </Card>
         ) : null}


### PR DESCRIPTION
## Summary
Operator had 7 rows whose date got parsed with the wrong year (a spreadsheet error in the source upload). Needed a way to correct them in-place rather than re-uploading.

## Changes
**Backend** — extend \`PATCH /api/v1/schedule-assessments/[id]/rows\` to accept \`raw_scheduled_date\`. Validates ISO \`YYYY-MM-DD\` with year ∈ \[1900, 2200\] before persisting; bad values silently dropped so the caller can retry.

**Frontend** — each visit row in the calendar's expanded day list now has an "Edit date" button. Click → inline date input + Save/Cancel; save calls the rows PATCH and the calendar reloads so the corrected visit moves to its new day. The parent's \`rows\` state mirrors the change so other surfaces stay in sync without a full page reload.

## Test plan
- [ ] Navigate to a month with a wrong-year visit, click the day to expand
- [ ] Click "Edit date", pick the correct date, hit Save
- [ ] Confirm the visit disappears from the bad day and shows up on the new day
- [ ] Confirm the calendar's date range and summary update accordingly
- [ ] Try a bad input (year < 1900 or > 2200) — confirm the server drops it silently and the UI shows the unchanged date
- [ ] Re-run the coach review after fixing all 7 — confirm the date envelope reflects the corrected dates

🤖 Generated with [Claude Code](https://claude.com/claude-code)