### PR TITLE
Calendar Current/Proposed toggle + drag-drop rescheduling

### DIFF
--- a/api/v1/schedule-assessments/[id]/proposed-calendar.ts
+++ b/api/v1/schedule-assessments/[id]/proposed-calendar.ts
@@ -1,0 +1,187 @@
+// GET /api/v1/schedule-assessments/[id]/proposed-calendar
+//
+// Returns the optimized cycle's visits in the same shape as the
+// upload calendar (date-keyed, with addresses + serviceable_sqft +
+// crew labels). Powers the "Proposed" view of the calendar toggle
+// on the assessment detail page.
+//
+// Source of truth: scheduled_visits for the most recent cycle of
+// the assessment's baseline_template_id.
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { createAdminClient } from '../../../_lib/supabase.js'
+import { authenticateRequest } from '../../../_lib/auth.js'
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'GET') return res.status(405).json({ error: 'Method not allowed' })
+  try { await authenticateRequest(req) } catch (err: any) {
+    return res.status(err.statusCode ?? 401).json({ error: err.message ?? 'Unauthorized' })
+  }
+  const id = req.query.id as string
+  const db = createAdminClient()
+
+  const { data: assessment } = await db
+    .from('schedule_assessments')
+    .select('id, baseline_template_id')
+    .eq('id', id)
+    .maybeSingle()
+  if (!assessment) return res.status(404).json({ error: 'Assessment not found' })
+  const a = assessment as any
+  if (!a.baseline_template_id) {
+    return res.status(400).json({
+      error: 'No baseline template linked to this assessment.',
+      code: 'NO_BASELINE',
+    })
+  }
+
+  const { data: cycleRow } = await db
+    .from('cycle_instances')
+    .select('id, start_date, end_date')
+    .eq('template_id', a.baseline_template_id)
+    .order('generated_at', { ascending: false })
+    .limit(1)
+    .maybeSingle()
+  if (!cycleRow) {
+    return res.status(400).json({ error: 'Linked template has no generated cycle.' })
+  }
+  const cycleId = (cycleRow as any).id
+
+  // Pull all scheduled visits with SL + property for sqft / address.
+  const PAGE = 1000
+  type RawVisit = {
+    id: string
+    scheduled_date: string | null
+    crew_index: number | null
+    service_location_id: string | null
+    service_locations: {
+      display_name: string | null
+      serviceable_sqft: number | null
+      property: {
+        address_line1: string | null
+        city: string | null
+        state: string | null
+        postal_code: string | null
+        latitude: number | null
+        longitude: number | null
+      } | null
+    } | null
+  }
+  const visits: RawVisit[] = []
+  for (let p = 0; p < 50; p++) {
+    const { data } = await db
+      .from('scheduled_visits')
+      .select(
+        'id, scheduled_date, crew_index, service_location_id, ' +
+          'service_locations(display_name, serviceable_sqft, property:properties(address_line1, city, state, postal_code, latitude, longitude))'
+      )
+      .eq('cycle_instance_id', cycleId)
+      .not('scheduled_date', 'is', null)
+      .range(p * PAGE, p * PAGE + PAGE - 1)
+    const arr = (data ?? []) as any[]
+    visits.push(...(arr as RawVisit[]))
+    if (arr.length < PAGE) break
+  }
+
+  // Crew labels — pull canonical names off crew_day_routes.
+  const { data: cdRows } = await db
+    .from('crew_day_routes')
+    .select('crew_index, crew_label')
+    .eq('cycle_instance_id', cycleId)
+    .limit(500)
+  const crewLabelByIdx = new Map<number, string>()
+  for (const r of (cdRows ?? []) as any[]) {
+    if (typeof r.crew_index === 'number' && !crewLabelByIdx.has(r.crew_index)) {
+      crewLabelByIdx.set(r.crew_index, r.crew_label ?? `Crew ${r.crew_index + 1}`)
+    }
+  }
+
+  type DayVisit = {
+    row_id: string
+    sl_id: string | null
+    display_name: string | null
+    address: string | null
+    city: string | null
+    state: string | null
+    postal_code: string | null
+    crew_name: string | null
+    sqft: number | null
+    lat: number | null
+    lng: number | null
+  }
+  type Day = {
+    date: string
+    dow: string
+    visits: DayVisit[]
+    total_sqft: number
+    visit_count: number
+    distinct_crews: number
+  }
+  const dowNames = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
+  const byDate = new Map<string, Day>()
+  for (const v of visits) {
+    if (!v.scheduled_date) continue
+    let day = byDate.get(v.scheduled_date)
+    if (!day) {
+      const dt = new Date(v.scheduled_date + 'T00:00:00Z')
+      day = {
+        date: v.scheduled_date,
+        dow: !Number.isNaN(dt.getTime()) ? dowNames[dt.getUTCDay()] : '?',
+        visits: [],
+        total_sqft: 0,
+        visit_count: 0,
+        distinct_crews: 0,
+      }
+      byDate.set(v.scheduled_date, day)
+    }
+    const sl = v.service_locations
+    const sqft = sl?.serviceable_sqft ?? null
+    const crewLabel =
+      typeof v.crew_index === 'number'
+        ? crewLabelByIdx.get(v.crew_index) ?? `Crew ${v.crew_index + 1}`
+        : null
+    day.visits.push({
+      row_id: v.id,
+      sl_id: v.service_location_id,
+      display_name: sl?.display_name ?? null,
+      address: sl?.property?.address_line1 ?? null,
+      city: sl?.property?.city ?? null,
+      state: sl?.property?.state ?? null,
+      postal_code: sl?.property?.postal_code ?? null,
+      crew_name: crewLabel,
+      sqft,
+      lat: sl?.property?.latitude ?? null,
+      lng: sl?.property?.longitude ?? null,
+    })
+    day.visit_count++
+    if (typeof sqft === 'number') day.total_sqft += sqft
+  }
+  for (const day of byDate.values()) {
+    const crews = new Set(
+      day.visits.map((v) => (v.crew_name ?? '').trim().toLowerCase()).filter(Boolean)
+    )
+    day.distinct_crews = crews.size
+    day.visits.sort((a, b) => (b.sqft ?? 0) - (a.sqft ?? 0))
+  }
+
+  const days = Array.from(byDate.values()).sort((a, b) => a.date.localeCompare(b.date))
+  const totalSqft = days.reduce((s, d) => s + d.total_sqft, 0)
+  const maxDailySqft = days.reduce((m, d) => Math.max(m, d.total_sqft), 0)
+  const maxDailyVisits = days.reduce((m, d) => Math.max(m, d.visit_count), 0)
+
+  return res.status(200).json({
+    cycle: {
+      id: cycleId,
+      start_date: (cycleRow as any).start_date,
+      end_date: (cycleRow as any).end_date,
+    },
+    summary: {
+      start_date: days[0]?.date ?? null,
+      end_date: days[days.length - 1]?.date ?? null,
+      day_count: days.length,
+      visit_count: visits.length,
+      total_sqft: totalSqft,
+      max_daily_sqft: maxDailySqft,
+      max_daily_visits: maxDailyVisits,
+    },
+    days,
+  })
+}

--- a/src/components/scheduler/ScheduleAssessmentCalendar.tsx
+++ b/src/components/scheduler/ScheduleAssessmentCalendar.tsx
@@ -1,12 +1,17 @@
-// Calendar view for an uploaded schedule assessment. Month grid where
-// each day cell shows visit count + total square footage so the
-// operator can tell at a glance which days are heavy by *footprint*
-// (one big building → maybe one crew can absorb it) vs heavy by
-// *count* (many small buildings → potentially needs a second crew).
+// Calendar view for a schedule assessment. Month grid where each day
+// cell shows visit count + total square footage so the operator can
+// tell at a glance which days are heavy by *footprint* (one big
+// building → maybe one crew can absorb it) vs heavy by *count* (many
+// small buildings → potentially needs a second crew).
+//
+// Two-mode toggle: "Current" (the operator's upload) and "Proposed"
+// (the engine's optimized cycle). In Current mode the operator can
+// drag a property from one day to another to rebook it — saved via
+// onEditDate. Proposed mode is read-only.
 //
 // Click a day to expand a list of properties for that day with their
 // individual sqft. Sqft is also reflected as a color heat scale on
-// the cell itself relative to the busiest day in the upload.
+// the cell itself relative to the busiest day in the active view.
 import { useMemo, useState } from 'react'
 import { ChevronLeft, ChevronRight } from 'lucide-react'
 import Button from '../ui/Button'
@@ -44,6 +49,8 @@ export interface CalendarSummary {
   max_daily_visits: number
 }
 
+type ViewMode = 'current' | 'proposed'
+
 interface Props {
   days: CalendarDay[]
   summary: CalendarSummary
@@ -52,6 +59,11 @@ interface Props {
   // whatever the server returned so the caller can decide whether to
   // refetch the calendar.
   onEditDate?: (rowId: string, newDate: string) => Promise<void>
+  // Optional proposed-cycle data + summary. When supplied, the
+  // component renders a Current/Proposed toggle and shows the active
+  // view's data.
+  proposedDays?: CalendarDay[] | null
+  proposedSummary?: CalendarSummary | null
 }
 
 const MONTH_NAMES = [
@@ -66,22 +78,43 @@ function fmtSqft(n: number): string {
   return `${n}`
 }
 
-export default function ScheduleAssessmentCalendar({ days, summary, onEditDate }: Props) {
+export default function ScheduleAssessmentCalendar({
+  days,
+  summary,
+  onEditDate,
+  proposedDays,
+  proposedSummary,
+}: Props) {
+  const [mode, setMode] = useState<ViewMode>('current')
   const [editingRowId, setEditingRowId] = useState<string | null>(null)
   const [editingDate, setEditingDate] = useState<string>('')
   const [savingDate, setSavingDate] = useState(false)
   const [editError, setEditError] = useState<string | null>(null)
+  // Drag/drop state — only meaningful in current mode. Tracks which
+  // visit is being dragged and which day is the current drop target
+  // so we can highlight the target while dragging.
+  const [draggingRowId, setDraggingRowId] = useState<string | null>(null)
+  const [dragOverDate, setDragOverDate] = useState<string | null>(null)
+  const [savingDrop, setSavingDrop] = useState(false)
+
+  const hasProposed =
+    !!proposedDays && !!proposedSummary && proposedSummary.day_count > 0
+  const activeDays = mode === 'proposed' && hasProposed ? proposedDays! : days
+  const activeSummary =
+    mode === 'proposed' && hasProposed ? proposedSummary! : summary
+  const dragEnabled = mode === 'current' && !!onEditDate
+
   const dayByDate = useMemo(() => {
     const m = new Map<string, CalendarDay>()
-    for (const d of days) m.set(d.date, d)
+    for (const d of activeDays) m.set(d.date, d)
     return m
-  }, [days])
+  }, [activeDays])
 
   const months = useMemo(() => {
     const set = new Set<string>()
-    for (const d of days) set.add(d.date.slice(0, 7))
+    for (const d of activeDays) set.add(d.date.slice(0, 7))
     return Array.from(set).sort()
-  }, [days])
+  }, [activeDays])
 
   const [monthIndex, setMonthIndex] = useState(0)
   const [expandedDate, setExpandedDate] = useState<string | null>(null)
@@ -89,7 +122,9 @@ export default function ScheduleAssessmentCalendar({ days, summary, onEditDate }
   if (months.length === 0) {
     return (
       <div className="rounded-md border border-border bg-surface p-6 text-sm text-fg-muted">
-        No matched rows with scheduled dates yet.
+        {mode === 'proposed'
+          ? 'No proposed cycle yet — generate a cycle on the linked baseline template first.'
+          : 'No matched rows with scheduled dates yet.'}
       </div>
     )
   }
@@ -112,8 +147,8 @@ export default function ScheduleAssessmentCalendar({ days, summary, onEditDate }
   // Heat scale based on sqft relative to the cycle's busiest day. Steps
   // approximate quartiles so the worst day stands out.
   const heatClass = (sqft: number): string => {
-    if (sqft <= 0 || summary.max_daily_sqft <= 0) return ''
-    const ratio = sqft / summary.max_daily_sqft
+    if (sqft <= 0 || activeSummary.max_daily_sqft <= 0) return ''
+    const ratio = sqft / activeSummary.max_daily_sqft
     if (ratio >= 0.85) return 'bg-rose-500/15 border-rose-400/50'
     if (ratio >= 0.6) return 'bg-amber-500/15 border-amber-400/50'
     if (ratio >= 0.35) return 'bg-yellow-500/10 border-yellow-400/40'
@@ -122,23 +157,66 @@ export default function ScheduleAssessmentCalendar({ days, summary, onEditDate }
 
   return (
     <div className="space-y-3">
+      {hasProposed && (
+        <div className="flex items-center justify-between gap-3 flex-wrap">
+          <div className="inline-flex rounded-md border border-border bg-surface overflow-hidden text-xs">
+            <button
+              type="button"
+              onClick={() => {
+                setMode('current')
+                setExpandedDate(null)
+                setMonthIndex(0)
+              }}
+              className={cn(
+                'px-3 py-1.5 transition-colors',
+                mode === 'current'
+                  ? 'bg-accent/15 text-fg font-medium'
+                  : 'text-fg-muted hover:bg-surface-muted'
+              )}
+            >
+              Current (your upload)
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setMode('proposed')
+                setExpandedDate(null)
+                setMonthIndex(0)
+              }}
+              className={cn(
+                'px-3 py-1.5 border-l border-border transition-colors',
+                mode === 'proposed'
+                  ? 'bg-accent/15 text-fg font-medium'
+                  : 'text-fg-muted hover:bg-surface-muted'
+              )}
+            >
+              Proposed (engine)
+            </button>
+          </div>
+          {dragEnabled && (
+            <p className="text-xs text-fg-muted italic">
+              Tip: drag a property between days in Current view to reschedule it.
+            </p>
+          )}
+        </div>
+      )}
       <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 text-xs">
         <div className="rounded-md border border-border bg-surface-subtle px-3 py-2">
           <p className="text-fg-muted uppercase tracking-wide">Workdays</p>
-          <p className="text-base font-semibold text-fg font-tabular">{summary.day_count}</p>
+          <p className="text-base font-semibold text-fg font-tabular">{activeSummary.day_count}</p>
         </div>
         <div className="rounded-md border border-border bg-surface-subtle px-3 py-2">
           <p className="text-fg-muted uppercase tracking-wide">Total visits</p>
-          <p className="text-base font-semibold text-fg font-tabular">{summary.visit_count}</p>
+          <p className="text-base font-semibold text-fg font-tabular">{activeSummary.visit_count}</p>
         </div>
         <div className="rounded-md border border-border bg-surface-subtle px-3 py-2">
           <p className="text-fg-muted uppercase tracking-wide">Total sqft</p>
-          <p className="text-base font-semibold text-fg font-tabular">{fmtSqft(summary.total_sqft)}</p>
+          <p className="text-base font-semibold text-fg font-tabular">{fmtSqft(activeSummary.total_sqft)}</p>
         </div>
         <div className="rounded-md border border-border bg-surface-subtle px-3 py-2">
           <p className="text-fg-muted uppercase tracking-wide">Peak day</p>
           <p className="text-base font-semibold text-fg font-tabular">
-            {summary.max_daily_visits} visits · {fmtSqft(summary.max_daily_sqft)}
+            {activeSummary.max_daily_visits} visits · {fmtSqft(activeSummary.max_daily_sqft)}
           </p>
         </div>
       </div>
@@ -174,18 +252,59 @@ export default function ScheduleAssessmentCalendar({ days, summary, onEditDate }
           {cells.map((c, i) => {
             const day = c.date ? dayByDate.get(c.date) : null
             const isExpanded = !!day && expandedDate === c.date
+            const isDropTarget = dragEnabled && c.date && dragOverDate === c.date
             return (
               <button
                 key={i}
                 type="button"
                 disabled={!day}
                 onClick={() => day && setExpandedDate(isExpanded ? null : c.date)}
+                onDragOver={
+                  dragEnabled && c.date
+                    ? (e) => {
+                        e.preventDefault()
+                        e.dataTransfer.dropEffect = 'move'
+                        if (dragOverDate !== c.date) setDragOverDate(c.date)
+                      }
+                    : undefined
+                }
+                onDragLeave={
+                  dragEnabled && c.date
+                    ? () => {
+                        if (dragOverDate === c.date) setDragOverDate(null)
+                      }
+                    : undefined
+                }
+                onDrop={
+                  dragEnabled && c.date && onEditDate
+                    ? async (e) => {
+                        e.preventDefault()
+                        const rowId =
+                          e.dataTransfer.getData('text/x-row-id') || draggingRowId
+                        setDragOverDate(null)
+                        setDraggingRowId(null)
+                        if (!rowId || !c.date) return
+                        // No-op if dropped on the same day.
+                        const sourceDay = days.find((d) =>
+                          d.visits.some((v) => v.row_id === rowId)
+                        )
+                        if (sourceDay && sourceDay.date === c.date) return
+                        setSavingDrop(true)
+                        try {
+                          await onEditDate(rowId, c.date)
+                        } finally {
+                          setSavingDrop(false)
+                        }
+                      }
+                    : undefined
+                }
                 className={cn(
                   'min-h-[78px] border-b border-r border-border p-1.5 text-left text-xs transition-colors',
                   !c.date && 'bg-surface-subtle/40',
                   day && heatClass(day.total_sqft),
                   day && 'hover:bg-surface-muted/60 cursor-pointer',
-                  isExpanded && 'ring-2 ring-accent ring-inset'
+                  isExpanded && 'ring-2 ring-accent ring-inset',
+                  isDropTarget && 'ring-2 ring-emerald-400 ring-inset'
                 )}
               >
                 {c.dom && (
@@ -210,6 +329,11 @@ export default function ScheduleAssessmentCalendar({ days, summary, onEditDate }
             )
           })}
         </div>
+        {savingDrop && (
+          <p className="px-3 py-2 text-xs text-fg-muted border-t border-border">
+            Saving move…
+          </p>
+        )}
       </div>
 
       {expanded && (
@@ -232,8 +356,34 @@ export default function ScheduleAssessmentCalendar({ days, summary, onEditDate }
             {expanded.visits.map((v) => {
               const cityState = [v.city, v.state, v.postal_code].filter(Boolean).join(', ')
               const isEditing = editingRowId === v.row_id
+              const isDragging = draggingRowId === v.row_id
               return (
-                <li key={v.row_id} className="py-2 flex items-start gap-3 text-xs">
+                <li
+                  key={v.row_id}
+                  draggable={dragEnabled && !isEditing}
+                  onDragStart={
+                    dragEnabled && !isEditing
+                      ? (e) => {
+                          e.dataTransfer.setData('text/x-row-id', v.row_id)
+                          e.dataTransfer.effectAllowed = 'move'
+                          setDraggingRowId(v.row_id)
+                        }
+                      : undefined
+                  }
+                  onDragEnd={
+                    dragEnabled && !isEditing
+                      ? () => {
+                          setDraggingRowId(null)
+                          setDragOverDate(null)
+                        }
+                      : undefined
+                  }
+                  className={cn(
+                    'py-2 flex items-start gap-3 text-xs',
+                    dragEnabled && !isEditing && 'cursor-grab active:cursor-grabbing',
+                    isDragging && 'opacity-50'
+                  )}
+                >
                   <span className="font-tabular text-fg-muted shrink-0 w-24 text-right pt-0.5">
                     {v.sqft != null ? fmtSqft(v.sqft) + ' sqft' : '—'}
                   </span>
@@ -291,7 +441,7 @@ export default function ScheduleAssessmentCalendar({ days, summary, onEditDate }
                   {v.crew_name && !isEditing && (
                     <span className="text-fg-subtle shrink-0 pt-0.5">{v.crew_name}</span>
                   )}
-                  {onEditDate && !isEditing && (
+                  {dragEnabled && !isEditing && (
                     <Button
                       size="sm"
                       variant="ghost"

--- a/src/pages/accounts/scheduler/ScheduleAssessmentDetail.tsx
+++ b/src/pages/accounts/scheduler/ScheduleAssessmentDetail.tsx
@@ -179,6 +179,8 @@ export default function ScheduleAssessmentDetailPage() {
   const [calendarSummary, setCalendarSummary] = useState<CalendarSummary | null>(null)
   const [calendarLoading, setCalendarLoading] = useState(false)
   const [calendarError, setCalendarError] = useState<string | null>(null)
+  const [proposedDays, setProposedDays] = useState<CalendarDay[] | null>(null)
+  const [proposedSummary, setProposedSummary] = useState<CalendarSummary | null>(null)
   const [diffFilter, setDiffFilter] = useState<DiffStatus | 'all_actionable'>('all_actionable')
   const [detections, setDetections] = useState<DetectedConstraint[]>([])
   const [detecting, setDetecting] = useState(false)
@@ -275,13 +277,30 @@ export default function ScheduleAssessmentDetailPage() {
     setCalendarError(null)
     try {
       const token = await getToken()
-      const res = await fetch(`/api/v1/schedule-assessments/${id}/calendar`, {
-        headers: { Authorization: `Bearer ${token}` },
-      })
-      const j = await res.json()
-      if (!res.ok) throw new Error(j.error ?? `Calendar failed (${res.status})`)
-      setCalendarDays(j.days as CalendarDay[])
-      setCalendarSummary(j.summary as CalendarSummary)
+      // Fire current + proposed in parallel. Proposed is best-effort —
+      // returns 400 when there's no baseline_template_id, which is
+      // expected for a fresh assessment.
+      const [curRes, propRes] = await Promise.all([
+        fetch(`/api/v1/schedule-assessments/${id}/calendar`, {
+          headers: { Authorization: `Bearer ${token}` },
+        }),
+        fetch(`/api/v1/schedule-assessments/${id}/proposed-calendar`, {
+          headers: { Authorization: `Bearer ${token}` },
+        }),
+      ])
+      const cur = await curRes.json()
+      if (!curRes.ok) throw new Error(cur.error ?? `Calendar failed (${curRes.status})`)
+      setCalendarDays(cur.days as CalendarDay[])
+      setCalendarSummary(cur.summary as CalendarSummary)
+      if (propRes.ok) {
+        const prop = await propRes.json()
+        setProposedDays(prop.days as CalendarDay[])
+        setProposedSummary(prop.summary as CalendarSummary)
+      } else {
+        // 400/404 just means no baseline yet — clear any stale data.
+        setProposedDays(null)
+        setProposedSummary(null)
+      }
     } catch (err) {
       setCalendarError(err instanceof Error ? err.message : String(err))
     } finally {
@@ -1550,6 +1569,8 @@ export default function ScheduleAssessmentDetailPage() {
                 days={calendarDays}
                 summary={calendarSummary}
                 onEditDate={editRowDate}
+                proposedDays={proposedDays}
+                proposedSummary={proposedSummary}
               />
             )}
           </Card>


### PR DESCRIPTION
## Summary
Operator wanted a single calendar with a toggle between the upload ("Current") and the engine's optimized cycle ("Proposed"), plus drag-and-drop rescheduling.

## Changes
**Backend** — \`GET /api/v1/schedule-assessments/[id]/proposed-calendar\` returns the most recent cycle of the linked baseline_template_id in the same date-keyed shape as the upload calendar (visit count, total_sqft, distinct_crews per day; per-visit address/city/state/sqft/crew). 400 with code \`NO_BASELINE\` if no template is linked.

**Frontend (calendar component)**:
- Current/Proposed toggle above the stats; switches the dataset driving the grid and stats.
- Drag-and-drop in Current view: each visit row in the expanded list is draggable; calendar cells are drop targets. Drop → onEditDate (rows PATCH) → calendar reloads. Drop target highlights with an emerald ring while hovered.
- Stats row + heat scale reflect the active view's summary.
- Edit date button only shows in Current mode (proposed dates are the engine's, not the operator's to override here).
- Empty-state copy changes per mode.

**Frontend (parent)** — loadCalendar fires both endpoints in parallel. Proposed is best-effort; a 400 just clears proposed state without surfacing an error (no-baseline is normal for fresh assessments).

## Test plan
- [ ] Open an assessment with a linked baseline template — confirm the toggle appears
- [ ] Toggle to Proposed — confirm the engine's cycle renders with correct visit counts and sqft
- [ ] Toggle back to Current — confirm the upload renders with the drag tip and the drag-drop affordance
- [ ] In Current view, drag a property from one day to another — confirm the visit moves and the calendar refreshes
- [ ] In Proposed view, confirm visits are NOT draggable and the Edit date button is hidden
- [ ] Open an assessment with no baseline — confirm only Current shows (no toggle) and no proposed-calendar errors surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)