### PR TITLE
fix: treat custom routing-template cycle as a one-time planning window

### DIFF
--- a/api/_lib/scheduler/build-routing-template.ts
+++ b/api/_lib/scheduler/build-routing-template.ts
@@ -236,14 +236,22 @@ export function buildRoutingTemplate(input: BuildTemplateInput): TemplateBuildRe
   const cycleDays = cycleResult.cycle_length_days
 
   // ── 2. Build visit specs (with addon attachment) ──────────────────
+  // A user-supplied custom cycle is a one-time planning window ("finish
+  // every property within N days"), not a recurring period. In that mode
+  // every property gets at least one visit placed in the window. The
+  // auto cycle, by contrast, is a recurring period sized to the shortest
+  // visit interval, so properties that visit LESS often than the cycle
+  // are deferred to alternating cycles (skipped here) to avoid
+  // over-servicing them.
+  const isCustomWindow = !!input.custom_cycle_length_days && input.custom_cycle_length_days > 0
   const visitSpecs: VisitSpec[] = []
   let totalRequired = 0
   for (const p of input.routed_properties) {
     if (p.parent_visit_interval_years <= 0) continue
     const intervalDays = p.parent_visit_interval_years * DAYS_PER_YEAR
-    if (intervalDays > cycleDays) {
-      // Property visits less often than the cycle — skipped in this builder.
-      // Cycle generator handles the parity case.
+    if (intervalDays > cycleDays && !isCustomWindow) {
+      // Auto recurring cycle: property visits less often than the cycle —
+      // deferred to alternating cycles, not scheduled this cycle.
       continue
     }
     const visitsPerCycle = Math.max(1, Math.round(cycleDays / intervalDays))

--- a/tests/unit/custom-cycle-window.test.ts
+++ b/tests/unit/custom-cycle-window.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Unit test: custom cycle length shorter than the portfolio's shortest
+ * visit interval should be treated as a one-time planning window —
+ * every property gets at least one visit placed, instead of every
+ * property being skipped (which produced a 0-visit "failed" template).
+ *
+ * Regression guard for: custom 120-day cycle on a 2x/year (182-day)
+ * portfolio failing because intervalDays > cycleDays skipped everything.
+ *
+ * Run: npx tsx tests/unit/custom-cycle-window.test.ts
+ */
+import {
+  buildRoutingTemplate,
+  type BuildTemplateInput,
+  type PropertyForBuild,
+} from '../../api/_lib/scheduler/build-routing-template.js'
+
+function assert(cond: boolean, msg: string) {
+  if (!cond) throw new Error(`FAIL: ${msg}`)
+}
+
+const BRANCH = { name: 'Phoenix', lat: 33.4, lng: -112.0 }
+
+function prop(id: string, lat: number, lng: number, intervalYears: number): PropertyForBuild {
+  return {
+    service_location_id: `sl-${id}`,
+    property_id: `prop-${id}`,
+    address: `${id} Test St, Phoenix, AZ`,
+    lat,
+    lng,
+    parent_offering_id: 'off-1',
+    parent_offering_name: 'Project Clean',
+    parent_visit_interval_years: intervalYears,
+    base_hours_per_visit: 2,
+    serviceable_sqft: 10000,
+    constraints: [],
+    eligible_addons: [],
+  }
+}
+
+const CONFIG: BuildTemplateInput['config'] = {
+  crew_size: 2,
+  hours_per_day: 8,
+  work_start_time: '08:00',
+  work_end_time: '18:00',
+  buffer_minutes_per_stop: 15,
+  drive_speed_mph: 45,
+  overnight_trigger_one_way_hours: 4,
+  cluster_radius_miles: 30,
+  max_work_hours_per_crew_day: 10,
+  fuel_cost_per_mile: 0.65,
+  hourly_loaded_labor_cost: 50,
+  cost_per_night: 150,
+  per_diem_per_night: 50,
+}
+
+const PREFS: BuildTemplateInput['preferences'] = {
+  objective: 'balanced',
+  soft_constraint_weight: 0.5,
+  allow_hard_constraint_violation: false,
+}
+
+function baseInput(props: PropertyForBuild[], custom?: number): BuildTemplateInput {
+  return {
+    account_id: 'acct-1',
+    client_id: 'client-1',
+    routed_properties: props,
+    branches: [BRANCH],
+    crew_count: 1,
+    config: CONFIG,
+    custom_cycle_length_days: custom,
+    preferences: PREFS,
+    cycle_start_year: 2026,
+  }
+}
+
+// ── Case 1: custom 120-day cycle on a 2x/year (182-day) portfolio ──
+// Both properties' interval (182d) exceeds the 120-day cycle. Before the
+// fix they were skipped → 0 visits → failed. Now each must be scheduled
+// once within the window.
+{
+  const props = [
+    prop('a', 33.41, -112.01, 0.5),
+    prop('b', 33.42, -112.02, 0.5),
+  ]
+  const res = buildRoutingTemplate(baseInput(props, 120))
+  assert(res.cycle_length_days === 120, `custom cycle honored (got ${res.cycle_length_days})`)
+  assert(
+    res.total_visits_required_per_cycle === 2,
+    `each property scheduled once in custom window (required=${res.total_visits_required_per_cycle}, expected 2)`
+  )
+  assert(
+    res.total_visits_per_cycle > 0,
+    `at least one visit placed → template not 'failed' (placed=${res.total_visits_per_cycle})`
+  )
+}
+
+// ── Case 2 (regression guard): AUTO cycle must still defer low-frequency
+// properties. A 1-year property in an auto 6-month cycle (driven by the
+// 2x/year property) should NOT be visited every cycle — it's deferred to
+// alternating cycles. Removing the skip entirely would over-service it.
+{
+  const props = [
+    prop('a', 33.41, -112.01, 0.5), // 2x/year → drives auto cycle to ~182d
+    prop('c', 33.43, -112.03, 1.0), // 1x/year → 365d > 182d → deferred
+  ]
+  const res = buildRoutingTemplate(baseInput(props)) // no custom cycle
+  assert(
+    res.total_visits_required_per_cycle === 1,
+    `auto cycle still defers the yearly property (required=${res.total_visits_required_per_cycle}, expected 1)`
+  )
+}
+
+console.log('PASS: custom-cycle-window')


### PR DESCRIPTION
## Problem

Setting a **custom cycle length shorter than the portfolio's shortest visit interval** on a routing template fails. Example: the auto/default cycle is 6 months (182 days, driven by a 2×/year offering); entering a custom **120-day** cycle produces a template stamped `status: 'failed'` with zero visits.

## Root cause

The builder treats the cycle as a *recurring* period and skips any property whose visit interval exceeds the cycle (`build-routing-template.ts`):

```ts
if (intervalDays > cycleDays) {
  // Property visits less often than the cycle — skipped in this builder.
  // Cycle generator handles the parity case.   ← never implemented
  continue
}
```

That "parity case" handler (`visitsForPropertyInCycle`) is **dead code** — defined but never called. With the auto cycle (sized to the *shortest* interval) nothing ever exceeds it, so the skip is harmless. But a custom cycle shorter than the shortest interval means **every** property hits `intervalDays > cycleDays` → all skipped → `total_visits_per_cycle === 0` → the API marks the template `failed` (`templates/index.ts:573`).

## Fix

Gate the skip on `!isCustomWindow`. A user-supplied custom cycle is a one-time **planning window** ("finish every property within N days"), so each property now gets at least one visit placed in the window. The auto cycle keeps its recurring-period semantics, so low-frequency properties aren't over-serviced. The fix is in the shared builder, so it covers both the create and regenerate endpoints.

## Verification

- New regression test `tests/unit/custom-cycle-window.test.ts` (TDD — written failing first):
  - custom 120-day cycle on a 182-day portfolio now schedules each property once (was `required=0`),
  - guard case confirms the **auto** cycle still defers a yearly property (no over-servicing).
- `npx tsc --noEmit` passes.

Note: a shorter window gives crews proportionally less capacity, so large portfolios may surface more `unplaced_visits` with the existing "add a crew or extend cycle" note — correct, graceful behavior, not a failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core visit-count logic in the shared template builder (create/regenerate), but behavior is narrowly scoped with a regression test for auto vs custom cycles.
> 
> **Overview**
> Fixes routing templates that **failed with zero visits** when `custom_cycle_length_days` was shorter than every property’s visit interval (e.g. 120 days on a 2×/year portfolio).
> 
> In `buildRoutingTemplate`, visit specs used to **skip** any property with `intervalDays > cycleDays`, which is correct for the **auto** recurring cycle (yearly sites stay off the 6‑month cycle) but wrong for a **custom** cycle meant as a “finish everyone in N days” window. The skip is now gated with `isCustomWindow` so custom cycles still schedule **at least one visit per property** via `Math.max(1, …)`; auto cycles keep deferring low-frequency properties.
> 
> Adds `tests/unit/custom-cycle-window.test.ts` for the 120‑day regression and to ensure auto-cycle deferral is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60dd599a8f02ae9909921dfbe5ec380ec21492c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->