### PR TITLE
Always-visible toggle + Adopt engine plan action

### DIFF
--- a/src/components/scheduler/ScheduleAssessmentCalendar.tsx
+++ b/src/components/scheduler/ScheduleAssessmentCalendar.tsx
@@ -64,6 +64,10 @@ interface Props {
   // view's data.
   proposedDays?: CalendarDay[] | null
   proposedSummary?: CalendarSummary | null
+  // When the proposed view isn't available, the parent supplies a
+  // human-readable reason so the toggle can render disabled with
+  // an inline explanation instead of silently hiding.
+  proposedDisabledReason?: string | null
 }
 
 const MONTH_NAMES = [
@@ -84,6 +88,7 @@ export default function ScheduleAssessmentCalendar({
   onEditDate,
   proposedDays,
   proposedSummary,
+  proposedDisabledReason,
 }: Props) {
   const [mode, setMode] = useState<ViewMode>('current')
   const [editingRowId, setEditingRowId] = useState<string | null>(null)
@@ -157,49 +162,61 @@ export default function ScheduleAssessmentCalendar({
 
   return (
     <div className="space-y-3">
-      {hasProposed && (
-        <div className="flex items-center justify-between gap-3 flex-wrap">
-          <div className="inline-flex rounded-md border border-border bg-surface overflow-hidden text-xs">
-            <button
-              type="button"
-              onClick={() => {
-                setMode('current')
-                setExpandedDate(null)
-                setMonthIndex(0)
-              }}
-              className={cn(
-                'px-3 py-1.5 transition-colors',
-                mode === 'current'
-                  ? 'bg-accent/15 text-fg font-medium'
-                  : 'text-fg-muted hover:bg-surface-muted'
-              )}
-            >
-              Current (your upload)
-            </button>
-            <button
-              type="button"
-              onClick={() => {
-                setMode('proposed')
-                setExpandedDate(null)
-                setMonthIndex(0)
-              }}
-              className={cn(
-                'px-3 py-1.5 border-l border-border transition-colors',
-                mode === 'proposed'
-                  ? 'bg-accent/15 text-fg font-medium'
-                  : 'text-fg-muted hover:bg-surface-muted'
-              )}
-            >
-              Proposed (engine)
-            </button>
-          </div>
-          {dragEnabled && (
-            <p className="text-xs text-fg-muted italic">
-              Tip: drag a property between days in Current view to reschedule it.
-            </p>
-          )}
+      <div className="flex items-center justify-between gap-3 flex-wrap">
+        <div className="inline-flex rounded-md border border-border bg-surface overflow-hidden text-xs">
+          <button
+            type="button"
+            onClick={() => {
+              setMode('current')
+              setExpandedDate(null)
+              setMonthIndex(0)
+            }}
+            className={cn(
+              'px-3 py-1.5 transition-colors',
+              mode === 'current'
+                ? 'bg-accent/15 text-fg font-medium'
+                : 'text-fg-muted hover:bg-surface-muted'
+            )}
+          >
+            Current (your upload)
+          </button>
+          <button
+            type="button"
+            disabled={!hasProposed}
+            title={
+              !hasProposed
+                ? proposedDisabledReason ??
+                  'Link a baseline template (and generate a cycle on it) to enable the Proposed view.'
+                : undefined
+            }
+            onClick={() => {
+              if (!hasProposed) return
+              setMode('proposed')
+              setExpandedDate(null)
+              setMonthIndex(0)
+            }}
+            className={cn(
+              'px-3 py-1.5 border-l border-border transition-colors',
+              mode === 'proposed' && hasProposed
+                ? 'bg-accent/15 text-fg font-medium'
+                : 'text-fg-muted hover:bg-surface-muted',
+              !hasProposed && 'opacity-50 cursor-not-allowed hover:bg-transparent'
+            )}
+          >
+            Proposed (engine)
+          </button>
         </div>
-      )}
+        {!hasProposed && proposedDisabledReason && (
+          <p className="text-xs text-fg-muted italic">
+            {proposedDisabledReason}
+          </p>
+        )}
+        {hasProposed && dragEnabled && (
+          <p className="text-xs text-fg-muted italic">
+            Tip: drag a property between days in Current view to reschedule it.
+          </p>
+        )}
+      </div>
       <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 text-xs">
         <div className="rounded-md border border-border bg-surface-subtle px-3 py-2">
           <p className="text-fg-muted uppercase tracking-wide">Workdays</p>

--- a/src/pages/accounts/scheduler/ScheduleAssessmentDetail.tsx
+++ b/src/pages/accounts/scheduler/ScheduleAssessmentDetail.tsx
@@ -181,6 +181,8 @@ export default function ScheduleAssessmentDetailPage() {
   const [calendarError, setCalendarError] = useState<string | null>(null)
   const [proposedDays, setProposedDays] = useState<CalendarDay[] | null>(null)
   const [proposedSummary, setProposedSummary] = useState<CalendarSummary | null>(null)
+  const [proposedReason, setProposedReason] = useState<string | null>(null)
+  const [adoptingEnginePlan, setAdoptingEnginePlan] = useState(false)
   type ImplausibleRow = {
     row_id: string
     raw_scheduled_date: string | null
@@ -312,10 +314,14 @@ export default function ScheduleAssessmentDetailPage() {
         const prop = await propRes.json()
         setProposedDays(prop.days as CalendarDay[])
         setProposedSummary(prop.summary as CalendarSummary)
+        setProposedReason(null)
       } else {
-        // 400/404 just means no baseline yet — clear any stale data.
+        // Capture the reason so the UI can tell the operator what's
+        // missing rather than silently hiding the toggle.
+        const j = await propRes.json().catch(() => ({}))
         setProposedDays(null)
         setProposedSummary(null)
+        setProposedReason((j as any)?.error ?? `Proposed view unavailable (${propRes.status})`)
       }
     } catch (err) {
       setCalendarError(err instanceof Error ? err.message : String(err))
@@ -332,6 +338,75 @@ export default function ScheduleAssessmentDetailPage() {
       void loadCalendar()
     }
   }, [id, rows, loadCalendar])
+
+  // Adopt the engine's plan in one click: set hybrid_choice='optimized'
+  // for every moved_date + only_optimized row, and 'skip' for every
+  // only_current row. Loads the diff first if it isn't loaded yet.
+  // After the PATCH lands, the operator can use the existing "Save as
+  // routing template" card below to materialize the choices.
+  async function adoptEnginePlan() {
+    if (!id) return
+    if (!confirm('Adopt the engine\'s proposed plan? This sets every difference row to use the optimized choice (move date / add visit) or skip (when the engine drops a visit). You can still review and tweak per-row choices before saving as a template.')) {
+      return
+    }
+    setAdoptingEnginePlan(true)
+    setError(null)
+    try {
+      const token = await getToken()
+      // Make sure we have the diff payload.
+      let diffPayload = diff
+      if (!diffPayload) {
+        const dRes = await fetch(`/api/v1/schedule-assessments/${id}/diff`, {
+          headers: { Authorization: `Bearer ${token}` },
+        })
+        const dj = await dRes.json()
+        if (!dRes.ok) throw new Error(dj.error ?? `Diff failed (${dRes.status})`)
+        diffPayload = dj as DiffPayload
+        setDiff(diffPayload)
+      }
+      // Build the bulk PATCH.
+      const updates: Array<{ key: string; source: 'optimized' | 'skip' }> = []
+      for (const r of diffPayload.diff) {
+        if (!r.hybrid_key) continue
+        if (r.status === 'moved_date' || r.status === 'only_optimized') {
+          updates.push({ key: r.hybrid_key, source: 'optimized' })
+        } else if (r.status === 'only_current') {
+          updates.push({ key: r.hybrid_key, source: 'skip' })
+        }
+      }
+      if (updates.length === 0) {
+        setError('No actionable differences — nothing to adopt.')
+        return
+      }
+      const res = await fetch(`/api/v1/schedule-assessments/${id}/hybrid`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        body: JSON.stringify({ rows: updates }),
+      })
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}))
+        throw new Error((j as any)?.error ?? `Adopt failed (${res.status})`)
+      }
+      // Optimistically reflect the choices on the cached diff.
+      const keySet = new Set(updates.map((u) => u.key))
+      setDiff((prev) => {
+        if (!prev) return prev
+        return {
+          ...prev,
+          diff: prev.diff.map((r) => {
+            if (!r.hybrid_key || !keySet.has(r.hybrid_key)) return r
+            const choice =
+              r.status === 'only_current' ? 'skip' : 'optimized'
+            return { ...r, hybrid_choice: choice }
+          }),
+        }
+      })
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setAdoptingEnginePlan(false)
+    }
+  }
 
   // Edit a single row's scheduled_date — used to fix wrong-year rows
   // (spreadsheet errors). Refresh the calendar after so the visit
@@ -1560,18 +1635,37 @@ export default function ScheduleAssessmentDetailPage() {
         {(calendarDays && calendarSummary && calendarSummary.day_count > 0) || calendarLoading ? (
           <Card className="space-y-3">
             <div className="flex items-start justify-between gap-3 flex-wrap">
-              <div>
-                <CardTitle>Upload calendar</CardTitle>
+              <div className="flex-1 min-w-0">
+                <CardTitle>Schedule calendar</CardTitle>
                 <p className="text-xs text-fg-muted mt-0.5">
-                  Each cell shows visit count and total square footage for that day.
-                  Color heat reflects sqft relative to your busiest day. Click a
-                  day to see the property list.
+                  Toggle Current vs Proposed below to compare your upload to
+                  the engine's optimized cycle. In Current view, drag any
+                  visit to a different day to reschedule it; click any day for
+                  the property list.
                 </p>
               </div>
-              {calendarLoading && (
-                <p className="text-xs text-fg-muted italic">Loading…</p>
-              )}
+              <div className="flex items-center gap-2 shrink-0">
+                {calendarLoading && (
+                  <p className="text-xs text-fg-muted italic">Loading…</p>
+                )}
+                {assessment?.baseline_template_id && proposedSummary && proposedSummary.day_count > 0 && (
+                  <Button
+                    size="sm"
+                    onClick={adoptEnginePlan}
+                    loading={adoptingEnginePlan}
+                  >
+                    Adopt engine plan
+                  </Button>
+                )}
+              </div>
             </div>
+            {assessment?.baseline_template_id && proposedSummary && proposedSummary.day_count > 0 && (
+              <p className="text-xs text-fg-muted">
+                "Adopt engine plan" sets every difference row to use the engine's
+                date (or skip when the engine drops a visit). Tweak per-row
+                choices in the diff section below before saving as a template.
+              </p>
+            )}
             {calendarError && <p className="text-sm text-danger">{calendarError}</p>}
             {implausibleRows.length > 0 && (
               <div className="rounded-md border border-warning/40 bg-warning-subtle/30 p-3 space-y-2">
@@ -1674,6 +1768,12 @@ export default function ScheduleAssessmentDetailPage() {
                 onEditDate={editRowDate}
                 proposedDays={proposedDays}
                 proposedSummary={proposedSummary}
+                proposedDisabledReason={
+                  proposedReason ??
+                  (assessment?.baseline_template_id
+                    ? null
+                    : 'Link a baseline template below to enable the Proposed view.')
+                }
               />
             )}
           </Card>


### PR DESCRIPTION
## Summary
Two issues from operator feedback:
1. **Couldn't find the toggle.** It was gated on \`hasProposed\` — silently invisible when the assessment had no baseline template or no generated cycle. Operator had no idea why or how to fix it.
2. **No actionable trigger anywhere.** The "actions" were buried in per-row hybrid dropdowns inside a collapsed diff section. Nothing on the calendar surface said "here's what to do."

## Changes
**Calendar component** — toggle always renders. When the Proposed view isn't available, the button renders disabled with a tooltip, and the parent's reason string surfaces inline next to the toggle ("Link a baseline template below…"). The reason comes from the proposed-calendar endpoint's actual error so it's specific (missing baseline vs missing cycle vs fetch error).

**Parent page**:
- New "Adopt engine plan" button at the top of the calendar card, visible whenever the proposed view loaded. Clicking loads the diff if needed, then bulk-PATCHes hybrid_choice for every diff row — \`optimized\` for moved-date and only-optimized rows, \`skip\` for only-current rows. Optimistically updates the cached diff.
- Helper line under the button explains what it does and points to per-row tweaking + save-as-template below.
- Confirm dialog so the operator can't bulk-toggle by accident.
- Card title renamed "Upload calendar" → "Schedule calendar" (it hosts both views now).

## Test plan
- [ ] Open an assessment with NO baseline template — confirm the toggle is visible with Proposed disabled and an inline reason
- [ ] Pick a baseline template that has no cycle generated — confirm reason updates ("Linked template has no generated cycle yet…")
- [ ] Pick a baseline with a generated cycle — confirm Proposed enables and "Adopt engine plan" appears
- [ ] Click "Adopt engine plan", confirm — verify hybrid choices in the per-visit detail table flip to optimized/skip
- [ ] Save as template afterward to confirm the choices propagate

🤖 Generated with [Claude Code](https://claude.com/claude-code)